### PR TITLE
only prompt for version if the flag is enabled.

### DIFF
--- a/openshift/4.0/pipelines/Jenkinsfile.cicd
+++ b/openshift/4.0/pipelines/Jenkinsfile.cicd
@@ -112,10 +112,7 @@ pipeline {
 
     stage('Version Prompt') {
       when {
-        anyOf {
-          expression { env.GIT_BRANCH == 'origin/dev' }
-          expression { new Boolean(env.ENABLE_VERSION_PROMPT) }
-        }
+        expression { new Boolean(env.ENABLE_VERSION_PROMPT) }
       }
       steps {
         script {


### PR DESCRIPTION
as requested by @Fosol, this will remove the version prompt unless it is explicitly enabled.