### PR TITLE
PSP-2221: Property Filter - Reset button not clearing properties on map view

### DIFF
--- a/frontend/src/components/maps/leaflet/Map.tsx
+++ b/frontend/src/components/maps/leaflet/Map.tsx
@@ -87,7 +87,7 @@ const defaultFilterValues: IPropertyFilter = {
   location: '',
 };
 
-const whitelistedFilterKeys = ['PID', 'PIN', 'ADDRESS', 'LOCATION'];
+const whitelistedFilterKeys = ['PID', 'PIN', 'STREET_ADDRESS_1', 'LOCATION'];
 
 /**
  * Converts the map filter to a geo search filter.


### PR DESCRIPTION
The geo filter contains a key for `STREET_ADDRESS_1` and not `ADDRESS`. Reset was not working for address as it was constantly saying that the filter was unchanged as it was comparing `undefined` to `undefined`.