### PR TITLE
PSP-1711 automatic versioning

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,13 +7,13 @@ end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.ts]
+[{*.ts,*js]
 indent_style = space
 
 [*.cs]
 indent_size = 4
 
-[{*.json,*.md,*.yml,*.groovy,Jenkinsfile*}]
+[{*.json,*.md,*.yml,*.groovy,Jenkinsfile*,*.sh}]
 indent_style = space
 indent_size = 2
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,28 @@
+name: Bump version
+
+on:
+  push:
+    branches: [dev, versioning]
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+      - name: Bump version number
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+          NEW_VERSION=$(node ./build/bump-version.js --release-version)
+
+          # bump version
+          node ./build/bump-version.js --apply
+
+          # create commit
+          git add -A
+          git commit -m "build(release): Bump version to v${NEW_VERSION}"
+          git push

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -17,7 +17,8 @@ jobs:
           git config user.name "github-actions"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          NEW_VERSION=$(node ./build/bump-version.js --release-version)
+          # this just prints the new version number - will not update any files
+          NEW_VERSION=$(node ./build/bump-version.js --print-version)
 
           # bump version
           node ./build/bump-version.js --apply

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -2,7 +2,7 @@ name: Bump version
 
 on:
   push:
-    branches: [dev, versioning]
+    branches: [dev]
 
 jobs:
   version:
@@ -14,8 +14,8 @@ jobs:
           node-version: "14"
       - name: Bump version number
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name "github-actions"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           NEW_VERSION=$(node ./build/bump-version.js --release-version)
 

--- a/backend/api/Pims.Api.csproj
+++ b/backend/api/Pims.Api.csproj
@@ -61,11 +61,3 @@
     <ProjectReference Include="..\notifications\Pims.Notifications.csproj" />
   </ItemGroup>
 </Project>
-
-
-
-
-
-
-
-

--- a/backend/api/Pims.Api.csproj
+++ b/backend/api/Pims.Api.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>net5.0</TargetFramework>
     <UserSecretsId>0ef6255f-9ea0-49ec-8c65-c172304b4926</UserSecretsId>
     <LangVersion>8.0</LangVersion>
-    <Version>0.2.0.7</Version>
-    <AssemblyVersion>0.2.0.7</AssemblyVersion>
+    <Version>0.2.0-8.0</Version>
+    <AssemblyVersion>0.2.0.8</AssemblyVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <ProjectGuid>16BC0468-78F6-4C91-87DA-7403C919E646</ProjectGuid>
@@ -61,3 +61,11 @@
     <ProjectReference Include="..\notifications\Pims.Notifications.csproj" />
   </ItemGroup>
 </Project>
+
+
+
+
+
+
+
+

--- a/build/.prettierrc.js
+++ b/build/.prettierrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  semi: true,
+  trailingComma: 'all',
+  singleQuote: true,
+  printWidth: 100,
+  tabWidth: 2,
+  endOfLine: 'lf',
+};

--- a/build/README.md
+++ b/build/README.md
@@ -1,1 +1,7 @@
 # Build tools and scripts
+
+These are build scripts and files to automate DevOps processes:
+
+- continuous integration (CI),
+- deployment,
+- release management (i.e versioning + tagging)

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,1 @@
+# Build tools and scripts

--- a/build/bump-version.js
+++ b/build/bump-version.js
@@ -66,7 +66,7 @@ function updateJson(packageJson) {
 
 function updateCsproj(csproj) {
   console.info(`==> Applying changes to ${csprojLoc}`);
-  fs.writeFileSync(csprojLoc, `${csproj}${os.EOL}`, 'utf8');
+  fs.writeFileSync(csprojLoc, csproj, 'utf8');
 }
 
 // version format: <major>.<minor>.<patch>-<IS_number>.<build>

--- a/build/bump-version.js
+++ b/build/bump-version.js
@@ -1,0 +1,123 @@
+const fs = require('fs');
+const os = require('os');
+
+const packageJsonLoc = './frontend/package.json';
+const csprojLoc = './backend/api/Pims.Api.csproj';
+
+/**
+ * USAGE:
+ *
+ * node ./build/bump-version.js [<new-version> | major | minor | patch | is | build] [--apply] [--release-version]
+ *
+ * To print the next version without releasing anything, add the '--release-version' flag.
+ */
+
+// parse command-line args
+const args = process.argv.slice(2);
+run(args);
+
+////////////////////////// Helpers /////////////////////////////
+
+function run(args) {
+  const IS_DRY_RUN = !args.includes('--apply'); // default to dry-run
+  const IS_RELEASE_VERSION = args.includes('--release-version');
+
+  const releaseType = args[0];
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonLoc, 'utf8'));
+  const version = packageJson.version;
+  //   const version = require(packageJsonLoc).version;
+
+  let [newVersion, assemblyVersion] = bumpVersion(releaseType, version);
+
+  if (IS_RELEASE_VERSION) {
+    console.info(newVersion);
+    process.exit(0);
+  }
+
+  // bump version numbers
+  if (!IS_DRY_RUN) {
+    packageJson.version = newVersion;
+    updateJson(packageJson);
+
+    let csproj = fs.readFileSync(csprojLoc, 'utf8');
+    let modifiedCsproj = csproj
+      .replace(/<Version>(.+?)<\/Version>/gi, `<Version>${newVersion}</Version>`)
+      .replace(
+        /<AssemblyVersion>(.+?)<\/AssemblyVersion>/gi,
+        `<AssemblyVersion>${assemblyVersion}</AssemblyVersion>`,
+      );
+    updateCsproj(modifiedCsproj);
+
+    console.info(`    success`);
+  }
+
+  console.info(`==> Version bumped to: "${newVersion}"`);
+
+  if (IS_DRY_RUN) {
+    console.info('');
+    console.info(`THIS WAS A DRY RUN, SO NO FILE WAS ACTUALLY CHANGED`);
+    console.info(`Run this again with '--apply' to execute the changes`);
+  }
+}
+
+function updateJson(packageJson) {
+  console.info(`==> Applying changes to ${packageJsonLoc}`);
+  fs.writeFileSync(packageJsonLoc, `${JSON.stringify(packageJson, undefined, 2)}${os.EOL}`, 'utf8');
+}
+
+function updateCsproj(csproj) {
+  console.info(`==> Applying changes to ${csprojLoc}`);
+  fs.writeFileSync(csprojLoc, `${csproj}${os.EOL}`, 'utf8');
+}
+
+// version format: <major>.<minor>.<patch>-<IS_number>.<build>
+// e.g. 0.2.0-7.3
+function bumpVersion(releaseType, version) {
+  let major, minor, patch, is, build;
+
+  if (version) {
+    const [semVer, metadata] = version.split('-');
+    [major, minor, patch] = semVer.split('.');
+    [is, build] = metadata.split('.');
+
+    switch (releaseType) {
+      case 'major':
+        major = parseInt(major, 10) + 1;
+        minor = 0;
+        patch = 0;
+        build = 0;
+        break;
+
+      case 'minor':
+        minor = parseInt(minor, 10) + 1;
+        patch = 0;
+        build = 0;
+        break;
+
+      case 'patch':
+        patch = parseInt(patch, 10) + 1;
+        build = 0;
+        break;
+
+      case 'is':
+        is = parseInt(is, 10) + 1;
+        build = 0;
+        break;
+
+      default:
+        build = parseInt(build, 10) + 1;
+    }
+  } else {
+    // default
+    major = 0;
+    minor = 1;
+    patch = 0;
+    is = 1;
+    build = 0;
+  }
+
+  let newVersion = `${major}.${minor}.${patch}-${is}.${build}`;
+  let assemblyVersion = `${major}.${minor}.${patch}.${is}`;
+
+  return [newVersion, assemblyVersion];
+}

--- a/build/bump-version.js
+++ b/build/bump-version.js
@@ -5,11 +5,15 @@ const packageJsonLoc = './frontend/package.json';
 const csprojLoc = './backend/api/Pims.Api.csproj';
 
 /**
- * USAGE:
+ * A script for automated version bumps. It requires Node.js to be installed on the server.
+ * The script will default to a DRY RUN to avoid unintended changes; run with '--apply' to execute the changes.
  *
- * node ./build/bump-version.js [<new-version> | major | minor | patch | is | build] [--apply] [--release-version]
- *
+ * NOTE:
  * To print the next version without releasing anything, add the '--release-version' flag.
+ *
+ * USAGE:
+ * node ./build/bump-version.js [<new-version> | major | minor | patch | is | build] [--apply] [--print-version]
+ *
  */
 
 // parse command-line args
@@ -20,7 +24,7 @@ run(args);
 
 function run(args) {
   const IS_DRY_RUN = !args.includes('--apply'); // default to dry-run
-  const IS_RELEASE_VERSION = args.includes('--release-version');
+  const IS_PRINT_VERSION = args.includes('--print-version');
 
   const releaseType = args[0];
   const packageJson = JSON.parse(fs.readFileSync(packageJsonLoc, 'utf8'));
@@ -28,7 +32,7 @@ function run(args) {
 
   let [newVersion, assemblyVersion] = bumpVersion(releaseType, version);
 
-  if (IS_RELEASE_VERSION) {
+  if (IS_PRINT_VERSION) {
     console.info(newVersion);
     process.exit(0);
   }
@@ -115,7 +119,7 @@ function bumpVersion(releaseType, version) {
         break;
 
       case 'is':
-        is = parseInt(is, 10) + 1;
+        isNumber = parseInt(isNumber, 10) + 1;
         build = 0;
         break;
 
@@ -127,7 +131,7 @@ function bumpVersion(releaseType, version) {
     major = 0;
     minor = 1;
     patch = 0;
-    is = 1;
+    isNumber = 1;
     build = 0;
   }
 

--- a/build/bump-version.js
+++ b/build/bump-version.js
@@ -25,7 +25,6 @@ function run(args) {
   const releaseType = args[0];
   const packageJson = JSON.parse(fs.readFileSync(packageJsonLoc, 'utf8'));
   const version = packageJson.version;
-  //   const version = require(packageJsonLoc).version;
 
   let [newVersion, assemblyVersion] = bumpVersion(releaseType, version);
 
@@ -72,13 +71,29 @@ function updateCsproj(csproj) {
 
 // version format: <major>.<minor>.<patch>-<IS_number>.<build>
 // e.g. 0.2.0-7.3
-function bumpVersion(releaseType, version) {
-  let major, minor, patch, is, build;
+function isValidVersion(version) {
+  if (!version) {
+    return false;
+  }
+  return /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(version);
+}
 
-  if (version) {
-    const [semVer, metadata] = version.split('-');
-    [major, minor, patch] = semVer.split('.');
-    [is, build] = metadata.split('.');
+function parse(version) {
+  const [semVer, metadata] = version.split('-');
+  const [major, minor, patch] = semVer?.split('.');
+  const [isNumber, build] = metadata?.split('.');
+
+  return [major, minor, patch, isNumber, build];
+}
+
+function bumpVersion(releaseType, version) {
+  let major, minor, patch, isNumber, build;
+
+  // Support setting version to a fixed value; e.g. "0.1.0-8.5"
+  if (isValidVersion(releaseType)) {
+    [major, minor, patch, isNumber, build] = parse(releaseType);
+  } else if (version) {
+    [major, minor, patch, isNumber, build] = parse(version);
 
     switch (releaseType) {
       case 'major':
@@ -116,8 +131,8 @@ function bumpVersion(releaseType, version) {
     build = 0;
   }
 
-  let newVersion = `${major}.${minor}.${patch}-${is}.${build}`;
-  let assemblyVersion = `${major}.${minor}.${patch}.${is}`;
+  let newVersion = `${major}.${minor}.${patch}-${isNumber}.${build}`;
+  let assemblyVersion = `${major}.${minor}.${patch}.${isNumber}`;
 
   return [newVersion, assemblyVersion];
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.2.0",
+  "version": "0.2.0-8.0",
   "private": true,
   "dependencies": {
     "@bcgov/bc-sans": "1.0.1",


### PR DESCRIPTION
Implements a new GitHub action to automatically bump the build version number for PRs merged to DEV. 
It uses consistent versioning for backend and frontend sub-projects.

The agreed version number format is:

```
{major}.{minor}.{patch/hotfix}-{ISnumber}.{build}
```
