### PR TITLE
PSP-1663: Background image 'scaling'

### DIFF
--- a/frontend/src/features/account/LoginStyled.tsx
+++ b/frontend/src/features/account/LoginStyled.tsx
@@ -13,7 +13,7 @@ export const LoginStyled = styled(Container)`
       ? `url("${props.theme.tenant.login.backgroundImage}")`
       : ''};
   background-size: cover;
-  background-position: center top;
+  background-position: center;
   overflow: auto;
 
   .unauth {

--- a/frontend/src/features/account/__snapshots__/Login.test.tsx.snap
+++ b/frontend/src/features/account/__snapshots__/Login.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`login login renders correctly 1`] = `
   height: calc(100vh - undefined - undefined);
   background-image: url("/tenants/MOTI/background-image.jpg");
   background-size: cover;
-  background-position: center top;
+  background-position: center;
   overflow: auto;
 }
 

--- a/frontend/src/features/account/__snapshots__/LoginLoading.test.tsx.snap
+++ b/frontend/src/features/account/__snapshots__/LoginLoading.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`Empty Header CITZ Login Loading 1`] = `
   height: calc(100vh - undefined - undefined);
   background-image: url("/tenants/CITZ/background-image.png");
   background-size: cover;
-  background-position: center top;
+  background-position: center;
   overflow: auto;
 }
 
@@ -227,7 +227,7 @@ exports[`Empty Header MOTI Login Loading 1`] = `
   height: calc(100vh - undefined - undefined);
   background-image: url("/tenants/MOTI/background-image.jpg");
   background-size: cover;
-  background-position: center top;
+  background-position: center;
   overflow: auto;
 }
 


### PR DESCRIPTION
This will somewhat address the cutoff issues. 

I've played around with this ticket quite a bit and in order to show 100% of the image the image will be stretched as the container resolution and image resolution are not the same. 

The only other alternatives I could think of is having multiple different images/resolutions and have media queries to provide the user with the appropriate one for their screen size.

I'd suggest we just use one image instead of a collage for 'clean-ness' and consistency's sake but this can do for now depending on what the business wants. Having one image would have less off an impact on different resolutions as we wouldn't be looking for 4 even quadrants etc. 

Let me know if we have any other suggestions for this ticket.

![image](https://user-images.githubusercontent.com/15724124/129494589-d061797f-5288-43e0-ba02-7a57b10bd320.png)
