### PR TITLE
Correct 404 errors when zooming too far into the new map.

### DIFF
--- a/frontend/src/components/maps/leaflet/Map.tsx
+++ b/frontend/src/components/maps/leaflet/Map.tsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 import classNames from 'classnames';
 import { useLayerQuery } from 'components/maps/leaflet/LayerPopup';
 import { IGeoSearchParams } from 'constants/API';
+import { MAP_MAX_ZOOM } from 'constants/strings';
 import { SidebarSize } from 'features/mapSideBar/hooks/useQueryParamSideBar';
 import { PropertyFilter } from 'features/properties/filter';
 import { IPropertyFilter } from 'features/properties/filter/IPropertyFilter';
@@ -328,6 +329,7 @@ const Map: React.FC<MapProps> = ({
               ref={mapRef}
               center={[lat, lng]}
               zoom={lastZoom}
+              maxZoom={MAP_MAX_ZOOM}
               whenReady={() => {
                 fitMapBounds();
               }}

--- a/frontend/src/constants/strings.tsx
+++ b/frontend/src/constants/strings.tsx
@@ -30,6 +30,7 @@ export const HIGH_ZOOM = 14;
 
 // max zoom level when clicking on parcel/building pins
 export const MAX_ZOOM = 16;
+export const MAP_MAX_ZOOM = 17;
 
 // default url values
 export const DEFAULT_PAGE = '1';


### PR DESCRIPTION
this was introduced with the basemap change. Fix is to set the max zoom level at a value supported by the basemap.