### PR TITLE
PSP-1700 Fix automatic versioning action

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,14 +1,19 @@
 name: Bump version
 
 on:
-  push:
+  pull_request_target:
+    types: [closed]
     branches: [dev]
 
 jobs:
-  version:
+  bump-version:
+    # this job will only run if the PR has been merged
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }} # with this we can bypass branch protection rules here (no-push)
       - uses: actions/setup-node@v2
         with:
           node-version: "14"
@@ -18,12 +23,12 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           # this just prints the new version number - will not update any files
-          NEW_VERSION=$(node ./build/bump-version.js --print-version)
+          NEW_VERSION=$(node build/bump-version.js --print-version)
 
-          # bump version
-          # node ./build/bump-version.js --apply
+          # auto-increment version number upon merging pull requests
+          node build/bump-version.js --apply
 
           # create commit
-          # git add -A
-          # git commit -m "build(release): Bump version to v${NEW_VERSION}"
-          # git push
+          git add -A
+          git commit -m "chore: bump version to v${NEW_VERSION}"
+          git push


### PR DESCRIPTION
Made a few adjustments to the auto-increment action:
- It runs only when pull requests are merged (as opposed to any **push** to dev)
- It uses a deploy key with write access to the repo to act as an "admin" user with power to bypass the "no-push" restriction so it can commit the new version number back into the repo automatically