### PR TITLE
PSP-684 Add tenant environment colour

### DIFF
--- a/frontend/src/components/common/VerticalBar.tsx
+++ b/frontend/src/components/common/VerticalBar.tsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+/**
+ * Styled VerticalBar component.
+ */
+export const VerticalBar = styled.span`
+  border-left: 2px solid white;
+  font-size: 34px;
+  margin: 0 15px 0 25px;
+  vertical-align: top;
+`;
+
+export default VerticalBar;

--- a/frontend/src/components/layout/Header/EmptyHeader.tsx
+++ b/frontend/src/components/layout/Header/EmptyHeader.tsx
@@ -1,10 +1,9 @@
-import './Header.scss';
-
 import React from 'react';
 import { Navbar, Nav } from 'react-bootstrap';
-import styled from 'styled-components';
 import { useTenant, Logo } from 'tenants';
 import { BCGovLogo } from 'components/common/BCGovLogo';
+import { HeaderStyled } from './HeaderStyled';
+import { VerticalBar } from 'components/common/VerticalBar';
 
 /**
  * Display an "empty" header bar with limited functionality as a placeholder
@@ -12,7 +11,7 @@ import { BCGovLogo } from 'components/common/BCGovLogo';
 const EmptyHeader = () => {
   const tenant = useTenant();
   return (
-    <Navbar expand className="App-header">
+    <HeaderStyled expand className="App-header">
       <Navbar.Brand className="brand-box">
         <a target="_blank" rel="noopener noreferrer" href="https://www2.gov.bc.ca/gov/content/home">
           <BCGovLogo />
@@ -26,18 +25,8 @@ const EmptyHeader = () => {
           <h1 className="shortAppName">{tenant.shortName}</h1>
         </Nav.Item>
       </Nav>
-    </Navbar>
+    </HeaderStyled>
   );
 };
-
-/**
- * Styled VerticalBar component.
- */
-const VerticalBar = styled.span`
-  border-left: 2px solid white;
-  font-size: 34px;
-  margin: 0 15px 0 25px;
-  vertical-align: top;
-`;
 
 export default EmptyHeader;

--- a/frontend/src/components/layout/Header/Header.tsx
+++ b/frontend/src/components/layout/Header/Header.tsx
@@ -1,5 +1,3 @@
-import './Header.scss';
-
 import React from 'react';
 import { Navbar, Nav } from 'react-bootstrap';
 import { useHistory } from 'react-router-dom';
@@ -10,11 +8,12 @@ import { FaBomb } from 'react-icons/fa';
 import _ from 'lodash';
 import { UserProfile } from './UserProfile';
 import useKeycloakWrapper from 'hooks/useKeycloakWrapper';
-import styled from 'styled-components';
 import { useTenant } from 'tenants';
 import { ErrorModal } from './ErrorModal';
 import { Logo } from 'tenants';
 import { BCGovLogo } from 'components/common/BCGovLogo';
+import { HeaderStyled } from './HeaderStyled';
+import { VerticalBar } from 'components/common/VerticalBar';
 
 /**
  * A header component that includes the navigation bar.
@@ -44,7 +43,7 @@ export const Header = () => {
     return errors;
   });
   return (
-    <Navbar expand className="App-header">
+    <HeaderStyled expand className="App-header">
       <Navbar.Brand className="brand-box">
         <a target="_blank" rel="noopener noreferrer" href="https://www2.gov.bc.ca/gov/content/home">
           <BCGovLogo />
@@ -65,7 +64,7 @@ export const Header = () => {
         ) : null}
       </Nav>
       <ErrorModal errors={errors} show={show} setShow={setShow}></ErrorModal>
-    </Navbar>
+    </HeaderStyled>
   );
 };
 
@@ -76,15 +75,5 @@ export const Header = () => {
  */
 const isNetworkError = (action: any): action is IGenericNetworkAction =>
   (action as IGenericNetworkAction).type === 'ERROR';
-
-/**
- * Styled component returns a vertical bar.
- */
-const VerticalBar = styled.span`
-  border-left: 2px solid white;
-  font-size: 34px;
-  margin: 0 15px 0 25px;
-  vertical-align: top;
-`;
 
 export default Header;

--- a/frontend/src/components/layout/Header/HeaderStyled.tsx
+++ b/frontend/src/components/layout/Header/HeaderStyled.tsx
@@ -1,6 +1,10 @@
-@import '../../../fonts.scss';
+import { Navbar } from 'react-bootstrap';
+import styled from 'styled-components';
 
-.App-header.navbar {
+/**
+ * Styled header component.
+ */
+export const HeaderStyled = styled(Navbar)`
   padding: 0 10px;
   min-height: 70px;
   color: #ffffff;
@@ -41,14 +45,13 @@
       cursor: pointer;
     }
   }
-}
-.modal-content .label {
-  font-weight: 700;
-}
 
-// show long App Name when space allows
-@media (min-width: 992px) {
-  .App-header.navbar {
+  .modal-content .label {
+    font-weight: 700;
+  }
+
+  // show long App Name when space allows
+  @media (min-width: 992px) {
     .longAppName {
       display: block;
       text-align: left;
@@ -58,4 +61,6 @@
       display: none;
     }
   }
-}
+`;
+
+export default HeaderStyled;

--- a/frontend/src/components/layout/Header/HeaderStyled.tsx
+++ b/frontend/src/components/layout/Header/HeaderStyled.tsx
@@ -2,7 +2,9 @@ import { Navbar } from 'react-bootstrap';
 import styled from 'styled-components';
 
 /**
- * Styled header component.
+ * Styled component provides consistent css for the page header.
+ * Used by different layouts.
+ * Displays the page header background, title, and logo.
  */
 export const HeaderStyled = styled(Navbar)`
   padding: 0 10px;

--- a/frontend/src/components/layout/Header/__snapshots__/EmptyHeader.test.tsx.snap
+++ b/frontend/src/components/layout/Header/__snapshots__/EmptyHeader.test.tsx.snap
@@ -2,14 +2,84 @@
 
 exports[`Empty Header renders 1`] = `
 .c0 {
+  padding: 0 10px;
+  min-height: 70px;
+  color: #ffffff;
+}
+
+.c0 .longAppName {
+  display: none;
+}
+
+.c0 .shortAppName {
+  display: block;
+}
+
+.c0 .brand-box {
+  padding: 10px 0;
+}
+
+.c0 .brand-box .pims-logo {
+  margin: 0 10px;
+}
+
+.c0 .title h1 {
+  margin-top: 10px;
+  padding-left: 0px;
+  text-align: center;
+  font-size: 24px;
+  -webkit-text-decoration: none solid rgb(255,255,255);
+  text-decoration: none solid rgb(255,255,255);
+  font-family: 'BCSans',Fallback,sans-serif;
+  font-weight: 700;
+  white-space: normal;
+}
+
+.c0 .other {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row-reverse;
+  -ms-flex-direction: row-reverse;
+  flex-direction: row-reverse;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0;
+}
+
+.c0 .other:hover {
+  color: red;
+  cursor: pointer;
+}
+
+.c0 .modal-content .label {
+  font-weight: 700;
+}
+
+.c1 {
   border-left: 2px solid white;
   font-size: 34px;
   margin: 0 15px 0 25px;
   vertical-align: top;
 }
 
+@media (min-width:992px) {
+  .c0 .longAppName {
+    display: block;
+    text-align: left;
+    padding-left: 40px;
+  }
+
+  .c0 .shortAppName {
+    display: none;
+  }
+}
+
 <nav
-  class="App-header navbar navbar-expand navbar-light"
+  class="c0 App-header navbar navbar-expand navbar-light"
 >
   <span
     class="brand-box navbar-brand"
@@ -28,7 +98,7 @@ exports[`Empty Header renders 1`] = `
       />
     </a>
     <span
-      class="c0"
+      class="c1"
     />
     <img
       alt="PIMS logo"
@@ -50,7 +120,9 @@ exports[`Empty Header renders 1`] = `
       </h1>
       <h1
         class="shortAppName"
-      />
+      >
+        PIMS
+      </h1>
     </div>
   </div>
 </nav>

--- a/frontend/src/components/layout/Header/__snapshots__/Header.test.tsx.snap
+++ b/frontend/src/components/layout/Header/__snapshots__/Header.test.tsx.snap
@@ -2,14 +2,84 @@
 
 exports[`Header tests Header renders correctly 1`] = `
 .c0 {
+  padding: 0 10px;
+  min-height: 70px;
+  color: #ffffff;
+}
+
+.c0 .longAppName {
+  display: none;
+}
+
+.c0 .shortAppName {
+  display: block;
+}
+
+.c0 .brand-box {
+  padding: 10px 0;
+}
+
+.c0 .brand-box .pims-logo {
+  margin: 0 10px;
+}
+
+.c0 .title h1 {
+  margin-top: 10px;
+  padding-left: 0px;
+  text-align: center;
+  font-size: 24px;
+  -webkit-text-decoration: none solid rgb(255,255,255);
+  text-decoration: none solid rgb(255,255,255);
+  font-family: 'BCSans',Fallback,sans-serif;
+  font-weight: 700;
+  white-space: normal;
+}
+
+.c0 .other {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row-reverse;
+  -ms-flex-direction: row-reverse;
+  flex-direction: row-reverse;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0;
+}
+
+.c0 .other:hover {
+  color: red;
+  cursor: pointer;
+}
+
+.c0 .modal-content .label {
+  font-weight: 700;
+}
+
+.c1 {
   border-left: 2px solid white;
   font-size: 34px;
   margin: 0 15px 0 25px;
   vertical-align: top;
 }
 
+@media (min-width:992px) {
+  .c0 .longAppName {
+    display: block;
+    text-align: left;
+    padding-left: 40px;
+  }
+
+  .c0 .shortAppName {
+    display: none;
+  }
+}
+
 <nav
-  className="App-header navbar navbar-expand navbar-light"
+  className="c0 App-header navbar navbar-expand navbar-light"
 >
   <span
     className="brand-box navbar-brand"
@@ -28,7 +98,7 @@ exports[`Header tests Header renders correctly 1`] = `
       />
     </a>
     <span
-      className="c0"
+      className="c1"
     />
     <img
       alt="PIMS logo"

--- a/frontend/src/features/account/__snapshots__/IENotSupportedPage.test.tsx.snap
+++ b/frontend/src/features/account/__snapshots__/IENotSupportedPage.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`login error page login error page renders correctly 1`] = `
 >
   <br />
   <h1>
+    PIMS
      does not support Internet Explorer
   </h1>
   <br />

--- a/frontend/src/features/admin/access/__snapshots__/ManageAccessRequests.test.tsx.snap
+++ b/frontend/src/features/admin/access/__snapshots__/ManageAccessRequests.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`Manage access requests Snapshot matches 1`] = `
       <span
         className="title mr-auto"
       >
+        PIMS
          Guests (Pending Approval)
       </span>
     </div>

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1,5 +1,4 @@
 @import 'colors.scss';
-@import 'fonts.scss';
 
 body {
   margin: 0;

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1,4 +1,5 @@
 @import 'colors.scss';
+@import 'fonts.scss';
 
 body {
   margin: 0;

--- a/frontend/src/layouts/EmptyLayout.tsx
+++ b/frontend/src/layouts/EmptyLayout.tsx
@@ -3,24 +3,26 @@ import './PublicLayout.scss';
 import React from 'react';
 import { Container } from 'react-bootstrap';
 import { Footer, EmptyHeader } from 'components/layout';
+import HeaderStyled from './Header';
+import FooterStyled from './Footer';
 
 const EmptyLayout: React.FC = ({ children }) => {
   return (
     <>
       <Container fluid className="App">
-        <header className="header-layout fixed-top">
+        <HeaderStyled className="header-layout fixed-top">
           <Container className="px-0">
             <EmptyHeader />
           </Container>
-        </header>
+        </HeaderStyled>
 
         <main className="App-content">{children}</main>
 
-        <footer className="footer-layout fixed-bottom">
+        <FooterStyled className="footer-layout fixed-bottom">
           <Container className="px-0">
             <Footer />
           </Container>
-        </footer>
+        </FooterStyled>
       </Container>
     </>
   );

--- a/frontend/src/layouts/Footer.tsx
+++ b/frontend/src/layouts/Footer.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useTenant } from 'tenants';
+
+/**
+ * Footer component that applies tenant environmental styling.
+ * @param param0 Footer properties.
+ * @returns Footer component.
+ */
+export const Footer: React.FC<React.HTMLAttributes<HTMLElement>> = ({ ...rest }) => {
+  const tenant = useTenant();
+  return <FooterStyled {...rest} backgroundColor={tenant.colour}></FooterStyled>;
+};
+
+interface IFooterProps {
+  // Background color of footer.
+  backgroundColor: string;
+}
+
+const FooterStyled = styled.footer<IFooterProps>`
+  background-color: ${props => props.backgroundColor};
+
+  // colors
+  background-color: $primary-color;
+  border: none;
+  border-top: 2px solid $accent-color;
+
+  // sizing
+  flex-shrink: 0;
+
+  a,
+  h2 {
+    color: #fff;
+  }
+`;
+
+export default Footer;

--- a/frontend/src/layouts/Header.test.tsx
+++ b/frontend/src/layouts/Header.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import { TenantProvider, ITenantConfig, defaultTenant, config } from 'tenants';
+import { useTenant } from 'tenants/useTenant';
+import { Header } from './Header';
+
+jest.mock('tenants/useTenant');
+const mockUseTenant = useTenant as jest.Mock<ITenantConfig>;
+global.fetch = jest.fn(
+  () =>
+    Promise.resolve({ json: () => Promise.resolve(JSON.stringify(defaultTenant)) }) as Promise<
+      Response
+    >,
+);
+
+const testRender = () =>
+  render(
+    <TenantProvider>
+      <Header />
+    </TenantProvider>,
+  );
+
+describe('Tenant Header', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    delete process.env.REACT_APP_TENANT;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    process.env = OLD_ENV;
+  });
+
+  it('Header default background', async () => {
+    mockUseTenant.mockImplementation(() => defaultTenant);
+
+    await act(async () => {
+      const { container } = testRender();
+      expect(container).toMatchSnapshot();
+    });
+  });
+
+  it('Header black background', async () => {
+    mockUseTenant.mockImplementation(() => ({ ...defaultTenant, colour: 'black' }));
+
+    await act(async () => {
+      const { container } = testRender();
+      expect(container).toMatchSnapshot();
+    });
+  });
+
+  it('Header MOTI background', async () => {
+    mockUseTenant.mockImplementation(() => ({ ...defaultTenant, ...config['MOTI'] }));
+
+    await act(async () => {
+      const { container } = testRender();
+      expect(container).toMatchSnapshot();
+    });
+  });
+
+  it('Header CITZ background', async () => {
+    mockUseTenant.mockImplementation(() => ({ ...defaultTenant, ...config['CITZ'] }));
+
+    await act(async () => {
+      const { container } = testRender();
+      expect(container).toMatchSnapshot();
+    });
+  });
+});

--- a/frontend/src/layouts/Header.tsx
+++ b/frontend/src/layouts/Header.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useTenant } from 'tenants';
+
+/**
+ * Header component that applies tenant environmental styling.
+ * @param param0 Header properties.
+ * @returns Header component.
+ */
+export const Header: React.FC<React.HTMLAttributes<HTMLElement>> = ({ ...rest }) => {
+  const tenant = useTenant();
+  return <HeaderStyled {...rest} backgroundColor={tenant.colour}></HeaderStyled>;
+};
+
+interface IHeaderProps {
+  // Background color of header.
+  backgroundColor: string;
+}
+
+const HeaderStyled = styled.header<IHeaderProps>`
+  background-color: ${props => props.backgroundColor};
+  border: none;
+  border-bottom: 2px solid $accent-color;
+
+  // sizing
+  flex-shrink: 0;
+`;
+
+export default Header;

--- a/frontend/src/layouts/PublicLayout.scss
+++ b/frontend/src/layouts/PublicLayout.scss
@@ -20,28 +20,3 @@
   /* for Firefox */
   min-height: 0;
 }
-
-.header-layout {
-  // colors
-  background-color: $primary-color;
-  border: none;
-  border-bottom: 2px solid $accent-color;
-
-  // sizing
-  flex-shrink: 0;
-}
-
-.footer-layout {
-  // colors
-  background-color: $primary-color;
-  border: none;
-  border-top: 2px solid $accent-color;
-
-  // sizing
-  flex-shrink: 0;
-
-  a,
-  h2 {
-    color: #fff;
-  }
-}

--- a/frontend/src/layouts/PublicLayout.tsx
+++ b/frontend/src/layouts/PublicLayout.tsx
@@ -6,27 +6,29 @@ import LoadingBar from 'react-redux-loading-bar';
 import { ErrorBoundary } from 'react-error-boundary';
 import ErrorModal from 'components/common/ErrorModal';
 import { Footer, Header } from 'components/layout';
+import HeaderStyled from './Header';
+import FooterStyled from './Footer';
 
 const PublicLayout: React.FC = ({ children }) => {
   return (
     <>
       <LoadingBar style={{ zIndex: 9999, backgroundColor: '#fcba19', height: '3px' }} />
       <Container fluid className="App">
-        <header className="header-layout fixed-top">
+        <HeaderStyled className="header-layout fixed-top">
           <Container className="px-0">
             <Header />
           </Container>
-        </header>
+        </HeaderStyled>
 
         <main className="App-content">
           <ErrorBoundary FallbackComponent={ErrorModal}>{children}</ErrorBoundary>
         </main>
 
-        <footer className="footer-layout fixed-bottom">
+        <FooterStyled className="footer-layout fixed-bottom">
           <Container className="px-0">
             <Footer />
           </Container>
-        </footer>
+        </FooterStyled>
       </Container>
     </>
   );

--- a/frontend/src/layouts/__snapshots__/EmptyLayout.test.tsx.snap
+++ b/frontend/src/layouts/__snapshots__/EmptyLayout.test.tsx.snap
@@ -1,14 +1,72 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Empty Layout renders 1`] = `
-.c0 {
+.c1 {
+  padding: 0 10px;
+  min-height: 70px;
+  color: #ffffff;
+}
+
+.c1 .longAppName {
+  display: none;
+}
+
+.c1 .shortAppName {
+  display: block;
+}
+
+.c1 .brand-box {
+  padding: 10px 0;
+}
+
+.c1 .brand-box .pims-logo {
+  margin: 0 10px;
+}
+
+.c1 .title h1 {
+  margin-top: 10px;
+  padding-left: 0px;
+  text-align: center;
+  font-size: 24px;
+  -webkit-text-decoration: none solid rgb(255,255,255);
+  text-decoration: none solid rgb(255,255,255);
+  font-family: 'BCSans',Fallback,sans-serif;
+  font-weight: 700;
+  white-space: normal;
+}
+
+.c1 .other {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row-reverse;
+  -ms-flex-direction: row-reverse;
+  flex-direction: row-reverse;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0;
+}
+
+.c1 .other:hover {
+  color: red;
+  cursor: pointer;
+}
+
+.c1 .modal-content .label {
+  font-weight: 700;
+}
+
+.c2 {
   border-left: 2px solid white;
   font-size: 34px;
   margin: 0 15px 0 25px;
   vertical-align: top;
 }
 
-.c1 {
+.c4 {
   bottom: 0;
   padding: 10px 0;
   display: -webkit-box;
@@ -34,12 +92,12 @@ exports[`Empty Layout renders 1`] = `
   align-content: flex-start;
 }
 
-.c1 a {
+.c4 a {
   display: inline;
 }
 
-.c1 a:link,
-.c1 a:visited {
+.c4 a:link,
+.c4 a:visited {
   color: #ffffff;
   font-size: 16px;
   font-family: 'BCSans',Fallback,sans-serif;
@@ -47,13 +105,13 @@ exports[`Empty Layout renders 1`] = `
   border-right: 1px solid #666;
 }
 
-.c1 a:hover,
-.c1 a:focus {
+.c4 a:hover,
+.c4 a:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c1 div.version {
+.c4 div.version {
   color: #ffffff;
   font-size: 12px;
   font-family: 'BCSans',Fallback,sans-serif;
@@ -65,18 +123,54 @@ exports[`Empty Layout renders 1`] = `
   text-align: right;
 }
 
+.c0 {
+  background-color: #003366;
+  border: none;
+  border-bottom: 2px solid $accent-color;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c3 {
+  background-color: #003366;
+  background-color: $primary-color;
+  border: none;
+  border-top: 2px solid $accent-color;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c3 a,
+.c3 h2 {
+  color: #fff;
+}
+
+@media (min-width:992px) {
+  .c1 .longAppName {
+    display: block;
+    text-align: left;
+    padding-left: 40px;
+  }
+
+  .c1 .shortAppName {
+    display: none;
+  }
+}
+
 <div>
   <div
     class="App container-fluid"
   >
     <header
-      class="header-layout fixed-top"
+      class="c0 header-layout fixed-top"
     >
       <div
         class="px-0 container"
       >
         <nav
-          class="App-header navbar navbar-expand navbar-light"
+          class="c1 App-header navbar navbar-expand navbar-light"
         >
           <span
             class="brand-box navbar-brand"
@@ -95,7 +189,7 @@ exports[`Empty Layout renders 1`] = `
               />
             </a>
             <span
-              class="c0"
+              class="c2"
             />
             <img
               alt="PIMS logo"
@@ -117,7 +211,9 @@ exports[`Empty Layout renders 1`] = `
               </h1>
               <h1
                 class="shortAppName"
-              />
+              >
+                PIMS
+              </h1>
             </div>
           </div>
         </nav>
@@ -127,13 +223,13 @@ exports[`Empty Layout renders 1`] = `
       class="App-content"
     />
     <footer
-      class="footer-layout fixed-bottom"
+      class="c3 footer-layout fixed-bottom"
     >
       <div
         class="px-0 container"
       >
         <div
-          class="c1"
+          class="c4"
         >
           <a
             href="http://www.gov.bc.ca/gov/content/home/disclaimer"

--- a/frontend/src/layouts/__snapshots__/Header.test.tsx.snap
+++ b/frontend/src/layouts/__snapshots__/Header.test.tsx.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tenant Header Header CITZ background 1`] = `
+.c0 {
+  background-color: #003366;
+  border: none;
+  border-bottom: 2px solid $accent-color;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+<div>
+  <header
+    class="c0"
+  />
+</div>
+`;
+
+exports[`Tenant Header Header MOTI background 1`] = `
+.c0 {
+  background-color: #003366;
+  border: none;
+  border-bottom: 2px solid $accent-color;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+<div>
+  <header
+    class="c0"
+  />
+</div>
+`;
+
+exports[`Tenant Header Header black background 1`] = `
+.c0 {
+  background-color: black;
+  border: none;
+  border-bottom: 2px solid $accent-color;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+<div>
+  <header
+    class="c0"
+  />
+</div>
+`;
+
+exports[`Tenant Header Header default background 1`] = `
+.c0 {
+  background-color: #003366;
+  border: none;
+  border-bottom: 2px solid $accent-color;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+<div>
+  <header
+    class="c0"
+  />
+</div>
+`;

--- a/frontend/src/tenants/ITenantConfig.ts
+++ b/frontend/src/tenants/ITenantConfig.ts
@@ -2,10 +2,14 @@
  * Interface for tenant configuration settings.
  */
 export interface ITenantConfig {
+  // The unique identifier for the tenant.
+  id: string;
   // The name of the application to display in the header.
   title: string;
   // The shortname of the application.
   shortName: string;
+  // The colour to identify the environment.
+  colour: string;
   // The logos to display.
   logo: ITenantLogoConfig;
   // Login page settings.

--- a/frontend/src/tenants/config/CITZ.ts
+++ b/frontend/src/tenants/config/CITZ.ts
@@ -6,6 +6,7 @@ import { defaultTenant, ITenantConfig } from '..';
 export const config: ITenantConfig = {
   ...defaultTenant,
   ...{
+    id: 'CITZ',
     title: 'Property Inventory Management System',
     logo: {
       favicon: '/tenants/CITZ/favicon.ico',

--- a/frontend/src/tenants/config/MOTI.ts
+++ b/frontend/src/tenants/config/MOTI.ts
@@ -6,6 +6,7 @@ import { defaultTenant, ITenantConfig } from '..';
 export const config: ITenantConfig = {
   ...defaultTenant,
   ...{
+    id: 'MOTI',
     title: 'Property Information Management System',
     logo: {
       favicon: '/tenants/MOTI/favicon.ico',

--- a/frontend/src/tenants/config/default.ts
+++ b/frontend/src/tenants/config/default.ts
@@ -4,8 +4,10 @@ import { ITenantConfig } from 'tenants/ITenantConfig';
  * Default tenant configuration.
  */
 export const defaultTenant: ITenantConfig = {
+  id: 'DFLT',
   title: 'Default Tenant Name',
   shortName: 'PIMS',
+  colour: '#003366',
   logo: {
     favicon: '',
     image: '',

--- a/frontend/src/tenants/tenant.tsx
+++ b/frontend/src/tenants/tenant.tsx
@@ -34,7 +34,11 @@ export const TenantProvider: React.FC = props => {
         const config = JSON.parse(process.env.REACT_APP_TENANT);
         setTenant({ ...defaultTenant, ...config });
       } else {
-        setTenant(config[process.env.REACT_APP_TENANT] ?? defaultTenant);
+        setTenant(
+          config[process.env.REACT_APP_TENANT]
+            ? { ...defaultTenant, ...config[process.env.REACT_APP_TENANT] }
+            : defaultTenant,
+        );
       }
     } else {
       // Fetch the configuration file generated for the environment.

--- a/frontend/src/tenants/useTenant.test.tsx
+++ b/frontend/src/tenants/useTenant.test.tsx
@@ -57,7 +57,7 @@ describe('useTenant hook', () => {
       process.env.REACT_APP_TENANT = 'MOTI';
       const { container } = testRender();
       const title = getByTestId(container, 'tenant');
-      expect(title).toContainHTML(JSON.stringify(config['MOTI']));
+      expect(title).toContainHTML(JSON.stringify({ ...defaultTenant, ...config['MOTI'] }));
     });
   });
 
@@ -66,7 +66,7 @@ describe('useTenant hook', () => {
       process.env.REACT_APP_TENANT = 'CITZ';
       const { container } = testRender();
       const title = getByTestId(container, 'tenant');
-      expect(title).toContainHTML(JSON.stringify(config['CITZ']));
+      expect(title).toContainHTML(JSON.stringify({ ...defaultTenant, ...config['CITZ'] }));
     });
   });
 });

--- a/openshift/4.0/templates/app/deploy.yaml
+++ b/openshift/4.0/templates/app/deploy.yaml
@@ -215,7 +215,9 @@ objects:
     type: Opaque
     data:
       tenant.json: '{
+        "id": "MOTI",
         "title": "Property Information Management System",
+        "colour": "#003366",
         "logo": {
           "favicon": "/tenants/MOTI/favicon.ico",
           "image": "/tenants/MOTI/PIMS-logo.png",

--- a/openshift/4.0/templates/app/tenant-configMap.yaml
+++ b/openshift/4.0/templates/app/tenant-configMap.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: pims-app-tenant-config
+  annotations:
+    description: Deployment template for the tenant configuration file.
+    tags: pims,app
+parameters:
+  - name: APP_NAME
+    displayName: "App Name"
+    description: "The name of the application (grouped)."
+    required: true
+    value: "pims"
+  - name: ROLE_NAME
+    displayName: "Component Name"
+    description: "The name of the application role (e.g api, app, database)."
+    required: true
+    value: "app"
+  - name: PROJECT_NAMESPACE
+    displayName: "OpenShift Project Namespace"
+    description: "The namespace of the OpenShift project containing the application."
+    required: true
+    value: "3cd915"
+  - name: ENV_NAME
+    displayName: "Environment name"
+    description: "The name for this environment [dev, test, prod, tools]"
+    required: true
+    value: "dev"
+  - name: INSTANCE
+    displayName: "Unique Identifier"
+    description: "A unique identifier to allow for multiple instances (i.e. '-01')."
+    value: ""
+
+  - name: TENANT
+    displayName: "Tenant unique identity"
+    description: "Tenant unique identity key."
+    value: "MOTI"
+  - name: TENANT_TITLE
+    displayName: "Tenant Application Title"
+    description: "Tenant application title."
+    value: "Property Information Management System"
+  - name: TENANT_COLOUR
+    displayName: "Tenant Background Colour"
+    description: "Tenant background colour used to identify environments."
+    value: "#003366"
+  - name: TENANT_LOGIN_TITLE
+    displayName: "Tenant Login Title"
+    description: "Tenant login page title."
+    value: "TRAN Property Information Management System (PIMS)"
+  - name: TENANT_LOGIN_HEADING
+    displayName: "Tenant Login Heading"
+    description: "Tenant login page heading."
+    value: "PIMS enables you to view highways and properties owned by the Ministry of Transportation and Infrastructure"
+  - name: TENANT_LOGIN_BODY
+    displayName: "Tenant Login Body"
+    description: "Tenant login page message."
+    value: "WARNING: Not all data included within has been vetted for accuracy and completeness. Please use caution when proceeding and confirm data before relying on it."
+objects:
+  # Tenant configuration settings.
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: ${APP_NAME}-${ROLE_NAME}-tenant${INSTANCE}
+      namespace: ${PROJECT_NAMESPACE}-${ENV_NAME}
+      annotations:
+        description: Tenant configuration settings
+      labels:
+        name: ${APP_NAME}-${ROLE_NAME}-tenant${INSTANCE}
+        app: ${APP_NAME}
+        role: ${ROLE_NAME}
+        env: ${ENV_NAME}
+    type: Opaque
+    data:
+      tenant.json: '{
+        "id": "${TENANT}",
+        "title": "${TENANT_TITLE}",
+        "colour": "${TENANT_COLOUR}",
+        "logo": {
+          "favicon": "/tenants/${TENANT}/favicon.ico",
+          "image": "/tenants/${TENANT}/PIMS-logo.png",
+          "imageWithText": "/tenants/${TENANT}/PIMS-logo-with-text.png"
+        },
+        "login": {
+          "title": "${TENANT_LOGIN_TITLE}",
+          "heading": "${TENANT_LOGIN_HEADING}",
+          "body": "${TENANT_LOGIN_BODY}"
+        }
+      }'


### PR DESCRIPTION
The tenant configuration file can now control the background color of the header and footer.

Simply update the `tenant.json` ConfigMap in each environment with a `colour: "your color"`.

![image](https://user-images.githubusercontent.com/3180256/118321662-c22f7300-b4b2-11eb-9b92-4a71f27535e1.png)
