### PR TITLE
PSP-1146 Add SonarQube GitHub Action

### DIFF
--- a/.github/workflows/api-dotnetcore.yml
+++ b/.github/workflows/api-dotnetcore.yml
@@ -2,32 +2,43 @@ name: API (.NET 5)
 
 on:
   push:
-    branches: [master, dev, dev-alpha]
+    branches: [master, dev, test]
   pull_request:
-    branches: [master, dev, dev-alpha]
+    branches: [master, dev, test]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     env:
       working-directory: ./backend
-      codeCov-token: ${{ secrets.CodeCov }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Extract Branch Name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+
       - name: Setup .NET 5
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 5.0.300
+
       - name: Install dependencies
         run: dotnet restore
         working-directory: ${{env.working-directory}}
+
       - name: Install coverlet for code coverage
         run: dotnet tool install -g coverlet.console --version 1.7.2
         working-directory: ${{env.working-directory}}
+
       - name: Build
         run: dotnet build --configuration Release --no-restore
         working-directory: ${{env.working-directory}}
+
       - name: Test
         run: dotnet test --no-restore --verbosity normal
         working-directory: ${{env.working-directory}}
@@ -70,13 +81,14 @@ jobs:
           mv TestResults/*/* ../TestResults/
           cd ..
           head TestResults/coverage.opencover.xml
+
       - name: Codecov
         uses: codecov/codecov-action@v1.5.0
         with:
           # User defined upload name. Visible in Codecov UI
           name: PIMS
           # Repository upload token - get it from codecov.io. Required only for private repositories
-          token: ${{env.codeCov-token}}
+          token: ${{ secrets.CodeCov }}
           # Path to coverage file to upload
           file: ${{env.working-directory}}/tests/unit/TestResults/coverage.opencover.xml
           # Flag upload to group coverage metrics (e.g. unittests | integration | ui,chrome)
@@ -85,3 +97,18 @@ jobs:
           env_vars: C#
           # Specify whether or not CI build should fail if Codecov runs into an error during upload
           fail_ci_if_error: true
+
+      - name: SonarScanner for .NET 5 with pull request decoration support
+        uses: highbyte/sonarscan-dotnet@2.0
+        if: ${{ github.event_name == 'push' }}
+        with:
+          dotnetBuildArguments: ${{env.working-directory}}
+          dotnetDisableTests: true
+          # Optional extra command arguments the the SonarScanner 'begin' command
+          sonarBeginArguments: /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml" -d:sonar.cs.vstest.reportsPaths="**/TestResults/*.trx"
+          # The key of the SonarQube project
+          sonarProjectKey: format('pims-api-{0}', ${{steps.extract_branch.outputs.branch}})
+          # The name of the SonarQube project
+          sonarProjectName: format('PIMS Backend [{0}]', ${{steps.extract_branch.outputs.branch}})
+          # The SonarQube server URL. For SonarCloud, skip this setting.
+          sonarHostname: ${{secrets.SONAR_URL}}

--- a/.github/workflows/api-dotnetcore.yml
+++ b/.github/workflows/api-dotnetcore.yml
@@ -12,7 +12,6 @@ jobs:
     env:
       working-directory: ./backend
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2
@@ -101,14 +100,16 @@ jobs:
       - name: SonarScanner for .NET 5 with pull request decoration support
         uses: highbyte/sonarscan-dotnet@2.0
         if: ${{ github.event_name == 'push' }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           dotnetBuildArguments: ${{env.working-directory}}
-          dotnetDisableTests: true
+          dotnetTestArguments: ${{env.working-directory}} --logger trx --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
           # Optional extra command arguments the the SonarScanner 'begin' command
           sonarBeginArguments: /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml" -d:sonar.cs.vstest.reportsPaths="**/TestResults/*.trx"
           # The key of the SonarQube project
-          sonarProjectKey: format('pims-api-{0}', ${{steps.extract_branch.outputs.branch}})
+          sonarProjectKey: 483bc59d-f9ef-428c-866e-581d9ea69eab
           # The name of the SonarQube project
-          sonarProjectName: format('PIMS Backend [{0}]', ${{steps.extract_branch.outputs.branch}})
+          sonarProjectName: PIMS-API
           # The SonarQube server URL. For SonarCloud, skip this setting.
           sonarHostname: ${{secrets.SONAR_URL}}

--- a/.github/workflows/app-react.yml
+++ b/.github/workflows/app-react.yml
@@ -61,9 +61,13 @@ jobs:
       - name: SonarQube Scan
         uses: sonarsource/sonarqube-scan-action@master
         if: ${{ github.event_name == 'push' }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_URL }}
+          PROJECT_KEY: 21faa627-fe70-4a67-89e3-1262a32d2e2c
+          PROJECT_NAME: PIMS-APP
         with:
-          host: ${{secrets.SONAR_URL}}
-          login: ${{secrets.SONAR_TOKEN}}
           projectBaseDir: ${{env.working-directory}}
-          projectKey: format('pims-frontend-{0}', ${{steps.extract_branch.outputs.branch}})
-          projectName: format('PIMS Frontend [{0}]', ${{steps.extract_branch.outputs.branch}})
+          args: >
+            -Dsonar.projectKey=${{env.PROJECT_KEY}}
+            -Dsonar.projectName=${{env.PROJECT_NAME}}

--- a/.github/workflows/app-react.yml
+++ b/.github/workflows/app-react.yml
@@ -2,9 +2,9 @@ name: APP (React)
 
 on:
   push:
-    branches: [master, dev, dev-alpha]
+    branches: [master, dev, test]
   pull_request:
-    branches: [master, dev, dev-alpha]
+    branches: [master, dev, test]
 
 jobs:
   build:
@@ -12,7 +12,6 @@ jobs:
     env:
       CI: true
       working-directory: ./frontend
-      codeCov-token: ${{ secrets.CodeCov }}
 
     strategy:
       matrix:
@@ -20,25 +19,36 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Extract Branch Name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+
       - run: npm ci
         working-directory: ${{env.working-directory}}
+
       - run: npm run lint
         working-directory: ${{env.working-directory}}
+
       - run: npm run build --if-present
         working-directory: ${{env.working-directory}}
+
       - run: npm run coverage
         working-directory: ${{env.working-directory}}
+
       - name: Codecov
         uses: codecov/codecov-action@v1.5.0
         with:
           # User defined upload name. Visible in Codecov UI
           name: PIMS
           # Repository upload token - get it from codecov.io. Required only for private repositories
-          token: ${{env.codeCov-token}}
+          token: ${{ secrets.CodeCov }}
           # Path to coverage file to upload
           file: ${{env.working-directory}}/coverage/coverage-final.json
           # Flag upload to group coverage metrics (e.g. unittests | integration | ui,chrome)
@@ -47,3 +57,13 @@ jobs:
           env_vars: javascript
           # Specify whether or not CI build should fail if Codecov runs into an error during upload
           fail_ci_if_error: true
+
+      - name: SonarQube Scan
+        uses: sonarsource/sonarqube-scan-action@master
+        if: ${{ github.event_name == 'push' }}
+        with:
+          host: ${{secrets.SONAR_URL}}
+          login: ${{secrets.SONAR_TOKEN}}
+          projectBaseDir: ${{env.working-directory}}
+          projectKey: format('pims-frontend-{0}', ${{steps.extract_branch.outputs.branch}})
+          projectName: format('PIMS Frontend [{0}]', ${{steps.extract_branch.outputs.branch}})


### PR DESCRIPTION
Instead of submitting SonarQube scans with Jenkins we will submit them through GitHub Actions.

The SonarQube scans will only be run on a `push` (i.e. successful merge of a PR).

We cannot currently run the SonarQube scan during a `pull_request` because secrets will not be provided for forks for security reasons.