### PR TITLE
update csp to include a wider match for gov.bc.ca whitelist

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -9,7 +9,7 @@
     <!-- Any updates to this meta tag must be reflected in the applications nginx.conf.template for these changes to take effect in openshift-->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; frame-ancestors 'self'; img-src 'self' data: https://openmaps.gov.bc.ca/ https://maps.gov.bc.ca/ https://server.arcgisonline.com/; frame-src 'self' https://*.oidc.gov.bc.ca http://localhost:8080; connect-src 'self' https://*.oidc.gov.bc.ca/ http://localhost:8080/ https://openmaps.gov.bc.ca/ https://server.arcgisonline.com/; form-action 'self'; style-src 'self' 'unsafe-hashes' 'unsafe-inline'; script-src 'self' 'sha256-yt+SNVxRkIi6H6yb7ndFuZM1esMX9esg3UpRHaTsyVk=';"
+      content="default-src 'self'; frame-ancestors 'self'; img-src 'self' data: https://openmaps.gov.bc.ca/ https://maps.gov.bc.ca/ https://server.arcgisonline.com/; frame-src 'self' https://*.oidc.gov.bc.ca https://oidc.gov.bc.ca http://localhost:8080; connect-src 'self' https://*.oidc.gov.bc.ca/ https://oidc.gov.bc.ca http://localhost:8080/ https://openmaps.gov.bc.ca/ https://server.arcgisonline.com/; form-action 'self'; style-src 'self' 'unsafe-hashes' 'unsafe-inline'; script-src 'self' 'sha256-yt+SNVxRkIi6H6yb7ndFuZM1esMX9esg3UpRHaTsyVk=';"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
 

--- a/openshift/s2i/nginx-runtime/nginx.conf.template
+++ b/openshift/s2i/nginx-runtime/nginx.conf.template
@@ -40,7 +40,7 @@ http {
         ignore_invalid_headers off;
 
         # add in most common security headers
-        add_header Content-Security-Policy "default-src 'self'; frame-ancestors 'self'; img-src 'self' data: https://openmaps.gov.bc.ca/ https://maps.gov.bc.ca/ https://server.arcgisonline.com/; frame-src 'self' https://*.oidc.gov.bc.ca; connect-src 'self' https://*.oidc.gov.bc.ca/ https://openmaps.gov.bc.ca/ https://maps.gov.bc.ca/ https://server.arcgisonline.com/; form-action 'self'; style-src 'self' 'sha256-TJWtAQZhIjMP4+e4lQ8ZSVLt8o/wOfWY1ac6ZjvOwr8=' 'sha256-BeZ6EL8ajstckTUyE8k0bjY3v2P92XLxVp25GnrBG30=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';";
+        add_header Content-Security-Policy "default-src 'self'; frame-ancestors 'self'; img-src 'self' data: https://openmaps.gov.bc.ca/ https://maps.gov.bc.ca/ https://server.arcgisonline.com/; frame-src 'self' https://*.oidc.gov.bc.ca https://oidc.gov.bc.ca; connect-src 'self' https://*.oidc.gov.bc.ca/ https://oidc.gov.bc.ca/ https://openmaps.gov.bc.ca/ https://maps.gov.bc.ca/ https://server.arcgisonline.com/; form-action 'self'; style-src 'self' 'sha256-TJWtAQZhIjMP4+e4lQ8ZSVLt8o/wOfWY1ac6ZjvOwr8=' 'sha256-BeZ6EL8ajstckTUyE8k0bjY3v2P92XLxVp25GnrBG30=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';";
         add_header Strict-Transport-Security "max-age=86400; includeSubDomains";
         add_header X-Content-Type-Options "nosniff";
         add_header X-XSS-Protection 1;


### PR DESCRIPTION
the current expectation is that all oidc domains are prefixed with the environment. IE:
dev.oidc.gov.bc.ca
test.oidc.gov.bc.ca

this is not the case for prod which is oidc.gov.bc.ca

The usage of * in csps is limited to subdomains of the non-starred section. As a result *.oidc.gov.bc.ca does not match prod (also *oidc.gov.bc.ca is invalid). 

My recommendation is we move up the matcher to *.gov.bc.ca
Another option would be to add an explicit matcher for oidc.gov.bc.ca in addition to *.oidc.gov.bc.ca