### PR TITLE
Update Docker compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   ####################### Keycloak #######################
   keycloak:
     restart: on-failure:1
-    container_name: pims-keycloak
+    container_name: psp-keycloak
     build:
       context: ./auth/keycloak
     env_file:
@@ -12,20 +12,20 @@ services:
     volumes:
       - ./auth/keycloak/config/realm-export.json:/tmp/realm-export.json
     ports:
-      - 8080:8080
+      - ${KEYCLOAK_PORT:-8080}:8080
     networks:
       - pims
 
   ####################### Database #######################
   database:
     restart: on-failure:1
-    container_name: api-db
+    container_name: psp-db
     build:
       context: database/mssql
     env_file:
       - database/mssql/.env
     ports:
-      - "5433:1433"
+      - ${DATABASE_PORT:-5433}:1433
     volumes:
       - api-db-data:/var/opt/mssql
     networks:
@@ -34,15 +34,15 @@ services:
   ####################### Backend #######################
   backend:
     restart: on-failure:1
-    container_name: backend-api
+    container_name: psp-api
     build:
       context: backend
       args:
         BUILD_CONFIGURATION: Debug
     env_file: backend/api/.env
     ports:
-      - "5001:443"
-      - "5000:8080"
+      - ${API_HTTPS_PORT:-5001}:443
+      - ${API_HTTP_PORT:-5000}:8080
     depends_on:
       - database
       - keycloak
@@ -54,7 +54,7 @@ services:
     stdin_open: true
     tty: true
     restart: on-failure:1
-    container_name: frontend-app
+    container_name: psp-app
     build:
       context: frontend
     volumes:
@@ -62,7 +62,7 @@ services:
       - ./frontend/public:/usr/app/public
       - frontend-node-cache:/usr/app/node_modules
     ports:
-      - "3000:3000"
+      - ${APP_HTTP_PORT:-3000}:3000
     depends_on:
       - backend
     env_file: ./frontend/.env


### PR DESCRIPTION
Supporting multiple instances of PIMS is currently impossible due to ports and naming conventions.  This update will allow more flexibility for each developer to control their environment.

This will require you to update your containers.

```bash
make down
make up
```

You can now control your environment ports with `.env`.  However, note that you will need to update other `.env` files to point to the selected ports if you don't use the defaults.