### PR TITLE
Correction to PSP-2361

### DIFF
--- a/frontend/src/features/leases/detail/LeasePages/details/__snapshots__/DetailAdministration.test.tsx.snap
+++ b/frontend/src/features/leases/detail/LeasePages/details/__snapshots__/DetailAdministration.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`DetailAdministration component renders a complete lease as expected 1`]
   border-left: 1px solid #666666;
 }
 
-.c1 .form-control {
+.c1 .form-control:not(.description) {
   font-weight: 700;
 }
 
@@ -187,7 +187,7 @@ exports[`DetailAdministration component renders minimally as expected 1`] = `
   border-left: 1px solid #666666;
 }
 
-.c1 .form-control {
+.c1 .form-control:not(.description) {
   font-weight: 700;
 }
 

--- a/frontend/src/features/leases/detail/LeasePages/details/__snapshots__/PropertiesInformation.test.tsx.snap
+++ b/frontend/src/features/leases/detail/LeasePages/details/__snapshots__/PropertiesInformation.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`PropertiesInformation component renders as expected 1`] = `
   border-left: 1px solid #666666;
 }
 
-.c1 .form-control {
+.c1 .form-control:not(.description) {
   font-weight: 700;
 }
 

--- a/frontend/src/features/leases/detail/LeasePages/details/__snapshots__/PropertyInformation.test.tsx.snap
+++ b/frontend/src/features/leases/detail/LeasePages/details/__snapshots__/PropertyInformation.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`PropertyInformation component renders a complete lease as expected 1`] 
   border-left: 1px solid #666666;
 }
 
-.c1 .form-control {
+.c1 .form-control:not(.description) {
   font-weight: 700;
 }
 
@@ -146,7 +146,7 @@ exports[`PropertyInformation component renders minimally as expected 1`] = `
   border-left: 1px solid #666666;
 }
 
-.c1 .form-control {
+.c1 .form-control:not(.description) {
   font-weight: 700;
 }
 

--- a/frontend/src/features/leases/detail/LeasePages/improvements/components/Improvement/Improvement.tsx
+++ b/frontend/src/features/leases/detail/LeasePages/improvements/components/Improvement/Improvement.tsx
@@ -38,6 +38,7 @@ export const Improvement: React.FunctionComponent<IImprovementProps> = ({
         <Input disabled={disabled} field={withNameSpace(nameSpace, 'structureSize')} />
         <Styled.FormDescriptionLabel>Description</Styled.FormDescriptionLabel>
         <Styled.FormDescriptionBody
+          className="description"
           rows={5}
           disabled={disabled}
           field={withNameSpace(nameSpace, 'description')}

--- a/frontend/src/features/leases/detail/LeasePages/tenant/__snapshots__/Tenant.test.tsx.snap
+++ b/frontend/src/features/leases/detail/LeasePages/tenant/__snapshots__/Tenant.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`Tenant component renders as expected 1`] = `
   border-left: 1px solid #666666;
 }
 
-.c3 .form-control {
+.c3 .form-control:not(.description) {
   font-weight: 700;
 }
 

--- a/frontend/src/features/leases/detail/__snapshots__/LeaseContainer.test.tsx.snap
+++ b/frontend/src/features/leases/detail/__snapshots__/LeaseContainer.test.tsx.snap
@@ -207,7 +207,7 @@ exports[`LeaseContainer component renders as expected 1`] = `
   border-left: 1px solid #666666;
 }
 
-.c26 .form-control {
+.c26 .form-control:not(.description) {
   font-weight: 700;
 }
 

--- a/frontend/src/features/leases/detail/styles.ts
+++ b/frontend/src/features/leases/detail/styles.ts
@@ -113,7 +113,7 @@ export const FormGrid = styled.div`
     border-left: 1px solid #666666;
   }
 
-  & .form-control {
+  & .form-control:not(.description) {
     font-weight: 700;
   }
 


### PR DESCRIPTION
Stashed code erroneously left out of last PR.

`form-control` currently overriding font weight with `700`, added this to exclude the description text and use appropriate weight of `400`