### PR TITLE
PSP-2204: Access request auto populate fields

### DIFF
--- a/frontend/src/features/admin/access-request/AccessRequestPage.tsx
+++ b/frontend/src/features/admin/access-request/AccessRequestPage.tsx
@@ -8,7 +8,7 @@ import { AUTHORIZATION_URL } from 'constants/strings';
 import { Formik } from 'formik';
 import useKeycloakWrapper from 'hooks/useKeycloakWrapper';
 import useLookupCodeHelpers from 'hooks/useLookupCodeHelpers';
-import { IAccessRequest, IUserInfo } from 'interfaces';
+import { IAccessRequest, IAccessRequestUserInfo } from 'interfaces';
 import React, { useEffect } from 'react';
 import Alert from 'react-bootstrap/Alert';
 import Button from 'react-bootstrap/Button';
@@ -33,7 +33,7 @@ import { Form, Input, Select, TextArea } from '../../../components/common/form';
 const AccessRequestPage = () => {
   const keycloakWrapper = useKeycloakWrapper();
   const keycloak = keycloakWrapper.obj;
-  const userInfo = keycloak?.userInfo as IUserInfo;
+  const userInfo = keycloak?.userInfo as IAccessRequestUserInfo;
   const { fetchCurrentAccessRequest, addAccessRequest } = useAccessRequests();
   const [alert, setAlert] = React.useState<ISnackbarState>({});
 
@@ -54,10 +54,10 @@ const AccessRequestPage = () => {
     user: {
       id: userInfo?.id,
       keycloakUserId: userInfo?.keycloakUserId,
-      businessIdentifier: userInfo?.businessIdentifier,
+      businessIdentifier: userInfo?.username,
       displayName: userInfo?.name,
       firstName: userInfo?.firstName,
-      surname: userInfo?.surname,
+      surname: userInfo?.family_name,
       email: userInfo?.email,
       position: accessRequest?.user?.position ?? userInfo?.position ?? '',
     },

--- a/frontend/src/interfaces/IAccessRequestUserInfo.ts
+++ b/frontend/src/interfaces/IAccessRequestUserInfo.ts
@@ -1,0 +1,10 @@
+export interface IAccessRequestUserInfo {
+  id: number;
+  keycloakUserId: string;
+  username: string;
+  name: string;
+  email: string;
+  firstName: string;
+  family_name: string;
+  position?: string;
+}

--- a/frontend/src/interfaces/index.ts
+++ b/frontend/src/interfaces/index.ts
@@ -1,6 +1,7 @@
 export * from './IAccessRequest';
 export * from './IAccessRequestOrganization';
 export * from './IAccessRequestRole';
+export * from './IAccessRequestUserInfo';
 export * from './IAddress';
 export * from './ILease';
 export * from './ILeaseSearchResult';

--- a/testing/Profiles/default.glbl
+++ b/testing/Profiles/default.glbl
@@ -6,12 +6,12 @@
    <defaultProfile>true</defaultProfile>
    <GlobalVariableEntity>
       <description></description>
-      <initValue>'jotoombs'</initValue>
+      <initValue>''</initValue>
       <name>userName</name>
    </GlobalVariableEntity>
    <GlobalVariableEntity>
       <description></description>
-      <initValue>'lvv2h9Gg0Xe+I8XHrMSSNg=='</initValue>
+      <initValue>''</initValue>
       <name>password</name>
    </GlobalVariableEntity>
 </GlobalVariableEntities>


### PR DESCRIPTION
Finally got my docker working so I could test this.

Information given by the `userinfo` fetch at this step was slightly misaligned with the interface we were using at this point causing the `idir` and `last name` to be blank.

Created a new interface to represent the data at this point in time of the access request.
