### PR TITLE
force refresh local geoserver layer.

### DIFF
--- a/geoserver/geoserver_data/psp/mssql/PIMS_PROPERTY_LOCATION_VW/featuretype.xml
+++ b/geoserver/geoserver_data/psp/mssql/PIMS_PROPERTY_LOCATION_VW/featuretype.xml
@@ -1,5 +1,5 @@
 <featureType>
-  <id>FeatureTypeInfoImpl--47c96824:17c20b17224:-7ff4</id>
+  <id>FeatureTypeInfoImpl--3da53034:17d0594c855:-7131</id>
   <name>PIMS_PROPERTY_LOCATION_VW</name>
   <nativeName>PIMS_PROPERTY_LOCATION_VW</nativeName>
   <namespace>
@@ -34,30 +34,26 @@
   AUTHORITY[&quot;EPSG&quot;,&quot;3005&quot;]]</nativeCRS>
   <srs>EPSG:3005</srs>
   <nativeBoundingBox>
-    <minx>34758.748716825736</minx>
-    <maxx>1883159.4990994572</maxx>
-    <miny>359549.2446022132</miny>
-    <maxy>1736633.6842181894</maxy>
+    <minx>593913.8585748569</minx>
+    <maxx>1677969.564075983</maxx>
+    <miny>380698.3425773544</miny>
+    <maxy>1303737.645752608</maxy>
     <crs class="projected">EPSG:3005</crs>
   </nativeBoundingBox>
   <latLonBoundingBox>
-    <minx>-143.20695227594084</minx>
-    <maxx>-110.20610352993367</maxx>
-    <miny>47.46059909146709</miny>
-    <maxy>60.61128669358577</maxy>
+    <minx>-132.6266178439845</minx>
+    <maxx>-114.99383662436095</maxx>
+    <miny>48.049005189764884</miny>
+    <maxy>56.72280217252524</maxy>
     <crs>EPSG:4326</crs>
   </latLonBoundingBox>
   <projectionPolicy>FORCE_DECLARED</projectionPolicy>
   <enabled>true</enabled>
-  <metadata>
-    <entry key="cachingEnabled">false</entry>
-  </metadata>
   <store class="dataStore">
     <id>DataStoreInfoImpl--47c96824:17c20b17224:-7ff6</id>
   </store>
   <serviceConfiguration>false</serviceConfiguration>
   <simpleConversionEnabled>false</simpleConversionEnabled>
-  <cqlFilter>GEOMETRY is not null</cqlFilter>
   <maxFeatures>0</maxFeatures>
   <numDecimals>0</numDecimals>
   <padWithZeros>false</padWithZeros>

--- a/geoserver/geoserver_data/psp/mssql/PIMS_PROPERTY_LOCATION_VW/layer.xml
+++ b/geoserver/geoserver_data/psp/mssql/PIMS_PROPERTY_LOCATION_VW/layer.xml
@@ -1,22 +1,16 @@
 <layer>
   <name>PIMS_PROPERTY_LOCATION_VW</name>
-  <id>LayerInfoImpl--47c96824:17c20b17224:-7ff3</id>
+  <id>LayerInfoImpl--3da53034:17d0594c855:-7130</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl--47c96824:17c20b17224:-7ffc</id>
+    <id>StyleInfoImpl-dccd8c1:17c8054825a:-7ffc</id>
   </defaultStyle>
-  <styles class="linked-hash-set">
-    <style>
-      <id>StyleInfoImpl--47c96824:17c20b17224:-8000</id>
-    </style>
-  </styles>
   <resource class="featureType">
-    <id>FeatureTypeInfoImpl--47c96824:17c20b17224:-7ff4</id>
+    <id>FeatureTypeInfoImpl--3da53034:17d0594c855:-7131</id>
   </resource>
   <attribution>
     <logoWidth>0</logoWidth>
     <logoHeight>0</logoHeight>
   </attribution>
-  <dateCreated>2021-09-26 06:36:26.182 UTC</dateCreated>
-  <dateModified>2021-09-26 17:36:47.54 UTC</dateModified>
+  <dateCreated>2021-11-10 17:27:18.456 UTC</dateCreated>
 </layer>


### PR DESCRIPTION
I did not realize this, but it seems like geoserver caches exposes layers, so my update to the location layer in my last PR will not be visible within geoserver. I was able to resolve this locally by recreating the layer, hopefully by propagating that configuration your local dev geoserver's will display the new layer. if not I recommend restarting the container.