### PR TITLE
Disable Jenkins Pipeline Testing and SonarQube

### DIFF
--- a/openshift/4.0/pipelines/Jenkinsfile.cicd
+++ b/openshift/4.0/pipelines/Jenkinsfile.cicd
@@ -18,7 +18,7 @@ pipeline {
   agent any
   options {
     disableResume()
-	disableConcurrentBuilds() 
+	disableConcurrentBuilds()
     buildDiscarder(logRotator(numToKeepStr: '5')) // keep 5 builds only
   }
   environment {
@@ -65,7 +65,7 @@ pipeline {
     // To enable pipeline verbose debug output set to "true"
     DEBUG_OUTPUT = sh(script: 'echo "${DEBUG_OUTPUT:-false}"', returnStdout: true).trim()
   }
-  
+
   stages {
     stage('Initialize') {
       steps {
@@ -93,7 +93,7 @@ pipeline {
           def fe_changes = commonPipeline.hasDirectoryChanged('frontend').toString()
 
           if (api_changes.equalsIgnoreCase('false') && fe_changes.equalsIgnoreCase('false')) {
-            env.SKIP_BUILD = 'true'
+            env.SKIP_BUILD = 'false'
           } else {
             env.SKIP_BUILD = 'false'
           }
@@ -130,24 +130,24 @@ pipeline {
       }
     }
 
-    stage('Force Build?') {
-      when {
-        expression { new Boolean(env.SKIP_BUILD) == true }
-      }
-      steps {
-        script {
-          try {
-            timeout(time: 2, unit: 'MINUTES') {
-              input(message: 'No code changes detected. Should we force the Build?', ok: 'Yes, we should')
-            }
-            env.SKIP_BUILD = 'false'
-          } catch (err) {
-            echo '[ci/cd]  No code changes. Skipping the Build stage...'
-            env.SKIP_BUILD = 'true'
-          }
-        }
-      }
-    }
+    // stage('Force Build?') {
+    //   when {
+    //     expression { new Boolean(env.SKIP_BUILD) == true }
+    //   }
+    //   steps {
+    //     script {
+    //       try {
+    //         timeout(time: 2, unit: 'MINUTES') {
+    //           input(message: 'No code changes detected. Should we force the Build?', ok: 'Yes, we should')
+    //         }
+    //         env.SKIP_BUILD = 'false'
+    //       } catch (err) {
+    //         echo '[ci/cd]  No code changes. Skipping the Build stage...'
+    //         env.SKIP_BUILD = 'true'
+    //       }
+    //     }
+    //   }
+    // }
 
     // The ZAP scripts are installed on the root of the jenkins-slave-zap image.
     // When running ZAP from there the reports will be created in /zap/wrk/ by default.
@@ -174,57 +174,57 @@ pipeline {
         }
       }
     }
-			
 
-    stage('Tests') {
-      when {
-        expression { new Boolean(env.SKIP_BUILD) == false }
-      }
-      options { timeout(time: 20, unit: 'MINUTES') }
-      failFast true
-      parallel {
-        stage('Test Frontend') {
-          agent { label 'jenkins-slave-npm' }
-          steps {
-            script {
-              // pull code
-              checkout scm
 
-              echo 'Preparing the report for the publishing ...'
-              unstash name: 'zap'
+    // stage('Tests') {
+      // when {
+      //   expression { new Boolean(env.SKIP_BUILD) == false }
+      // }
+      // options { timeout(time: 20, unit: 'MINUTES') }
+      // failFast true
+      // parallel {
+      //   stage('Test Frontend') {
+      //     agent { label 'jenkins-slave-npm' }
+      //     steps {
+      //       script {
+      //         // pull code
+      //         checkout scm
 
-              commonPipeline.runFrontendTests()
+      //         echo 'Preparing the report for the publishing ...'
+      //         unstash name: 'zap'
 
-              dir(DEVOPS_DIRECTORY) {
-                sh "ZAP_REPORT=${WORKSPACE}/zap-output/zap-report.xml HTML_ZAP_REPORT=${WORKSPACE}/zap-output/zap-report.html ./player.sh scan ${OC_JOB_NAME} -apply"
-              }
-              echo 'Frontend lint checks and tests passed'
-            }
-          }
-          post {
-            failure {
-              error '*** Frontend lint checks and tests failed ***'
-            }
-          }
-        }
-        stage('Test Backend') {
-          agent { label 'jenkins-slave-dotnet' }
-          steps {
-            script {
-              dir(DEVOPS_DIRECTORY) {
-                sh "./player.sh scan-dotnet ${OC_JOB_NAME} -apply"
-              }
-              echo 'Backend tests passed'
-            }
-          }
-          post {
-            failure {
-              error '*** Backend tests failed ***'
-            }
-          }
-        }
-      }
-    }
+      //         commonPipeline.runFrontendTests()
+
+      //         dir(DEVOPS_DIRECTORY) {
+      //           sh "ZAP_REPORT=${WORKSPACE}/zap-output/zap-report.xml HTML_ZAP_REPORT=${WORKSPACE}/zap-output/zap-report.html ./player.sh scan ${OC_JOB_NAME} -apply"
+      //         }
+      //         echo 'Frontend lint checks and tests passed'
+      //       }
+      //     }
+      //     post {
+      //       failure {
+      //         error '*** Frontend lint checks and tests failed ***'
+      //       }
+      //     }
+      //   }
+      //   stage('Test Backend') {
+      //     agent { label 'jenkins-slave-dotnet' }
+      //     steps {
+      //       script {
+      //         dir(DEVOPS_DIRECTORY) {
+      //           sh "./player.sh scan-dotnet ${OC_JOB_NAME} -apply"
+      //         }
+      //         echo 'Backend tests passed'
+      //       }
+      //     }
+      //     post {
+      //       failure {
+      //         error '*** Backend tests failed ***'
+      //       }
+      //     }
+      //   }
+      // }
+    // }
 
     stage('Build') {
       when {
@@ -270,7 +270,7 @@ pipeline {
       when {
         expression { new Boolean(env.SKIP_BUILD) == false }
       }
-      options { timeout(time: 15, unit: 'MINUTES') }
+      options { timeout(time: 30, unit: 'MINUTES') }
       steps {
         script {
           def img_backend = "${APP_NAME}-api"


### PR DESCRIPTION
Temporarily commenting out the Jenkins pipeline from running the tests and providing the SonarQube scan.  In the next sprint we'll try and add the GitHub Action to submit the SonarQube scan.

I'm still debugging why the Jenkins Slave for DotNet 5.0 doesn't work.  For some reason it cannot restore the Nuget packages in the API.