### PR TITLE
Cleaned unused usings on backend code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ db-deploy:
 
 db-scaffold: ## Requires local install of sqlcmd
 	@echo "$(P) regenerate ef core entities from database"
-	@cd backend/dal; eval $(grep -v '^#' .env | xargs) dotnet ef dbcontext scaffold Name=PIMS Microsoft.EntityFrameworkCore.SqlServer -o ../entities/ef --schema dbo --context PimsContext --context-namespace Pims.Dal --context-dir . --startup-project ../api --no-onconfiguring --namespace Pims.Dal.Entities -v -f
+	@cd backend/dal; eval $(grep -v '^#' .env | xargs) dotnet ef dbcontext scaffold Name=PIMS Microsoft.EntityFrameworkCore.SqlServer -o ../entities/ef --schema dbo --context PimsContext --context-namespace Pims.Dal --context-dir . --startup-project ../api --no-onconfiguring --namespace Pims.Dal.Entities --data-annotations -v -f
 
 keycloak-sync: ## Syncs accounts with Keycloak and PIMS
 	@echo "$(P) Syncing keycloak with PIMS..."

--- a/backend/.editorconfig
+++ b/backend/.editorconfig
@@ -79,4 +79,7 @@ dotnet_diagnostic.S3442.severity = error
 dotnet_diagnostic.S125.severity = warning
 # S4136 Method overloads should be adjacent
 dotnet_diagnostic.S4136.severity = none
+# S1128 Remove this unnecessary 'using'
+dotnet_diagnostic.S1128.severity = warning
+
 

--- a/backend/.editorconfig
+++ b/backend/.editorconfig
@@ -51,6 +51,8 @@ dotnet_diagnostic.CA1801.severity = none # #TODO: Requires further analysis
 dotnet_diagnostic.CA1822.severity = warning
 # CS1591: Missing XML comment
 dotnet_diagnostic.CS1591.severity = none
+# CS8019: Using directive is unnecessary.
+dotnet_diagnostic.CS8019.severity = warning
 
 # SonarQube
 # S4487 Unread "private" fields should be removed.
@@ -82,4 +84,13 @@ dotnet_diagnostic.S4136.severity = none
 # S1128 Remove this unnecessary 'using'
 dotnet_diagnostic.S1128.severity = warning
 
+# Entity Framework files
+[**{entities/ef/*,PIMSContext}.cs]
+# CS8019: Using directive is unnecessary.
+dotnet_diagnostic.CS8019.severity = none
 
+# SonarQube
+# S1128 Remove this unnecessary 'using'
+dotnet_diagnostic.S1128.severity = none
+# S3251 Supply an implementation for this partial method.
+dotnet_diagnostic.S3251.severity = none

--- a/backend/api/Areas/Admin/Mapping/Role/RoleMap.cs
+++ b/backend/api/Areas/Admin/Mapping/Role/RoleMap.cs
@@ -1,5 +1,4 @@
 using Mapster;
-using System.Linq;
 using Entity = Pims.Dal.Entities;
 using Model = Pims.Api.Areas.Admin.Models.Role;
 

--- a/backend/api/Areas/Contacts/Controllers/ContactController.cs
+++ b/backend/api/Areas/Contacts/Controllers/ContactController.cs
@@ -1,11 +1,8 @@
 using System.Collections.Generic;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using MapsterMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Pims.Api.Policies;
-using Pims.Core.Converters;
 using Pims.Dal;
 using Pims.Dal.Security;
 using Swashbuckle.AspNetCore.Annotations;

--- a/backend/api/Areas/Contacts/Mapping/Contact/PersonMap.cs
+++ b/backend/api/Areas/Contacts/Mapping/Contact/PersonMap.cs
@@ -1,6 +1,5 @@
 using Mapster;
 using Pims.Dal.Entities;
-using Pims.Dal.Helpers.Extensions;
 using Entity = Pims.Dal.Entities;
 using Model = Pims.Api.Areas.Contact.Models.Contact;
 

--- a/backend/api/Areas/Leases/Mapping/Lease/PersonMap.cs
+++ b/backend/api/Areas/Leases/Mapping/Lease/PersonMap.cs
@@ -1,6 +1,5 @@
 using Mapster;
 using Pims.Dal.Entities;
-using Pims.Dal.Helpers.Extensions;
 using Entity = Pims.Dal.Entities;
 using Model = Pims.Api.Areas.Lease.Models.Lease;
 

--- a/backend/api/Areas/Reports/Controllers/LeaseController.cs
+++ b/backend/api/Areas/Reports/Controllers/LeaseController.cs
@@ -12,7 +12,6 @@ using Pims.Dal.Entities.Models;
 using Pims.Dal.Security;
 using Swashbuckle.AspNetCore.Annotations;
 using System;
-using Pims.Dal.Helpers.Extensions;
 using System.Linq;
 using System.Collections.Generic;
 

--- a/backend/api/Helpers/Extensions/MapperExtensions.cs
+++ b/backend/api/Helpers/Extensions/MapperExtensions.cs
@@ -1,4 +1,3 @@
-using Pims.Api.Areas.Lease.Models.Lease;
 using Pims.Api.Models;
 using Pims.Dal.Entities;
 

--- a/backend/api/Mapping/User/OrganizationMap.cs
+++ b/backend/api/Mapping/User/OrganizationMap.cs
@@ -1,5 +1,4 @@
 using Mapster;
-using System.Linq;
 using Entity = Pims.Dal.Entities;
 using Model = Pims.Api.Models.User;
 

--- a/backend/dal.keycloak/Pims.Dal.Keycloak.csproj
+++ b/backend/dal.keycloak/Pims.Dal.Keycloak.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Mapster.DependencyInjection" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\entities\Pims.Dal.Entities.csproj" />

--- a/backend/dal/Helpers/Extensions/IdentityExtensions.cs
+++ b/backend/dal/Helpers/Extensions/IdentityExtensions.cs
@@ -1,4 +1,3 @@
-using Microsoft.EntityFrameworkCore;
 using Pims.Core.Extensions;
 using Pims.Dal.Entities;
 using Pims.Dal.Exceptions;

--- a/backend/dal/Helpers/Extensions/LeaseExtensions.cs
+++ b/backend/dal/Helpers/Extensions/LeaseExtensions.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Data.SqlClient;
 using System.Linq;
-using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
 using Pims.Core.Extensions;
 using Pims.Dal.Entities;

--- a/backend/dal/PIMSContext.cs
+++ b/backend/dal/PIMSContext.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Pims.Dal.Entities;
 
 #nullable disable
@@ -160,88 +162,21 @@ namespace Pims.Dal
                 entity.HasKey(e => e.AccessRequestId)
                     .HasName("ACRQST_PK");
 
-                entity.ToTable("PIMS_ACCESS_REQUEST");
+                entity.Property(e => e.AccessRequestId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ACCESS_REQUEST_ID_SEQ])");
 
-                entity.HasIndex(e => e.AccessRequestStatusTypeCode, "ACRQST_ACCESS_REQUEST_STATUS_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.RoleId, "ACRQST_ROLE_ID_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.UserId, "ACRQST_USER_ID_IDX");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AccessRequestId)
-                    .HasColumnName("ACCESS_REQUEST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ACCESS_REQUEST_ID_SEQ])");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AccessRequestStatusTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("ACCESS_REQUEST_STATUS_TYPE_CODE");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Note).HasColumnName("NOTE");
-
-                entity.Property(e => e.RoleId).HasColumnName("ROLE_ID");
-
-                entity.Property(e => e.UserId).HasColumnName("USER_ID");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
                 entity.HasOne(d => d.AccessRequestStatusTypeCodeNavigation)
                     .WithMany(p => p.PimsAccessRequests)
@@ -266,86 +201,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.AccessRequestHistId)
                     .HasName("PIMS_ACRQST_H_PK");
 
-                entity.ToTable("PIMS_ACCESS_REQUEST_HIST");
+                entity.Property(e => e.AccessRequestHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ACCESS_REQUEST_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.AccessRequestHistId, e.EndDateHist }, "PIMS_ACRQST_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.AccessRequestHistId)
-                    .HasColumnName("_ACCESS_REQUEST_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ACCESS_REQUEST_H_ID_SEQ])");
-
-                entity.Property(e => e.AccessRequestId).HasColumnName("ACCESS_REQUEST_ID");
-
-                entity.Property(e => e.AccessRequestStatusTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("ACCESS_REQUEST_STATUS_TYPE_CODE");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.RoleId).HasColumnName("ROLE_ID");
-
-                entity.Property(e => e.UserId).HasColumnName("USER_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsAccessRequestOrganization>(entity =>
@@ -353,86 +211,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.AccessRequestOrganizationId)
                     .HasName("ACRQOR_PK");
 
-                entity.ToTable("PIMS_ACCESS_REQUEST_ORGANIZATION");
+                entity.Property(e => e.AccessRequestOrganizationId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ACCESS_REQUEST_ORGANIZATION_ID_SEQ])");
 
-                entity.HasIndex(e => e.AccessRequestId, "ACRQOR_ACCESS_REQUEST_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => new { e.OrganizationId, e.AccessRequestId }, "ACRQOR_ORGANIZATION_ACCESS_REQUEST_TUC")
-                    .IsUnique();
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.OrganizationId, "ACRQOR_ORGANIZATION_ID_IDX");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AccessRequestOrganizationId)
-                    .HasColumnName("ACCESS_REQUEST_ORGANIZATION_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ACCESS_REQUEST_ORGANIZATION_ID_SEQ])");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AccessRequestId).HasColumnName("ACCESS_REQUEST_ID");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.IsDisabled)
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.OrganizationId).HasColumnName("ORGANIZATION_ID");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
                 entity.HasOne(d => d.AccessRequest)
                     .WithMany(p => p.PimsAccessRequestOrganizations)
@@ -451,83 +246,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.AccessRequestOrganizationHistId)
                     .HasName("PIMS_ACRQOR_H_PK");
 
-                entity.ToTable("PIMS_ACCESS_REQUEST_ORGANIZATION_HIST");
+                entity.Property(e => e.AccessRequestOrganizationHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ACCESS_REQUEST_ORGANIZATION_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.AccessRequestOrganizationHistId, e.EndDateHist }, "PIMS_ACRQOR_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.AccessRequestOrganizationHistId)
-                    .HasColumnName("_ACCESS_REQUEST_ORGANIZATION_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ACCESS_REQUEST_ORGANIZATION_H_ID_SEQ])");
-
-                entity.Property(e => e.AccessRequestId).HasColumnName("ACCESS_REQUEST_ID");
-
-                entity.Property(e => e.AccessRequestOrganizationId).HasColumnName("ACCESS_REQUEST_ORGANIZATION_ID");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.OrganizationId).HasColumnName("ORGANIZATION_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsAccessRequestStatusType>(entity =>
@@ -535,49 +256,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.AccessRequestStatusTypeCode)
                     .HasName("ARQSTT_PK");
 
-                entity.ToTable("PIMS_ACCESS_REQUEST_STATUS_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AccessRequestStatusTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("ACCESS_REQUEST_STATUS_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsActivity>(entity =>
@@ -585,83 +274,21 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ActivityId)
                     .HasName("ACTVTY_PK");
 
-                entity.ToTable("PIMS_ACTIVITY");
+                entity.Property(e => e.ActivityId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ACTIVITY_ID_SEQ])");
 
-                entity.HasIndex(e => e.ActivityModelId, "ACTVTY_ACTIVITY_MODEL_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.ProjectId, "ACTVTY_PROJECT_ID_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.WorkflowId, "ACTVTY_WORKFLOW_ID_IDX");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.ActivityId)
-                    .HasColumnName("ACTIVITY_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ACTIVITY_ID_SEQ])");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ActivityModelId).HasColumnName("ACTIVITY_MODEL_ID");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.ProjectId).HasColumnName("PROJECT_ID");
-
-                entity.Property(e => e.WorkflowId).HasColumnName("WORKFLOW_ID");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
                 entity.HasOne(d => d.ActivityModel)
                     .WithMany(p => p.PimsActivities)
@@ -685,83 +312,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ActivityHistId)
                     .HasName("PIMS_ACTVTY_H_PK");
 
-                entity.ToTable("PIMS_ACTIVITY_HIST");
+                entity.Property(e => e.ActivityHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ACTIVITY_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.ActivityHistId, e.EndDateHist }, "PIMS_ACTVTY_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.ActivityHistId)
-                    .HasColumnName("_ACTIVITY_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ACTIVITY_H_ID_SEQ])");
-
-                entity.Property(e => e.ActivityId).HasColumnName("ACTIVITY_ID");
-
-                entity.Property(e => e.ActivityModelId).HasColumnName("ACTIVITY_MODEL_ID");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.ProjectId).HasColumnName("PROJECT_ID");
-
-                entity.Property(e => e.WorkflowId).HasColumnName("WORKFLOW_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsActivityModel>(entity =>
@@ -769,81 +322,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ActivityModelId)
                     .HasName("ACTMDL_PK");
 
-                entity.ToTable("PIMS_ACTIVITY_MODEL");
+                entity.Property(e => e.ActivityModelId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ACTIVITY_MODEL_ID_SEQ])");
 
-                entity.Property(e => e.ActivityModelId)
-                    .HasColumnName("ACTIVITY_MODEL_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ACTIVITY_MODEL_ID_SEQ])");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsActivityModelHist>(entity =>
@@ -851,84 +346,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ActivityModelHistId)
                     .HasName("PIMS_ACTMDL_H_PK");
 
-                entity.ToTable("PIMS_ACTIVITY_MODEL_HIST");
+                entity.Property(e => e.ActivityModelHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ACTIVITY_MODEL_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.ActivityModelHistId, e.EndDateHist }, "PIMS_ACTMDL_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.ActivityModelHistId)
-                    .HasColumnName("_ACTIVITY_MODEL_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ACTIVITY_MODEL_H_ID_SEQ])");
-
-                entity.Property(e => e.ActivityModelId).HasColumnName("ACTIVITY_MODEL_ID");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsAddress>(entity =>
@@ -936,124 +356,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.AddressId)
                     .HasName("ADDRSS_PK");
 
-                entity.ToTable("PIMS_ADDRESS");
+                entity.Property(e => e.AddressId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ADDRESS_ID_SEQ])");
 
-                entity.HasIndex(e => e.CountryId, "ADDRSS_COUNTRY_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.DistrictCode, "ADDRSS_DISTRICT_CODE_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.ProvinceStateId, "ADDRSS_PROVINCE_STATE_ID_IDX");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.HasIndex(e => e.RegionCode, "ADDRSS_REGION_CODE_IDX");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AddressId)
-                    .HasColumnName("ADDRESS_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ADDRESS_ID_SEQ])");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.Comment)
-                    .HasMaxLength(2000)
-                    .HasColumnName("COMMENT");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.CountryId).HasColumnName("COUNTRY_ID");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DistrictCode).HasColumnName("DISTRICT_CODE");
-
-                entity.Property(e => e.Latitude)
-                    .HasColumnType("numeric(8, 6)")
-                    .HasColumnName("LATITUDE");
-
-                entity.Property(e => e.Longitude)
-                    .HasColumnType("numeric(9, 6)")
-                    .HasColumnName("LONGITUDE");
-
-                entity.Property(e => e.MunicipalityName)
-                    .HasMaxLength(200)
-                    .HasColumnName("MUNICIPALITY_NAME");
-
-                entity.Property(e => e.OtherCountry)
-                    .HasMaxLength(200)
-                    .HasColumnName("OTHER_COUNTRY")
-                    .HasComment("Other country not listed in drop-down list");
-
-                entity.Property(e => e.PostalCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("POSTAL_CODE");
-
-                entity.Property(e => e.ProvinceStateId).HasColumnName("PROVINCE_STATE_ID");
-
-                entity.Property(e => e.RegionCode).HasColumnName("REGION_CODE");
-
-                entity.Property(e => e.StreetAddress1)
-                    .HasMaxLength(200)
-                    .HasColumnName("STREET_ADDRESS_1");
-
-                entity.Property(e => e.StreetAddress2)
-                    .HasMaxLength(200)
-                    .HasColumnName("STREET_ADDRESS_2");
-
-                entity.Property(e => e.StreetAddress3)
-                    .HasMaxLength(200)
-                    .HasColumnName("STREET_ADDRESS_3");
+                entity.Property(e => e.OtherCountry).HasComment("Other country not listed in drop-down list");
 
                 entity.HasOne(d => d.Country)
                     .WithMany(p => p.PimsAddresses)
@@ -1082,121 +401,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.AddressHistId)
                     .HasName("PIMS_ADDRSS_H_PK");
 
-                entity.ToTable("PIMS_ADDRESS_HIST");
+                entity.Property(e => e.AddressHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ADDRESS_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.AddressHistId, e.EndDateHist }, "PIMS_ADDRSS_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.AddressHistId)
-                    .HasColumnName("_ADDRESS_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ADDRESS_H_ID_SEQ])");
-
-                entity.Property(e => e.AddressId).HasColumnName("ADDRESS_ID");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.Comment)
-                    .HasMaxLength(2000)
-                    .HasColumnName("COMMENT");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.CountryId).HasColumnName("COUNTRY_ID");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.DistrictCode).HasColumnName("DISTRICT_CODE");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.Latitude)
-                    .HasColumnType("numeric(18, 0)")
-                    .HasColumnName("LATITUDE");
-
-                entity.Property(e => e.Longitude)
-                    .HasColumnType("numeric(18, 0)")
-                    .HasColumnName("LONGITUDE");
-
-                entity.Property(e => e.MunicipalityName)
-                    .HasMaxLength(200)
-                    .HasColumnName("MUNICIPALITY_NAME");
-
-                entity.Property(e => e.OtherCountry)
-                    .HasMaxLength(200)
-                    .HasColumnName("OTHER_COUNTRY");
-
-                entity.Property(e => e.PostalCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("POSTAL_CODE");
-
-                entity.Property(e => e.ProvinceStateId).HasColumnName("PROVINCE_STATE_ID");
-
-                entity.Property(e => e.RegionCode).HasColumnName("REGION_CODE");
-
-                entity.Property(e => e.StreetAddress1)
-                    .HasMaxLength(200)
-                    .HasColumnName("STREET_ADDRESS_1");
-
-                entity.Property(e => e.StreetAddress2)
-                    .HasMaxLength(200)
-                    .HasColumnName("STREET_ADDRESS_2");
-
-                entity.Property(e => e.StreetAddress3)
-                    .HasMaxLength(200)
-                    .HasColumnName("STREET_ADDRESS_3");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsAddressUsageType>(entity =>
@@ -1204,49 +411,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.AddressUsageTypeCode)
                     .HasName("ADUSGT_PK");
 
-                entity.ToTable("PIMS_ADDRESS_USAGE_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AddressUsageTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("ADDRESS_USAGE_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsAreaUnitType>(entity =>
@@ -1254,54 +429,25 @@ namespace Pims.Dal
                 entity.HasKey(e => e.AreaUnitTypeCode)
                     .HasName("ARUNIT_PK");
 
-                entity.ToTable("PIMS_AREA_UNIT_TYPE");
-
                 entity.HasComment("The area unit used for measuring Properties.  The units must be in metric: square metres or hectares.");
 
-                entity.Property(e => e.AreaUnitTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("AREA_UNIT_TYPE_CODE")
-                    .HasComment("The area unit used for measuring Properties.  The units must be in metric: square metres or hectares.");
+                entity.Property(e => e.AreaUnitTypeCode).HasComment("The area unit used for measuring Properties.  The units must be in metric: square metres or hectares.");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION")
-                    .HasComment("Translation of the code value into a description that can be displayed to the user.");
+                entity.Property(e => e.Description).HasComment("Translation of the code value into a description that can be displayed to the user.");
 
-                entity.Property(e => e.DisplayOrder)
-                    .HasColumnName("DISPLAY_ORDER")
-                    .HasComment("Order in which to display the code values, if required.");
+                entity.Property(e => e.DisplayOrder).HasComment("Order in which to display the code values, if required.");
 
                 entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
                     .HasDefaultValueSql("(CONVERT([bit],(0)))")
                     .HasComment("Indicates if the code value is still active or is now disabled.");
             });
@@ -1311,94 +457,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ClaimId)
                     .HasName("CLMTYP_PK");
 
-                entity.ToTable("PIMS_CLAIM");
+                entity.Property(e => e.ClaimId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_CLAIM_ID_SEQ])");
 
-                entity.HasIndex(e => e.ClaimUid, "CLMTYP_CLAIM_UID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.KeycloakRoleId, "CLMTYP_KEYCLOAK_ROLE_ID_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ClaimId)
-                    .HasColumnName("CLAIM_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_CLAIM_ID_SEQ])");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ClaimUid).HasColumnName("CLAIM_UID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(500)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.KeycloakRoleId).HasColumnName("KEYCLOAK_ROLE_ID");
-
-                entity.Property(e => e.Name)
-                    .IsRequired()
-                    .HasMaxLength(100)
-                    .HasColumnName("NAME");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsClaimHist>(entity =>
@@ -1406,93 +481,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ClaimHistId)
                     .HasName("PIMS_CLMTYP_H_PK");
 
-                entity.ToTable("PIMS_CLAIM_HIST");
+                entity.Property(e => e.ClaimHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_CLAIM_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.ClaimHistId, e.EndDateHist }, "PIMS_CLMTYP_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.ClaimHistId)
-                    .HasColumnName("_CLAIM_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_CLAIM_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ClaimId).HasColumnName("CLAIM_ID");
-
-                entity.Property(e => e.ClaimUid).HasColumnName("CLAIM_UID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(500)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.KeycloakRoleId).HasColumnName("KEYCLOAK_ROLE_ID");
-
-                entity.Property(e => e.Name)
-                    .IsRequired()
-                    .HasMaxLength(100)
-                    .HasColumnName("NAME");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsContactMethod>(entity =>
@@ -1500,95 +491,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ContactMethodId)
                     .HasName("CNTMTH_PK");
 
-                entity.ToTable("PIMS_CONTACT_METHOD");
+                entity.Property(e => e.ContactMethodId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_CONTACT_METHOD_ID_SEQ])");
 
-                entity.HasIndex(e => e.ContactMethodTypeCode, "CNTMTH_CONTACT_METHOD_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.OrganizationId, "CNTMTH_ORGANIZATION_ID_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.PersonId, "CNTMTH_PERSON_ID_IDX");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.ContactMethodId)
-                    .HasColumnName("CONTACT_METHOD_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_CONTACT_METHOD_ID_SEQ])");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.ContactMethodTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("CONTACT_METHOD_TYPE_CODE");
-
-                entity.Property(e => e.ContactMethodValue)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("CONTACT_METHOD_VALUE");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.IsPreferredMethod)
-                    .HasColumnName("IS_PREFERRED_METHOD")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.OrganizationId).HasColumnName("ORGANIZATION_ID");
-
-                entity.Property(e => e.PersonId).HasColumnName("PERSON_ID");
+                entity.Property(e => e.IsPreferredMethod).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
                 entity.HasOne(d => d.ContactMethodTypeCodeNavigation)
                     .WithMany(p => p.PimsContactMethods)
@@ -1612,93 +531,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ContactMethodHistId)
                     .HasName("PIMS_CNTMTH_H_PK");
 
-                entity.ToTable("PIMS_CONTACT_METHOD_HIST");
+                entity.Property(e => e.ContactMethodHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_CONTACT_METHOD_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.ContactMethodHistId, e.EndDateHist }, "PIMS_CNTMTH_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.ContactMethodHistId)
-                    .HasColumnName("_CONTACT_METHOD_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_CONTACT_METHOD_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.ContactMethodId).HasColumnName("CONTACT_METHOD_ID");
-
-                entity.Property(e => e.ContactMethodTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("CONTACT_METHOD_TYPE_CODE");
-
-                entity.Property(e => e.ContactMethodValue)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("CONTACT_METHOD_VALUE");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IsPreferredMethod).HasColumnName("IS_PREFERRED_METHOD");
-
-                entity.Property(e => e.OrganizationId).HasColumnName("ORGANIZATION_ID");
-
-                entity.Property(e => e.PersonId).HasColumnName("PERSON_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsContactMethodType>(entity =>
@@ -1706,102 +541,24 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ContactMethodTypeCode)
                     .HasName("CNTMTT_PK");
 
-                entity.ToTable("PIMS_CONTACT_METHOD_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.ContactMethodTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("CONTACT_METHOD_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsContactMgrVw>(entity =>
             {
-                entity.HasNoKey();
-
                 entity.ToView("PIMS_CONTACT_MGR_VW");
 
-                entity.Property(e => e.AddressId).HasColumnName("ADDRESS_ID");
-
-                entity.Property(e => e.FirstName)
-                    .HasMaxLength(50)
-                    .HasColumnName("FIRST_NAME");
-
-                entity.Property(e => e.Id)
-                    .IsRequired()
-                    .HasMaxLength(25)
-                    .IsUnicode(false)
-                    .HasColumnName("ID");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.MailingAddress)
-                    .HasMaxLength(200)
-                    .HasColumnName("MAILING_ADDRESS");
-
-                entity.Property(e => e.MiddleNames)
-                    .HasMaxLength(200)
-                    .HasColumnName("MIDDLE_NAMES");
-
-                entity.Property(e => e.MunicipalityName)
-                    .HasMaxLength(200)
-                    .HasColumnName("MUNICIPALITY_NAME");
-
-                entity.Property(e => e.OrganizationId).HasColumnName("ORGANIZATION_ID");
-
-                entity.Property(e => e.OrganizationName)
-                    .HasMaxLength(200)
-                    .HasColumnName("ORGANIZATION_NAME");
-
-                entity.Property(e => e.PersonId).HasColumnName("PERSON_ID");
-
-                entity.Property(e => e.ProvinceState)
-                    .HasMaxLength(20)
-                    .HasColumnName("PROVINCE_STATE");
-
-                entity.Property(e => e.Summary)
-                    .HasMaxLength(302)
-                    .HasColumnName("SUMMARY");
-
-                entity.Property(e => e.Surname)
-                    .HasMaxLength(50)
-                    .HasColumnName("SURNAME");
+                entity.Property(e => e.Id).IsUnicode(false);
             });
 
             modelBuilder.Entity<PimsCountry>(entity =>
@@ -1809,49 +566,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.CountryId)
                     .HasName("CNTRY_PK");
 
-                entity.ToTable("PIMS_COUNTRY");
+                entity.Property(e => e.CountryId).ValueGeneratedNever();
 
-                entity.Property(e => e.CountryId)
-                    .ValueGeneratedNever()
-                    .HasColumnName("COUNTRY_ID");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.CountryCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("COUNTRY_CODE");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
             });
 
             modelBuilder.Entity<PimsDataSourceType>(entity =>
@@ -1859,54 +584,25 @@ namespace Pims.Dal
                 entity.HasKey(e => e.DataSourceTypeCode)
                     .HasName("PIDSRT_PK");
 
-                entity.ToTable("PIMS_DATA_SOURCE_TYPE");
-
                 entity.HasComment("Describes the source system of the data (PAIMS, LIS, etc.)");
 
-                entity.Property(e => e.DataSourceTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("DATA_SOURCE_TYPE_CODE")
-                    .HasComment("Code val;ue of the source system of the data (PAIMS, LIS, etc.)");
+                entity.Property(e => e.DataSourceTypeCode).HasComment("Code val;ue of the source system of the data (PAIMS, LIS, etc.)");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION")
-                    .HasComment("Description of the source system of the data (PAIMS, LIS, etc.)");
+                entity.Property(e => e.Description).HasComment("Description of the source system of the data (PAIMS, LIS, etc.)");
 
-                entity.Property(e => e.DisplayOrder)
-                    .HasColumnName("DISPLAY_ORDER")
-                    .HasComment("Defines the default display order of the descriptions");
+                entity.Property(e => e.DisplayOrder).HasComment("Defines the default display order of the descriptions");
 
                 entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
                     .HasDefaultValueSql("(CONVERT([bit],(0)))")
                     .HasComment("Indicates if the code is still in use");
             });
@@ -1916,53 +612,19 @@ namespace Pims.Dal
                 entity.HasKey(e => e.DistrictCode)
                     .HasName("DSTRCT_PK");
 
-                entity.ToTable("PIMS_DISTRICT");
+                entity.Property(e => e.DistrictCode).ValueGeneratedNever();
 
-                entity.HasIndex(e => e.RegionCode, "DSTRCT_REGION_CODE_IDX");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.DistrictCode)
-                    .ValueGeneratedNever()
-                    .HasColumnName("DISTRICT_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.DistrictName)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DISTRICT_NAME");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.RegionCode).HasColumnName("REGION_CODE");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
                 entity.HasOne(d => d.RegionCodeNavigation)
                     .WithMany(p => p.PimsDistricts)
@@ -1976,138 +638,31 @@ namespace Pims.Dal
                 entity.HasKey(e => e.InsuranceId)
                     .HasName("INSRNC_PK");
 
-                entity.ToTable("PIMS_INSURANCE");
+                entity.Property(e => e.InsuranceId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_INSURANCE_ID_SEQ])");
 
-                entity.HasIndex(e => e.BctfaRiskMgmtContactId, "INSRNC_BCTFA_RISK_MGMT_CONTACT_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.InsurancePayeeTypeCode, "INSRNC_INSURANCE_PAYEE_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.HasIndex(e => e.InsuranceTypeCode, "INSRNC_INSURANCE_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.HasIndex(e => e.InsurerContactId, "INSRNC_INSURER_CONTACT_ID_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.InsurerOrgId, "INSRNC_INSURER_ORG_ID_IDX");
+                entity.Property(e => e.AppLastUpdateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.HasIndex(e => e.LeaseId, "INSRNC_LEASE_ID_IDX");
+                entity.Property(e => e.AppLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.HasIndex(e => e.MotiRiskMgmtContactId, "INSRNC_MOTI_RISK_MGMT_CONTACT_ID_IDX");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.InsuranceId)
-                    .HasColumnName("INSURANCE_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_INSURANCE_ID_SEQ])");
+                entity.Property(e => e.CoverageLimit).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.BctfaRiskMgmtContactId).HasColumnName("BCTFA_RISK_MGMT_CONTACT_ID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.CoverageDescription)
-                    .HasMaxLength(2000)
-                    .HasColumnName("COVERAGE_DESCRIPTION");
-
-                entity.Property(e => e.CoverageLimit)
-                    .HasColumnType("money")
-                    .HasColumnName("COVERAGE_LIMIT")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.ExpiryDate)
-                    .HasColumnType("date")
-                    .HasColumnName("EXPIRY_DATE");
-
-                entity.Property(e => e.InsurancePayeeTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("INSURANCE_PAYEE_TYPE_CODE");
-
-                entity.Property(e => e.InsuranceTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("INSURANCE_TYPE_CODE");
-
-                entity.Property(e => e.InsuredValue)
-                    .HasColumnType("money")
-                    .HasColumnName("INSURED_VALUE");
-
-                entity.Property(e => e.InsurerContactId).HasColumnName("INSURER_CONTACT_ID");
-
-                entity.Property(e => e.InsurerOrgId).HasColumnName("INSURER_ORG_ID");
-
-                entity.Property(e => e.LeaseId).HasColumnName("LEASE_ID");
-
-                entity.Property(e => e.MotiRiskMgmtContactId).HasColumnName("MOTI_RISK_MGMT_CONTACT_ID");
-
-                entity.Property(e => e.OtherInsuranceType)
-                    .HasMaxLength(200)
-                    .HasColumnName("OTHER_INSURANCE_TYPE");
-
-                entity.Property(e => e.RiskAssessmentCompletedDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("RISK ASSESSMENT_COMPLETED_DATE");
-
-                entity.Property(e => e.StartDate)
-                    .HasColumnType("date")
-                    .HasColumnName("START_DATE");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
                 entity.HasOne(d => d.BctfaRiskMgmtContact)
                     .WithMany(p => p.PimsInsuranceBctfaRiskMgmtContacts)
@@ -2157,125 +712,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.InsuranceHistId)
                     .HasName("PIMS_INSRNC_H_PK");
 
-                entity.ToTable("PIMS_INSURANCE_HIST");
+                entity.Property(e => e.InsuranceHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_INSURANCE_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.InsuranceHistId, e.EndDateHist }, "PIMS_INSRNC_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.InsuranceHistId)
-                    .HasColumnName("_INSURANCE_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_INSURANCE_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.BctfaRiskMgmtContactId).HasColumnName("BCTFA_RISK_MGMT_CONTACT_ID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.CoverageDescription)
-                    .HasMaxLength(2000)
-                    .HasColumnName("COVERAGE_DESCRIPTION");
-
-                entity.Property(e => e.CoverageLimit)
-                    .HasColumnType("money")
-                    .HasColumnName("COVERAGE_LIMIT");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.ExpiryDate)
-                    .HasColumnType("date")
-                    .HasColumnName("EXPIRY_DATE");
-
-                entity.Property(e => e.InsuranceId).HasColumnName("INSURANCE_ID");
-
-                entity.Property(e => e.InsurancePayeeTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("INSURANCE_PAYEE_TYPE_CODE");
-
-                entity.Property(e => e.InsuranceTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("INSURANCE_TYPE_CODE");
-
-                entity.Property(e => e.InsuredValue)
-                    .HasColumnType("money")
-                    .HasColumnName("INSURED_VALUE");
-
-                entity.Property(e => e.InsurerContactId).HasColumnName("INSURER_CONTACT_ID");
-
-                entity.Property(e => e.InsurerOrgId).HasColumnName("INSURER_ORG_ID");
-
-                entity.Property(e => e.LeaseId).HasColumnName("LEASE_ID");
-
-                entity.Property(e => e.MotiRiskMgmtContactId).HasColumnName("MOTI_RISK_MGMT_CONTACT_ID");
-
-                entity.Property(e => e.OtherInsuranceType)
-                    .HasMaxLength(200)
-                    .HasColumnName("OTHER_INSURANCE_TYPE");
-
-                entity.Property(e => e.RiskAssessmentCompletedDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("RISK ASSESSMENT_COMPLETED_DATE");
-
-                entity.Property(e => e.StartDate)
-                    .HasColumnType("date")
-                    .HasColumnName("START_DATE");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsInsurancePayeeType>(entity =>
@@ -2283,49 +722,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.InsurancePayeeTypeCode)
                     .HasName("INSPAY_PK");
 
-                entity.ToTable("PIMS_INSURANCE_PAYEE_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.InsurancePayeeTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("INSURANCE_PAYEE_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsInsuranceType>(entity =>
@@ -2333,49 +740,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.InsuranceTypeCode)
                     .HasName("INSPYT_PK");
 
-                entity.ToTable("PIMS_INSURANCE_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.InsuranceTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("INSURANCE_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsLease>(entity =>
@@ -2383,289 +758,112 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeaseId)
                     .HasName("LEASE_PK");
 
-                entity.ToTable("PIMS_LEASE");
+                entity.Property(e => e.LeaseId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_ID_SEQ])");
 
-                entity.HasIndex(e => e.LeaseCategoryTypeCode, "LEASE_LEASE_CATEGORY_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.LeaseInitiatorTypeCode, "LEASE_LEASE_INITIATOR_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.HasIndex(e => e.LeaseLicenseTypeCode, "LEASE_LEASE_LICENSE_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.HasIndex(e => e.LeasePayRvblTypeCode, "LEASE_LEASE_PAY_RVBL_TYPE_CODE_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.LeasePmtFreqTypeCode, "LEASE_LEASE_PMT_FREQ_TYPE_CODE_IDX");
+                entity.Property(e => e.AppLastUpdateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.HasIndex(e => e.LeaseProgramTypeCode, "LEASE_LEASE_PROGRAM_TYPE_CODE_IDX");
+                entity.Property(e => e.AppLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.HasIndex(e => e.LeasePurposeTypeCode, "LEASE_LEASE_PURPOSE_TYPE_CODE_IDX");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.HasIndex(e => e.LeaseResponsibilityTypeCode, "LEASE_LEASE_RESPONSIBILITY_TYPE_CODE_IDX");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.LeaseStatusTypeCode, "LEASE_LEASE_STATUS_TYPE_CODE_IDX");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.HasIndex(e => e.LFileNo, "LEASE_L_FILE_NO_IDX");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.PsFileNo, "LEASE_PS_FILE_NO_IDX");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.HasIndex(e => e.TfaFileNo, "LEASE_TFA_FILE_NO_IDX");
-
-                entity.Property(e => e.LeaseId)
-                    .HasColumnName("LEASE_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DocumentationReference)
-                    .HasMaxLength(500)
-                    .HasColumnName("DOCUMENTATION_REFERENCE")
-                    .HasComment("Location of documents pertianing to the lease/license");
+                entity.Property(e => e.DocumentationReference).HasComment("Location of documents pertianing to the lease/license");
 
                 entity.Property(e => e.HasDigitalFile)
-                    .IsRequired()
-                    .HasColumnName("HAS_DIGITAL_FILE")
                     .HasDefaultValueSql("(CONVERT([bit],(0)))")
                     .HasComment("Indicator that digital file exists");
 
                 entity.Property(e => e.HasDigitalLicense)
-                    .IsRequired()
-                    .HasColumnName("HAS_DIGITAL_LICENSE")
                     .HasDefaultValueSql("(CONVERT([bit],(0)))")
                     .HasComment("Indicator that digital license exists");
 
                 entity.Property(e => e.HasPhysicalFile)
-                    .IsRequired()
-                    .HasColumnName("HAS_PHYSICAL_FILE")
                     .HasDefaultValueSql("(CONVERT([bit],(0)))")
                     .HasComment("Indicator that phyical file exists");
 
                 entity.Property(e => e.HasPhysicialLicense)
-                    .IsRequired()
-                    .HasColumnName("HAS_PHYSICIAL_LICENSE")
                     .HasDefaultValueSql("(CONVERT([bit],(0)))")
                     .HasComment("Indicator that physical license exists");
 
-                entity.Property(e => e.InspectionDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("INSPECTION_DATE")
-                    .HasComment("Inspection date");
+                entity.Property(e => e.InspectionDate).HasComment("Inspection date");
 
-                entity.Property(e => e.InspectionNotes)
-                    .HasColumnName("INSPECTION_NOTES")
-                    .HasComment("Notes accompanying inspection");
+                entity.Property(e => e.InspectionNotes).HasComment("Notes accompanying inspection");
 
                 entity.Property(e => e.IsCommBldg)
-                    .HasColumnName("IS_COMM_BLDG")
                     .HasDefaultValueSql("(CONVERT([bit],(0)))")
                     .HasComment("Is a commercial building");
 
                 entity.Property(e => e.IsExpired)
-                    .IsRequired()
-                    .HasColumnName("IS_EXPIRED")
                     .HasDefaultValueSql("(CONVERT([bit],(0)))")
                     .HasComment("Incidcator that lease/license has expired");
 
                 entity.Property(e => e.IsOtherImprovement)
-                    .HasColumnName("IS_OTHER_IMPROVEMENT")
                     .HasDefaultValueSql("(CONVERT([bit],(0)))")
                     .HasComment("Is improvement of another description");
 
                 entity.Property(e => e.IsSubjectToRta)
-                    .HasColumnName("IS_SUBJECT_TO_RTA")
                     .HasDefaultValueSql("(CONVERT([bit],(0)))")
                     .HasComment("Is subject the Residential Tenancy Act");
 
-                entity.Property(e => e.LFileNo)
-                    .HasMaxLength(50)
-                    .HasColumnName("L_FILE_NO")
-                    .HasComment("Generated identifying lease/licence number");
+                entity.Property(e => e.LFileNo).HasComment("Generated identifying lease/licence number");
 
-                entity.Property(e => e.LeaseAmount)
-                    .HasColumnType("money")
-                    .HasColumnName("LEASE_AMOUNT")
-                    .HasComment("Lease/licence amount");
+                entity.Property(e => e.LeaseAmount).HasComment("Lease/licence amount");
 
-                entity.Property(e => e.LeaseCategoryOtherDesc)
-                    .HasMaxLength(200)
-                    .HasColumnName("LEASE_CATEGORY_OTHER_DESC")
-                    .HasComment("User-specified lease category description not included in standard set of lease purposes");
+                entity.Property(e => e.LeaseCategoryOtherDesc).HasComment("User-specified lease category description not included in standard set of lease purposes");
 
-                entity.Property(e => e.LeaseCategoryTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_CATEGORY_TYPE_CODE");
+                entity.Property(e => e.LeaseDescription).HasComment("Manually etered lease description, not the legal description");
 
-                entity.Property(e => e.LeaseDescription)
-                    .HasColumnName("LEASE_DESCRIPTION")
-                    .HasComment("Manually etered lease description, not the legal description");
+                entity.Property(e => e.LeaseNotes).HasComment("Notes accompanying lease");
 
-                entity.Property(e => e.LeaseInitiatorTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_INITIATOR_TYPE_CODE");
+                entity.Property(e => e.LeasePurposeOtherDesc).HasComment("User-specified lease purpose description not included in standard set of lease purposes");
 
-                entity.Property(e => e.LeaseLicenseTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_LICENSE_TYPE_CODE");
+                entity.Property(e => e.MotiContact).HasComment("Contact of the MoTI person associated with the lease");
 
-                entity.Property(e => e.LeaseNotes)
-                    .HasColumnName("LEASE_NOTES")
-                    .HasComment("Notes accompanying lease");
+                entity.Property(e => e.MotiRegion).HasComment("MoTI region associated with the lease");
 
-                entity.Property(e => e.LeasePayRvblTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_PAY_RVBL_TYPE_CODE");
+                entity.Property(e => e.OrigExpiryDate).HasComment("Original expiry date of the lease/license");
 
-                entity.Property(e => e.LeasePmtFreqTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_PMT_FREQ_TYPE_CODE");
+                entity.Property(e => e.OrigStartDate).HasComment("Original start date of the lease/license");
 
-                entity.Property(e => e.LeaseProgramTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_PROGRAM_TYPE_CODE");
+                entity.Property(e => e.OtherLeaseLicenseType).HasComment("Description of a non-standard lease/license type");
 
-                entity.Property(e => e.LeasePurposeOtherDesc)
-                    .HasMaxLength(200)
-                    .HasColumnName("LEASE_PURPOSE_OTHER_DESC")
-                    .HasComment("User-specified lease purpose description not included in standard set of lease purposes");
+                entity.Property(e => e.OtherLeaseProgramType).HasComment("Description of a non-standard lease program type");
 
-                entity.Property(e => e.LeasePurposeTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_PURPOSE_TYPE_CODE");
+                entity.Property(e => e.OtherLeasePurposeType).HasComment("Description of a non-standard lease purpose type");
 
-                entity.Property(e => e.LeaseResponsibilityTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_RESPONSIBILITY_TYPE_CODE");
+                entity.Property(e => e.PsFileNo).HasComment("Sourced from t_fileSubOverrideData.PSFile_No");
 
-                entity.Property(e => e.LeaseStatusTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_STATUS_TYPE_CODE");
+                entity.Property(e => e.ResponsibilityEffectiveDate).HasComment("Date current responsibility came into effect for this lease");
 
-                entity.Property(e => e.MotiContact)
-                    .HasMaxLength(200)
-                    .HasColumnName("MOTI_CONTACT")
-                    .HasComment("Contact of the MoTI person associated with the lease");
+                entity.Property(e => e.ReturnNotes).HasComment("Notes accompanying lease");
 
-                entity.Property(e => e.MotiRegion)
-                    .HasMaxLength(200)
-                    .HasColumnName("MOTI_REGION")
-                    .HasComment("MoTI region associated with the lease");
-
-                entity.Property(e => e.OrigExpiryDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("ORIG_EXPIRY_DATE")
-                    .HasComment("Original expiry date of the lease/license");
-
-                entity.Property(e => e.OrigStartDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("ORIG_START_DATE")
-                    .HasComment("Original start date of the lease/license");
-
-                entity.Property(e => e.OtherLeaseLicenseType)
-                    .HasMaxLength(200)
-                    .HasColumnName("OTHER_LEASE_LICENSE_TYPE")
-                    .HasComment("Description of a non-standard lease/license type");
-
-                entity.Property(e => e.OtherLeaseProgramType)
-                    .HasMaxLength(200)
-                    .HasColumnName("OTHER_LEASE_PROGRAM_TYPE")
-                    .HasComment("Description of a non-standard lease program type");
-
-                entity.Property(e => e.OtherLeasePurposeType)
-                    .HasMaxLength(200)
-                    .HasColumnName("OTHER_LEASE_PURPOSE_TYPE")
-                    .HasComment("Description of a non-standard lease purpose type");
-
-                entity.Property(e => e.PsFileNo)
-                    .HasMaxLength(50)
-                    .HasColumnName("PS_FILE_NO")
-                    .HasComment("Sourced from t_fileSubOverrideData.PSFile_No");
-
-                entity.Property(e => e.ResponsibilityEffectiveDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("RESPONSIBILITY_EFFECTIVE_DATE")
-                    .HasComment("Date current responsibility came into effect for this lease");
-
-                entity.Property(e => e.ReturnNotes)
-                    .HasColumnName("RETURN_NOTES")
-                    .HasComment("Notes accompanying lease");
-
-                entity.Property(e => e.TfaFileNo)
-                    .HasColumnName("TFA_FILE_NO")
-                    .HasComment("Sourced from t_fileMain.TFA_File_Number");
+                entity.Property(e => e.TfaFileNo).HasComment("Sourced from t_fileMain.TFA_File_Number");
 
                 entity.HasOne(d => d.LeaseCategoryTypeCodeNavigation)
                     .WithMany(p => p.PimsLeases)
                     .HasForeignKey(d => d.LeaseCategoryTypeCode)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("PIM_LSCATT_PIM_LEASE_FK");
 
                 entity.HasOne(d => d.LeaseInitiatorTypeCodeNavigation)
                     .WithMany(p => p.PimsLeases)
                     .HasForeignKey(d => d.LeaseInitiatorTypeCode)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("PIM_LINITT_PIM_LEASE_FK");
 
                 entity.HasOne(d => d.LeaseLicenseTypeCodeNavigation)
@@ -2683,6 +881,7 @@ namespace Pims.Dal
                 entity.HasOne(d => d.LeasePmtFreqTypeCodeNavigation)
                     .WithMany(p => p.PimsLeases)
                     .HasForeignKey(d => d.LeasePmtFreqTypeCode)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("PIM_LSPMTF_PIM_LEASE_FK");
 
                 entity.HasOne(d => d.LeaseProgramTypeCodeNavigation)
@@ -2700,6 +899,7 @@ namespace Pims.Dal
                 entity.HasOne(d => d.LeaseResponsibilityTypeCodeNavigation)
                     .WithMany(p => p.PimsLeases)
                     .HasForeignKey(d => d.LeaseResponsibilityTypeCode)
+                    .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("PIM_LRESPT_PIM_LEASE_FK");
 
                 entity.HasOne(d => d.LeaseStatusTypeCodeNavigation)
@@ -2714,49 +914,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeaseCategoryTypeCode)
                     .HasName("LSCATT_PK");
 
-                entity.ToTable("PIMS_LEASE_CATEGORY_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.LeaseCategoryTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_CATEGORY_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsLeaseHist>(entity =>
@@ -2764,196 +932,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeaseHistId)
                     .HasName("PIMS_LEASE_H_PK");
 
-                entity.ToTable("PIMS_LEASE_HIST");
+                entity.Property(e => e.LeaseHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.LeaseHistId, e.EndDateHist }, "PIMS_LEASE_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.LeaseHistId)
-                    .HasColumnName("_LEASE_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.DocumentationReference)
-                    .HasMaxLength(500)
-                    .HasColumnName("DOCUMENTATION_REFERENCE");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.HasDigitalFile).HasColumnName("HAS_DIGITAL_FILE");
-
-                entity.Property(e => e.HasDigitalLicense).HasColumnName("HAS_DIGITAL_LICENSE");
-
-                entity.Property(e => e.HasPhysicalFile).HasColumnName("HAS_PHYSICAL_FILE");
-
-                entity.Property(e => e.HasPhysicialLicense).HasColumnName("HAS_PHYSICIAL_LICENSE");
-
-                entity.Property(e => e.InspectionDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("INSPECTION_DATE");
-
-                entity.Property(e => e.IsCommBldg).HasColumnName("IS_COMM_BLDG");
-
-                entity.Property(e => e.IsExpired).HasColumnName("IS_EXPIRED");
-
-                entity.Property(e => e.IsOtherImprovement).HasColumnName("IS_OTHER_IMPROVEMENT");
-
-                entity.Property(e => e.IsSubjectToRta).HasColumnName("IS_SUBJECT_TO_RTA");
-
-                entity.Property(e => e.LFileNo)
-                    .HasMaxLength(50)
-                    .HasColumnName("L_FILE_NO");
-
-                entity.Property(e => e.LeaseAmount)
-                    .HasColumnType("money")
-                    .HasColumnName("LEASE_AMOUNT");
-
-                entity.Property(e => e.LeaseCategoryOtherDesc)
-                    .HasMaxLength(200)
-                    .HasColumnName("LEASE_CATEGORY_OTHER_DESC");
-
-                entity.Property(e => e.LeaseCategoryTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_CATEGORY_TYPE_CODE");
-
-                entity.Property(e => e.LeaseId).HasColumnName("LEASE_ID");
-
-                entity.Property(e => e.LeaseInitiatorTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_INITIATOR_TYPE_CODE");
-
-                entity.Property(e => e.LeaseLicenseTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_LICENSE_TYPE_CODE");
-
-                entity.Property(e => e.LeasePayRvblTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_PAY_RVBL_TYPE_CODE");
-
-                entity.Property(e => e.LeasePmtFreqTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_PMT_FREQ_TYPE_CODE");
-
-                entity.Property(e => e.LeaseProgramTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_PROGRAM_TYPE_CODE");
-
-                entity.Property(e => e.LeasePurposeOtherDesc)
-                    .HasMaxLength(200)
-                    .HasColumnName("LEASE_PURPOSE_OTHER_DESC");
-
-                entity.Property(e => e.LeasePurposeTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_PURPOSE_TYPE_CODE");
-
-                entity.Property(e => e.LeaseResponsibilityTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_RESPONSIBILITY_TYPE_CODE");
-
-                entity.Property(e => e.LeaseStatusTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_STATUS_TYPE_CODE");
-
-                entity.Property(e => e.MotiContact)
-                    .HasMaxLength(200)
-                    .HasColumnName("MOTI_CONTACT");
-
-                entity.Property(e => e.MotiRegion)
-                    .HasMaxLength(200)
-                    .HasColumnName("MOTI_REGION");
-
-                entity.Property(e => e.OrigExpiryDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("ORIG_EXPIRY_DATE");
-
-                entity.Property(e => e.OrigStartDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("ORIG_START_DATE");
-
-                entity.Property(e => e.OtherLeaseLicenseType)
-                    .HasMaxLength(200)
-                    .HasColumnName("OTHER_LEASE_LICENSE_TYPE");
-
-                entity.Property(e => e.OtherLeaseProgramType)
-                    .HasMaxLength(200)
-                    .HasColumnName("OTHER_LEASE_PROGRAM_TYPE");
-
-                entity.Property(e => e.OtherLeasePurposeType)
-                    .HasMaxLength(200)
-                    .HasColumnName("OTHER_LEASE_PURPOSE_TYPE");
-
-                entity.Property(e => e.PsFileNo)
-                    .HasMaxLength(50)
-                    .HasColumnName("PS_FILE_NO");
-
-                entity.Property(e => e.ResponsibilityEffectiveDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("RESPONSIBILITY_EFFECTIVE_DATE");
-
-                entity.Property(e => e.TfaFileNo).HasColumnName("TFA_FILE_NO");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsLeaseInitiatorType>(entity =>
@@ -2961,53 +942,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeaseInitiatorTypeCode)
                     .HasName("LINITT_PK");
 
-                entity.ToTable("PIMS_LEASE_INITIATOR_TYPE");
-
                 entity.HasComment("Describes the initiator of the lease");
 
-                entity.Property(e => e.LeaseInitiatorTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_INITIATOR_TYPE_CODE")
-                    .HasComment("Code value of the initiator of the lease");
+                entity.Property(e => e.LeaseInitiatorTypeCode).HasComment("Code value of the initiator of the lease");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION")
-                    .HasComment("Description of the initiator of the lease");
+                entity.Property(e => e.Description).HasComment("Description of the initiator of the lease");
 
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsLeaseLicenseType>(entity =>
@@ -3015,49 +966,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeaseLicenseTypeCode)
                     .HasName("LELIST_PK");
 
-                entity.ToTable("PIMS_LEASE_LICENSE_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.LeaseLicenseTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_LICENSE_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsLeasePayRvblType>(entity =>
@@ -3065,49 +984,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeasePayRvblTypeCode)
                     .HasName("LSPRTY_PK");
 
-                entity.ToTable("PIMS_LEASE_PAY_RVBL_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.LeasePayRvblTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_PAY_RVBL_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsLeasePayment>(entity =>
@@ -3115,114 +1002,29 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeasePaymentId)
                     .HasName("LSPYMT_PK");
 
-                entity.ToTable("PIMS_LEASE_PAYMENT");
+                entity.Property(e => e.LeasePaymentId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_PAYMENT_ID_SEQ])");
 
-                entity.HasIndex(e => e.LeasePaymentMethodTypeCode, "LSPYMT_LEASE_PAYMENT_METHOD_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.LeasePaymentPeriodId, "LSPYMT_LEASE_PAYMENT_PERIOD_ID_IDX");
+                entity.Property(e => e.AppCreateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.HasIndex(e => e.LeaseTermId, "LSPYMT_LEASE_TERM_ID_IDX");
+                entity.Property(e => e.AppCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.LeasePaymentId)
-                    .HasColumnName("LEASE_PAYMENT_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_PAYMENT_ID_SEQ])");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.AppLastUpdateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.AppLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.LeasePaymentMethodTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_PAYMENT_METHOD_TYPE_CODE");
-
-                entity.Property(e => e.LeasePaymentPeriodId).HasColumnName("LEASE_PAYMENT_PERIOD_ID");
-
-                entity.Property(e => e.LeaseTermId).HasColumnName("LEASE_TERM_ID");
-
-                entity.Property(e => e.Note)
-                    .HasMaxLength(2000)
-                    .HasColumnName("NOTE");
-
-                entity.Property(e => e.PaymentAmountGst)
-                    .HasColumnType("money")
-                    .HasColumnName("PAYMENT_AMOUNT_GST");
-
-                entity.Property(e => e.PaymentAmountPreTax)
-                    .HasColumnType("money")
-                    .HasColumnName("PAYMENT_AMOUNT_PRE_TAX");
-
-                entity.Property(e => e.PaymentAmountPst)
-                    .HasColumnType("money")
-                    .HasColumnName("PAYMENT_AMOUNT_PST");
-
-                entity.Property(e => e.PaymentAmountTotal)
-                    .HasColumnType("money")
-                    .HasColumnName("PAYMENT_AMOUNT_TOTAL");
-
-                entity.Property(e => e.PaymentReceivedDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("PAYMENT_RECEIVED_DATE");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
                 entity.HasOne(d => d.LeasePaymentMethodTypeCodeNavigation)
                     .WithMany(p => p.PimsLeasePayments)
@@ -3248,110 +1050,29 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeasePaymentForecastId)
                     .HasName("LPFCST_PK");
 
-                entity.ToTable("PIMS_LEASE_PAYMENT_FORECAST");
+                entity.Property(e => e.LeasePaymentForecastId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_PAYMENT_FORECAST_ID_SEQ])");
 
-                entity.HasIndex(e => e.LeasePaymentPeriodId, "LPFCST_LEASE_PAYMENT_PERIOD_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.LeasePaymentStatusTypeCode, "LPFCST_LEASE_PAYMENT_STATUS_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.HasIndex(e => e.LeaseTermId, "LPFCST_LEASE_TERM_ID_IDX");
+                entity.Property(e => e.AppCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.LeasePaymentForecastId)
-                    .HasColumnName("LEASE_PAYMENT_FORECAST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_PAYMENT_FORECAST_ID_SEQ])");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.AppLastUpdateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.AppLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.ForecastPaymentGst)
-                    .HasColumnType("money")
-                    .HasColumnName("FORECAST_PAYMENT_GST");
-
-                entity.Property(e => e.ForecastPaymentPreTax)
-                    .HasColumnType("money")
-                    .HasColumnName("FORECAST_PAYMENT_PRE_TAX");
-
-                entity.Property(e => e.ForecastPaymentPst)
-                    .HasColumnType("money")
-                    .HasColumnName("FORECAST_PAYMENT_PST");
-
-                entity.Property(e => e.ForecastPaymentTotal)
-                    .HasColumnType("money")
-                    .HasColumnName("FORECAST_PAYMENT_TOTAL");
-
-                entity.Property(e => e.LeasePaymentPeriodId).HasColumnName("LEASE_PAYMENT_PERIOD_ID");
-
-                entity.Property(e => e.LeasePaymentStatusTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_PAYMENT_STATUS_TYPE_CODE");
-
-                entity.Property(e => e.LeaseTermId).HasColumnName("LEASE_TERM_ID");
-
-                entity.Property(e => e.PaymentDueDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("PAYMENT_DUE_DATE");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
                 entity.HasOne(d => d.LeasePaymentPeriod)
                     .WithMany(p => p.PimsLeasePaymentForecasts)
@@ -3377,106 +1098,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeasePaymentForecastHistId)
                     .HasName("PIMS_LPFCST_H_PK");
 
-                entity.ToTable("PIMS_LEASE_PAYMENT_FORECAST_HIST");
+                entity.Property(e => e.LeasePaymentForecastHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_PAYMENT_FORECAST_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.LeasePaymentForecastHistId, e.EndDateHist }, "PIMS_LPFCST_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.LeasePaymentForecastHistId)
-                    .HasColumnName("_LEASE_PAYMENT_FORECAST_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_PAYMENT_FORECAST_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.ForecastPaymentGst)
-                    .HasColumnType("money")
-                    .HasColumnName("FORECAST_PAYMENT_GST");
-
-                entity.Property(e => e.ForecastPaymentPreTax)
-                    .HasColumnType("money")
-                    .HasColumnName("FORECAST_PAYMENT_PRE_TAX");
-
-                entity.Property(e => e.ForecastPaymentPst)
-                    .HasColumnType("money")
-                    .HasColumnName("FORECAST_PAYMENT_PST");
-
-                entity.Property(e => e.ForecastPaymentTotal)
-                    .HasColumnType("money")
-                    .HasColumnName("FORECAST_PAYMENT_TOTAL");
-
-                entity.Property(e => e.LeasePaymentForecastId).HasColumnName("LEASE_PAYMENT_FORECAST_ID");
-
-                entity.Property(e => e.LeasePaymentPeriodId).HasColumnName("LEASE_PAYMENT_PERIOD_ID");
-
-                entity.Property(e => e.LeasePaymentStatusTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_PAYMENT_STATUS_TYPE_CODE");
-
-                entity.Property(e => e.LeaseTermId).HasColumnName("LEASE_TERM_ID");
-
-                entity.Property(e => e.PaymentDueDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("PAYMENT_DUE_DATE");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsLeasePaymentHist>(entity =>
@@ -3484,110 +1108,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeasePaymentHistId)
                     .HasName("PIMS_LSPYMT_H_PK");
 
-                entity.ToTable("PIMS_LEASE_PAYMENT_HIST");
+                entity.Property(e => e.LeasePaymentHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_PAYMENT_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.LeasePaymentHistId, e.EndDateHist }, "PIMS_LSPYMT_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.LeasePaymentHistId)
-                    .HasColumnName("_LEASE_PAYMENT_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_PAYMENT_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.LeasePaymentId).HasColumnName("LEASE_PAYMENT_ID");
-
-                entity.Property(e => e.LeasePaymentMethodTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_PAYMENT_METHOD_TYPE_CODE");
-
-                entity.Property(e => e.LeasePaymentPeriodId).HasColumnName("LEASE_PAYMENT_PERIOD_ID");
-
-                entity.Property(e => e.LeaseTermId).HasColumnName("LEASE_TERM_ID");
-
-                entity.Property(e => e.Note)
-                    .HasMaxLength(2000)
-                    .HasColumnName("NOTE");
-
-                entity.Property(e => e.PaymentAmountGst)
-                    .HasColumnType("money")
-                    .HasColumnName("PAYMENT_AMOUNT_GST");
-
-                entity.Property(e => e.PaymentAmountPreTax)
-                    .HasColumnType("money")
-                    .HasColumnName("PAYMENT_AMOUNT_PRE_TAX");
-
-                entity.Property(e => e.PaymentAmountPst)
-                    .HasColumnType("money")
-                    .HasColumnName("PAYMENT_AMOUNT_PST");
-
-                entity.Property(e => e.PaymentAmountTotal)
-                    .HasColumnType("money")
-                    .HasColumnName("PAYMENT_AMOUNT_TOTAL");
-
-                entity.Property(e => e.PaymentReceivedDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("PAYMENT_RECEIVED_DATE");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsLeasePaymentMethodType>(entity =>
@@ -3595,52 +1118,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeasePaymentMethodTypeCode)
                     .HasName("LSPMMT_PK");
 
-                entity.ToTable("PIMS_LEASE_PAYMENT_METHOD_TYPE");
+                entity.Property(e => e.LeasePaymentMethodTypeCode).HasComment("Payment method type code");
 
-                entity.Property(e => e.LeasePaymentMethodTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_PAYMENT_METHOD_TYPE_CODE")
-                    .HasComment("Payment method type code");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.Description).HasComment("Payment method type description");
 
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION")
-                    .HasComment("Payment method type description");
-
-                entity.Property(e => e.DisplayOrder)
-                    .HasColumnName("DISPLAY_ORDER")
-                    .HasComment("Display order of the descriptions");
+                entity.Property(e => e.DisplayOrder).HasComment("Display order of the descriptions");
 
                 entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
                     .HasDefaultValueSql("(CONVERT([bit],(0)))")
                     .HasComment("Is this code disabled?");
             });
@@ -3650,84 +1144,31 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeasePaymentPeriodId)
                     .HasName("LPYPER_PK");
 
-                entity.ToTable("PIMS_LEASE_PAYMENT_PERIOD");
+                entity.Property(e => e.LeasePaymentPeriodId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_PAYMENT_PERIOD_ID_SEQ])");
 
-                entity.Property(e => e.LeasePaymentPeriodId)
-                    .HasColumnName("LEASE_PAYMENT_PERIOD_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_PAYMENT_PERIOD_ID_SEQ])");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.AppCreateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.AppCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.AppLastUpdateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.AppLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.IsPeriodClosed)
-                    .IsRequired()
-                    .HasColumnName("IS_PERIOD_CLOSED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.PeriodStartDate)
-                    .HasColumnType("date")
-                    .HasColumnName("PERIOD_START_DATE");
+                entity.Property(e => e.IsPeriodClosed).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsLeasePaymentPeriodHist>(entity =>
@@ -3735,83 +1176,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeasePaymentPeriodHistId)
                     .HasName("PIMS_LPYPER_H_PK");
 
-                entity.ToTable("PIMS_LEASE_PAYMENT_PERIOD_HIST");
+                entity.Property(e => e.LeasePaymentPeriodHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_PAYMENT_PERIOD_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.LeasePaymentPeriodHistId, e.EndDateHist }, "PIMS_LPYPER_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.LeasePaymentPeriodHistId)
-                    .HasColumnName("_LEASE_PAYMENT_PERIOD_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_PAYMENT_PERIOD_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IsPeriodClosed).HasColumnName("IS_PERIOD_CLOSED");
-
-                entity.Property(e => e.LeasePaymentPeriodId).HasColumnName("LEASE_PAYMENT_PERIOD_ID");
-
-                entity.Property(e => e.PeriodStartDate)
-                    .HasColumnType("date")
-                    .HasColumnName("PERIOD_START_DATE");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsLeasePaymentStatusType>(entity =>
@@ -3819,54 +1186,25 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeasePaymentStatusTypeCode)
                     .HasName("LPSTST_PK");
 
-                entity.ToTable("PIMS_LEASE_PAYMENT_STATUS_TYPE");
-
                 entity.HasComment("Describes the status of forecast payments");
 
-                entity.Property(e => e.LeasePaymentStatusTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_PAYMENT_STATUS_TYPE_CODE")
-                    .HasComment("Payment status type code");
+                entity.Property(e => e.LeasePaymentStatusTypeCode).HasComment("Payment status type code");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION")
-                    .HasComment("Payment status type description");
+                entity.Property(e => e.Description).HasComment("Payment status type description");
 
-                entity.Property(e => e.DisplayOrder)
-                    .HasColumnName("DISPLAY_ORDER")
-                    .HasComment("Display order of the descriptions");
+                entity.Property(e => e.DisplayOrder).HasComment("Display order of the descriptions");
 
                 entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
                     .HasDefaultValueSql("(CONVERT([bit],(0)))")
                     .HasComment("Is this code disabled?");
             });
@@ -3876,49 +1214,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeasePmtFreqTypeCode)
                     .HasName("LSPMTF_PK");
 
-                entity.ToTable("PIMS_LEASE_PMT_FREQ_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.LeasePmtFreqTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_PMT_FREQ_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsLeaseProgramType>(entity =>
@@ -3926,49 +1232,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeaseProgramTypeCode)
                     .HasName("LSPRGT_PK");
 
-                entity.ToTable("PIMS_LEASE_PROGRAM_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.LeaseProgramTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_PROGRAM_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsLeasePurposeType>(entity =>
@@ -3976,49 +1250,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeasePurposeTypeCode)
                     .HasName("LPRPTY_PK");
 
-                entity.ToTable("PIMS_LEASE_PURPOSE_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.LeasePurposeTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_PURPOSE_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsLeaseResponsibilityType>(entity =>
@@ -4026,53 +1268,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeaseResponsibilityTypeCode)
                     .HasName("LRESPT_PK");
 
-                entity.ToTable("PIMS_LEASE_RESPONSIBILITY_TYPE");
-
                 entity.HasComment("Describes which organization is responsible for this lease");
 
-                entity.Property(e => e.LeaseResponsibilityTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_RESPONSIBILITY_TYPE_CODE")
-                    .HasComment("Code value of the organization responsible for this lease");
+                entity.Property(e => e.LeaseResponsibilityTypeCode).HasComment("Code value of the organization responsible for this lease");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION")
-                    .HasComment("Description of the organization responsible for this lease");
+                entity.Property(e => e.Description).HasComment("Description of the organization responsible for this lease");
 
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsLeaseStatusType>(entity =>
@@ -4080,53 +1292,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeaseStatusTypeCode)
                     .HasName("LSSTYP_PK");
 
-                entity.ToTable("PIMS_LEASE_STATUS_TYPE");
-
                 entity.HasComment("Describes the status of the lease");
 
-                entity.Property(e => e.LeaseStatusTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_STATUS_TYPE_CODE")
-                    .HasComment("Code value of the status of the lease");
+                entity.Property(e => e.LeaseStatusTypeCode).HasComment("Code value of the status of the lease");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION")
-                    .HasComment("Description of the status of the lease");
+                entity.Property(e => e.Description).HasComment("Description of the status of the lease");
 
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsLeaseTenant>(entity =>
@@ -4134,98 +1316,29 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeaseTenantId)
                     .HasName("TENANT_PK");
 
-                entity.ToTable("PIMS_LEASE_TENANT");
+                entity.Property(e => e.LeaseTenantId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_TENANT_ID_SEQ])");
 
-                entity.HasIndex(e => e.LeaseId, "TENANT_LEASE_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.LessorTypeCode, "TENANT_LESSOR_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.HasIndex(e => e.OrganizationId, "TENANT_ORGANIZATION_ID_IDX");
+                entity.Property(e => e.AppCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.HasIndex(e => e.PersonId, "TENANT_PERSON_ID_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.LeaseTenantId)
-                    .HasColumnName("LEASE_TENANT_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_TENANT_ID_SEQ])");
+                entity.Property(e => e.AppLastUpdateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.AppLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.LeaseId).HasColumnName("LEASE_ID");
-
-                entity.Property(e => e.LessorTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("LESSOR_TYPE_CODE");
-
-                entity.Property(e => e.Note)
-                    .HasMaxLength(2000)
-                    .HasColumnName("NOTE");
-
-                entity.Property(e => e.OrganizationId).HasColumnName("ORGANIZATION_ID");
-
-                entity.Property(e => e.PersonId).HasColumnName("PERSON_ID");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
                 entity.HasOne(d => d.Lease)
                     .WithMany(p => p.PimsLeaseTenants)
@@ -4255,92 +1368,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeaseTenantHistId)
                     .HasName("PIMS_TENANT_H_PK");
 
-                entity.ToTable("PIMS_LEASE_TENANT_HIST");
+                entity.Property(e => e.LeaseTenantHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_TENANT_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.LeaseTenantHistId, e.EndDateHist }, "PIMS_TENANT_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.LeaseTenantHistId)
-                    .HasColumnName("_LEASE_TENANT_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_TENANT_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.LeaseId).HasColumnName("LEASE_ID");
-
-                entity.Property(e => e.LeaseTenantId).HasColumnName("LEASE_TENANT_ID");
-
-                entity.Property(e => e.LessorTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("LESSOR_TYPE_CODE");
-
-                entity.Property(e => e.Note)
-                    .HasMaxLength(2000)
-                    .HasColumnName("NOTE");
-
-                entity.Property(e => e.OrganizationId).HasColumnName("ORGANIZATION_ID");
-
-                entity.Property(e => e.PersonId).HasColumnName("PERSON_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsLeaseTerm>(entity =>
@@ -4348,101 +1378,35 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeaseTermId)
                     .HasName("LSTERM_PK");
 
-                entity.ToTable("PIMS_LEASE_TERM");
+                entity.Property(e => e.LeaseTermId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_TERM_ID_SEQ])");
 
-                entity.HasIndex(e => e.LeaseId, "LSTERM_LEASE_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.LeaseTermStatusTypeCode, "LSTERM_LEASE_TERM_STATUS_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.LeaseTermId)
-                    .HasColumnName("LEASE_TERM_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_TERM_ID_SEQ])");
+                entity.Property(e => e.AppCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.AppLastUpdateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.AppLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.TermExpiryDate).HasComment("Expiry date of the current term of the lease/licence");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.TermRenewalDate).HasComment("Renewal date of the current term of the lease/licence");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.LeaseId).HasColumnName("LEASE_ID");
-
-                entity.Property(e => e.LeaseTermStatusTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_TERM_STATUS_TYPE_CODE");
-
-                entity.Property(e => e.TermExpiryDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("TERM_EXPIRY_DATE")
-                    .HasComment("Expiry date of the current term of the lease/licence");
-
-                entity.Property(e => e.TermRenewalDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("TERM_RENEWAL_DATE")
-                    .HasComment("Renewal date of the current term of the lease/licence");
-
-                entity.Property(e => e.TermStartDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("TERM_START_DATE")
-                    .HasComment("Start date of the current term of the lease/licence");
+                entity.Property(e => e.TermStartDate).HasComment("Start date of the current term of the lease/licence");
 
                 entity.HasOne(d => d.Lease)
                     .WithMany(p => p.PimsLeaseTerms)
@@ -4462,96 +1426,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeaseTermHistId)
                     .HasName("PIMS_LSTERM_H_PK");
 
-                entity.ToTable("PIMS_LEASE_TERM_HIST");
+                entity.Property(e => e.LeaseTermHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_TERM_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.LeaseTermHistId, e.EndDateHist }, "PIMS_LSTERM_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.LeaseTermHistId)
-                    .HasColumnName("_LEASE_TERM_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_LEASE_TERM_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.LeaseId).HasColumnName("LEASE_ID");
-
-                entity.Property(e => e.LeaseTermId).HasColumnName("LEASE_TERM_ID");
-
-                entity.Property(e => e.LeaseTermStatusTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_TERM_STATUS_TYPE_CODE");
-
-                entity.Property(e => e.TermExpiryDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("TERM_EXPIRY_DATE");
-
-                entity.Property(e => e.TermRenewalDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("TERM_RENEWAL_DATE");
-
-                entity.Property(e => e.TermStartDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("TERM_START_DATE");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsLeaseTermStatusType>(entity =>
@@ -4559,53 +1436,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LeaseTermStatusTypeCode)
                     .HasName("LTRMST_PK");
 
-                entity.ToTable("PIMS_LEASE_TERM_STATUS_TYPE");
-
                 entity.HasComment("Describes the status of the lease term");
 
-                entity.Property(e => e.LeaseTermStatusTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LEASE_TERM_STATUS_TYPE_CODE")
-                    .HasComment("Code value of the status of the lease term");
+                entity.Property(e => e.LeaseTermStatusTypeCode).HasComment("Code value of the status of the lease term");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION")
-                    .HasComment("Description of the status of the lease term");
+                entity.Property(e => e.Description).HasComment("Description of the status of the lease term");
 
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsLessorType>(entity =>
@@ -4613,49 +1460,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.LessorTypeCode)
                     .HasName("LSSRTY_PK");
 
-                entity.ToTable("PIMS_LESSOR_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.LessorTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("LESSOR_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsOrgIdentifierType>(entity =>
@@ -4663,49 +1478,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.OrgIdentifierTypeCode)
                     .HasName("ORGIDT_PK");
 
-                entity.ToTable("PIMS_ORG_IDENTIFIER_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.OrgIdentifierTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("ORG_IDENTIFIER_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsOrganization>(entity =>
@@ -4713,130 +1496,27 @@ namespace Pims.Dal
                 entity.HasKey(e => e.OrganizationId)
                     .HasName("ORG_PK");
 
-                entity.ToTable("PIMS_ORGANIZATION");
-
                 entity.HasComment("Information related to an organization identified in the PSP system.");
 
-                entity.HasIndex(e => e.DistrictCode, "ORG_DISTRICT_CODE_IDX");
+                entity.Property(e => e.OrganizationId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ORGANIZATION_ID_SEQ])");
 
-                entity.HasIndex(e => e.OrganizationTypeCode, "ORG_ORGANIZATION_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.OrgIdentifierTypeCode, "ORG_ORG_IDENTIFIER_TYPE_CODE_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.PrntOrganizationId, "ORG_PRNT_ORGANIZATION_ID_IDX");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.HasIndex(e => e.RegionCode, "ORG_REGION_CODE_IDX");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.OrganizationId)
-                    .HasColumnName("ORGANIZATION_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ORGANIZATION_ID_SEQ])");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.IncorporationNumber).HasComment("Incorporation number of the orgnization");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.Comment)
-                    .HasMaxLength(2000)
-                    .HasColumnName("COMMENT");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DistrictCode).HasColumnName("DISTRICT_CODE");
-
-                entity.Property(e => e.IncorporationNumber)
-                    .HasMaxLength(50)
-                    .HasColumnName("INCORPORATION_NUMBER")
-                    .HasComment("Incorporation number of the orgnization");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.OrgIdentifierTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("ORG_IDENTIFIER_TYPE_CODE");
-
-                entity.Property(e => e.OrganizationAlias)
-                    .HasMaxLength(200)
-                    .HasColumnName("ORGANIZATION_ALIAS");
-
-                entity.Property(e => e.OrganizationIdentifier)
-                    .HasMaxLength(100)
-                    .HasColumnName("ORGANIZATION_IDENTIFIER");
-
-                entity.Property(e => e.OrganizationName)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("ORGANIZATION_NAME");
-
-                entity.Property(e => e.OrganizationTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("ORGANIZATION_TYPE_CODE");
-
-                entity.Property(e => e.PrntOrganizationId).HasColumnName("PRNT_ORGANIZATION_ID");
-
-                entity.Property(e => e.RegionCode).HasColumnName("REGION_CODE");
-
-                entity.Property(e => e.Website)
-                    .HasMaxLength(200)
-                    .HasColumnName("WEBSITE");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
                 entity.HasOne(d => d.DistrictCodeNavigation)
                     .WithMany(p => p.PimsOrganizations)
@@ -4871,96 +1551,25 @@ namespace Pims.Dal
                 entity.HasKey(e => e.OrganizationAddressId)
                     .HasName("ORGADD_PK");
 
-                entity.ToTable("PIMS_ORGANIZATION_ADDRESS");
-
                 entity.HasComment("An associative entity to define multiple addresses for a person.");
 
-                entity.HasIndex(e => e.AddressId, "ORGADD_ADDRESS_ID_IDX");
+                entity.Property(e => e.OrganizationAddressId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ORGANIZATION_ADDRESS_ID_SEQ])");
 
-                entity.HasIndex(e => e.AddressUsageTypeCode, "ORGADD_ADDRESS_USAGE_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.OrganizationId, "ORGADD_ORGANIZATION_ID_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => new { e.OrganizationId, e.AddressId, e.AddressUsageTypeCode }, "ORGADD_UNQ_ADDR_TYPE_TUC")
-                    .IsUnique();
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.OrganizationAddressId)
-                    .HasColumnName("ORGANIZATION_ADDRESS_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ORGANIZATION_ADDRESS_ID_SEQ])");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AddressId).HasColumnName("ADDRESS_ID");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AddressUsageTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("ADDRESS_USAGE_TYPE_CODE");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.OrganizationId).HasColumnName("ORGANIZATION_ID");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
                 entity.HasOne(d => d.Address)
                     .WithMany(p => p.PimsOrganizationAddresses)
@@ -4986,88 +1595,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.OrganizationAddressHistId)
                     .HasName("PIMS_ORGADD_H_PK");
 
-                entity.ToTable("PIMS_ORGANIZATION_ADDRESS_HIST");
+                entity.Property(e => e.OrganizationAddressHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ORGANIZATION_ADDRESS_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.OrganizationAddressHistId, e.EndDateHist }, "PIMS_ORGADD_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.OrganizationAddressHistId)
-                    .HasColumnName("_ORGANIZATION_ADDRESS_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ORGANIZATION_ADDRESS_H_ID_SEQ])");
-
-                entity.Property(e => e.AddressId).HasColumnName("ADDRESS_ID");
-
-                entity.Property(e => e.AddressUsageTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("ADDRESS_USAGE_TYPE_CODE");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.OrganizationAddressId).HasColumnName("ORGANIZATION_ADDRESS_ID");
-
-                entity.Property(e => e.OrganizationId).HasColumnName("ORGANIZATION_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsOrganizationHist>(entity =>
@@ -5075,120 +1605,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.OrganizationHistId)
                     .HasName("PIMS_ORG_H_PK");
 
-                entity.ToTable("PIMS_ORGANIZATION_HIST");
+                entity.Property(e => e.OrganizationHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ORGANIZATION_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.OrganizationHistId, e.EndDateHist }, "PIMS_ORG_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.OrganizationHistId)
-                    .HasColumnName("_ORGANIZATION_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ORGANIZATION_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.Comment)
-                    .HasMaxLength(2000)
-                    .HasColumnName("COMMENT");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.DistrictCode).HasColumnName("DISTRICT_CODE");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IncorporationNumber)
-                    .HasMaxLength(50)
-                    .HasColumnName("INCORPORATION_NUMBER");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.OrgIdentifierTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("ORG_IDENTIFIER_TYPE_CODE");
-
-                entity.Property(e => e.OrganizationAlias)
-                    .HasMaxLength(200)
-                    .HasColumnName("ORGANIZATION_ALIAS");
-
-                entity.Property(e => e.OrganizationId).HasColumnName("ORGANIZATION_ID");
-
-                entity.Property(e => e.OrganizationIdentifier)
-                    .HasMaxLength(100)
-                    .HasColumnName("ORGANIZATION_IDENTIFIER");
-
-                entity.Property(e => e.OrganizationName)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("ORGANIZATION_NAME");
-
-                entity.Property(e => e.OrganizationTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("ORGANIZATION_TYPE_CODE");
-
-                entity.Property(e => e.PrntOrganizationId).HasColumnName("PRNT_ORGANIZATION_ID");
-
-                entity.Property(e => e.RegionCode).HasColumnName("REGION_CODE");
-
-                entity.Property(e => e.Website)
-                    .HasMaxLength(200)
-                    .HasColumnName("WEBSITE");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsOrganizationType>(entity =>
@@ -5196,49 +1615,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.OrganizationTypeCode)
                     .HasName("ORGTYP_PK");
 
-                entity.ToTable("PIMS_ORGANIZATION_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.OrganizationTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("ORGANIZATION_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsPerson>(entity =>
@@ -5246,106 +1633,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PersonId)
                     .HasName("PERSON_PK");
 
-                entity.ToTable("PIMS_PERSON");
+                entity.Property(e => e.PersonId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PERSON_ID_SEQ])");
 
-                entity.Property(e => e.PersonId)
-                    .HasColumnName("PERSON_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PERSON_ID_SEQ])");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.BirthDate)
-                    .HasColumnType("date")
-                    .HasColumnName("BIRTH_DATE");
-
-                entity.Property(e => e.Comment)
-                    .HasMaxLength(2000)
-                    .HasColumnName("COMMENT");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.FirstName)
-                    .IsRequired()
-                    .HasMaxLength(50)
-                    .HasColumnName("FIRST_NAME");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.MiddleNames)
-                    .HasMaxLength(200)
-                    .HasColumnName("MIDDLE_NAMES");
-
-                entity.Property(e => e.NameSuffix)
-                    .HasMaxLength(50)
-                    .HasColumnName("NAME_SUFFIX");
-
-                entity.Property(e => e.PreferredName)
-                    .HasMaxLength(200)
-                    .HasColumnName("PREFERRED_NAME");
-
-                entity.Property(e => e.Surname)
-                    .IsRequired()
-                    .HasMaxLength(50)
-                    .HasColumnName("SURNAME");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsPersonAddress>(entity =>
@@ -5353,96 +1657,25 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PersonAddressId)
                     .HasName("PERADD_PK");
 
-                entity.ToTable("PIMS_PERSON_ADDRESS");
-
                 entity.HasComment("An associative entity to define multiple addresses for a person.");
 
-                entity.HasIndex(e => e.AddressId, "PERADD_ADDRESS_ID_IDX");
+                entity.Property(e => e.PersonAddressId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PERSON_ADDRESS_ID_SEQ])");
 
-                entity.HasIndex(e => e.AddressUsageTypeCode, "PERADD_ADDRESS_USAGE_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.PersonId, "PERADD_PERSON_ID_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => new { e.PersonId, e.AddressId, e.AddressUsageTypeCode }, "PERADD_UNQ_ADDR_TYPE_TUC")
-                    .IsUnique();
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.PersonAddressId)
-                    .HasColumnName("PERSON_ADDRESS_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PERSON_ADDRESS_ID_SEQ])");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AddressId).HasColumnName("ADDRESS_ID");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AddressUsageTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("ADDRESS_USAGE_TYPE_CODE");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.PersonId).HasColumnName("PERSON_ID");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
                 entity.HasOne(d => d.Address)
                     .WithMany(p => p.PimsPersonAddresses)
@@ -5468,88 +1701,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PersonAddressHistId)
                     .HasName("PIMS_PERADD_H_PK");
 
-                entity.ToTable("PIMS_PERSON_ADDRESS_HIST");
+                entity.Property(e => e.PersonAddressHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PERSON_ADDRESS_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.PersonAddressHistId, e.EndDateHist }, "PIMS_PERADD_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.PersonAddressHistId)
-                    .HasColumnName("_PERSON_ADDRESS_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PERSON_ADDRESS_H_ID_SEQ])");
-
-                entity.Property(e => e.AddressId).HasColumnName("ADDRESS_ID");
-
-                entity.Property(e => e.AddressUsageTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("ADDRESS_USAGE_TYPE_CODE");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.PersonAddressId).HasColumnName("PERSON_ADDRESS_ID");
-
-                entity.Property(e => e.PersonId).HasColumnName("PERSON_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsPersonHist>(entity =>
@@ -5557,109 +1711,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PersonHistId)
                     .HasName("PIMS_PERSON_H_PK");
 
-                entity.ToTable("PIMS_PERSON_HIST");
+                entity.Property(e => e.PersonHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PERSON_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.PersonHistId, e.EndDateHist }, "PIMS_PERSON_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.PersonHistId)
-                    .HasColumnName("_PERSON_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PERSON_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.BirthDate)
-                    .HasColumnType("date")
-                    .HasColumnName("BIRTH_DATE");
-
-                entity.Property(e => e.Comment)
-                    .HasMaxLength(2000)
-                    .HasColumnName("COMMENT");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.FirstName)
-                    .IsRequired()
-                    .HasMaxLength(50)
-                    .HasColumnName("FIRST_NAME");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.MiddleNames)
-                    .HasMaxLength(200)
-                    .HasColumnName("MIDDLE_NAMES");
-
-                entity.Property(e => e.NameSuffix)
-                    .HasMaxLength(50)
-                    .HasColumnName("NAME_SUFFIX");
-
-                entity.Property(e => e.PersonId).HasColumnName("PERSON_ID");
-
-                entity.Property(e => e.PreferredName)
-                    .HasMaxLength(200)
-                    .HasColumnName("PREFERRED_NAME");
-
-                entity.Property(e => e.Surname)
-                    .IsRequired()
-                    .HasMaxLength(50)
-                    .HasColumnName("SURNAME");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsPersonOrganization>(entity =>
@@ -5667,86 +1721,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PersonOrganizationId)
                     .HasName("PERORG_PK");
 
-                entity.ToTable("PIMS_PERSON_ORGANIZATION");
+                entity.Property(e => e.PersonOrganizationId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PERSON_ORGANIZATION_ID_SEQ])");
 
-                entity.HasIndex(e => e.OrganizationId, "PERORG_ORGANIZATION_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.PersonId, "PERORG_PERSON_ID_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => new { e.OrganizationId, e.PersonId }, "PERORG_PERSON_ORGANIZATION_TUC")
-                    .IsUnique();
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.PersonOrganizationId)
-                    .HasColumnName("PERSON_ORGANIZATION_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PERSON_ORGANIZATION_ID_SEQ])");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.IsDisabled)
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.OrganizationId).HasColumnName("ORGANIZATION_ID");
-
-                entity.Property(e => e.PersonId).HasColumnName("PERSON_ID");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
                 entity.HasOne(d => d.Organization)
                     .WithMany(p => p.PimsPersonOrganizations)
@@ -5764,83 +1755,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PersonOrganizationHistId)
                     .HasName("PIMS_PERORG_H_PK");
 
-                entity.ToTable("PIMS_PERSON_ORGANIZATION_HIST");
+                entity.Property(e => e.PersonOrganizationHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PERSON_ORGANIZATION_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.PersonOrganizationHistId, e.EndDateHist }, "PIMS_PERORG_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.PersonOrganizationHistId)
-                    .HasColumnName("_PERSON_ORGANIZATION_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PERSON_ORGANIZATION_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.OrganizationId).HasColumnName("ORGANIZATION_ID");
-
-                entity.Property(e => e.PersonId).HasColumnName("PERSON_ID");
-
-                entity.Property(e => e.PersonOrganizationId).HasColumnName("PERSON_ORGANIZATION_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsProject>(entity =>
@@ -5848,99 +1765,21 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ProjectId)
                     .HasName("PROJCT_PK");
 
-                entity.ToTable("PIMS_PROJECT");
+                entity.Property(e => e.ProjectId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROJECT_ID_SEQ])");
 
-                entity.HasIndex(e => e.ProjectRiskTypeCode, "PROJCT_PROJECT_RISK_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.ProjectStatusTypeCode, "PROJCT_PROJECT_STATUS_TYPE_CODE_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.ProjectTierTypeCode, "PROJCT_PROJECT_TIER_TYPE_CODE_IDX");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.HasIndex(e => e.ProjectTypeCode, "PROJCT_PROJECT_TYPE_CODE_IDX");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ProjectId)
-                    .HasColumnName("PROJECT_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROJECT_ID_SEQ])");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.ProjectRiskTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROJECT_RISK_TYPE_CODE");
-
-                entity.Property(e => e.ProjectStatusTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROJECT_STATUS_TYPE_CODE");
-
-                entity.Property(e => e.ProjectTierTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROJECT_TIER_TYPE_CODE");
-
-                entity.Property(e => e.ProjectTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROJECT_TYPE_CODE");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
                 entity.HasOne(d => d.ProjectRiskTypeCodeNavigation)
                     .WithMany(p => p.PimsProjects)
@@ -5972,97 +1811,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ProjectHistId)
                     .HasName("PIMS_PROJCT_H_PK");
 
-                entity.ToTable("PIMS_PROJECT_HIST");
+                entity.Property(e => e.ProjectHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROJECT_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.ProjectHistId, e.EndDateHist }, "PIMS_PROJCT_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.ProjectHistId)
-                    .HasColumnName("_PROJECT_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROJECT_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.ProjectId).HasColumnName("PROJECT_ID");
-
-                entity.Property(e => e.ProjectRiskTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROJECT_RISK_TYPE_CODE");
-
-                entity.Property(e => e.ProjectStatusTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROJECT_STATUS_TYPE_CODE");
-
-                entity.Property(e => e.ProjectTierTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROJECT_TIER_TYPE_CODE");
-
-                entity.Property(e => e.ProjectTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROJECT_TYPE_CODE");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsProjectNote>(entity =>
@@ -6070,75 +1821,21 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ProjectNoteId)
                     .HasName("PROJNT_PK");
 
-                entity.ToTable("PIMS_PROJECT_NOTE");
+                entity.Property(e => e.ProjectNoteId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROJECT_NOTE_ID_SEQ])");
 
-                entity.HasIndex(e => e.ProjectId, "PROJNT_PROJECT_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ProjectNoteId)
-                    .HasColumnName("PROJECT_NOTE_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROJECT_NOTE_ID_SEQ])");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.ProjectId).HasColumnName("PROJECT_ID");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
                 entity.HasOne(d => d.Project)
                     .WithMany(p => p.PimsProjectNotes)
@@ -6152,79 +1849,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ProjectNoteHistId)
                     .HasName("PIMS_PROJNT_H_PK");
 
-                entity.ToTable("PIMS_PROJECT_NOTE_HIST");
+                entity.Property(e => e.ProjectNoteHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROJECT_NOTE_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.ProjectNoteHistId, e.EndDateHist }, "PIMS_PROJNT_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.ProjectNoteHistId)
-                    .HasColumnName("_PROJECT_NOTE_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROJECT_NOTE_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.ProjectId).HasColumnName("PROJECT_ID");
-
-                entity.Property(e => e.ProjectNoteId).HasColumnName("PROJECT_NOTE_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsProjectProperty>(entity =>
@@ -6232,86 +1859,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ProjectPropertyId)
                     .HasName("PRJPRP_PK");
 
-                entity.ToTable("PIMS_PROJECT_PROPERTY");
+                entity.Property(e => e.ProjectPropertyId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROJECT_PROPERTY_ID_SEQ])");
 
-                entity.HasIndex(e => e.ProjectId, "PRJPRP_PROJECT_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => new { e.PropertyId, e.ProjectId }, "PRJPRP_PROJECT_PROPERTY_TUC")
-                    .IsUnique();
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.PropertyId, "PRJPRP_PROPERTY_ID_IDX");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.ProjectPropertyId)
-                    .HasColumnName("PROJECT_PROPERTY_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROJECT_PROPERTY_ID_SEQ])");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.IsDisabled)
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.ProjectId).HasColumnName("PROJECT_ID");
-
-                entity.Property(e => e.PropertyId).HasColumnName("PROPERTY_ID");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
                 entity.HasOne(d => d.Project)
                     .WithMany(p => p.PimsProjectProperties)
@@ -6331,83 +1895,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ProjectPropertyHistId)
                     .HasName("PIMS_PRJPRP_H_PK");
 
-                entity.ToTable("PIMS_PROJECT_PROPERTY_HIST");
+                entity.Property(e => e.ProjectPropertyHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROJECT_PROPERTY_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.ProjectPropertyHistId, e.EndDateHist }, "PIMS_PRJPRP_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.ProjectPropertyHistId)
-                    .HasColumnName("_PROJECT_PROPERTY_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROJECT_PROPERTY_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.ProjectId).HasColumnName("PROJECT_ID");
-
-                entity.Property(e => e.ProjectPropertyId).HasColumnName("PROJECT_PROPERTY_ID");
-
-                entity.Property(e => e.PropertyId).HasColumnName("PROPERTY_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsProjectRiskType>(entity =>
@@ -6415,49 +1905,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ProjectRiskTypeCode)
                     .HasName("PRJRSK_PK");
 
-                entity.ToTable("PIMS_PROJECT_RISK_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.ProjectRiskTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("PROJECT_RISK_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsProjectStatusType>(entity =>
@@ -6465,69 +1923,21 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ProjectStatusTypeCode)
                     .HasName("PRJSTY_PK");
 
-                entity.ToTable("PIMS_PROJECT_STATUS_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.ProjectStatusTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("PROJECT_STATUS_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.CodeGroup)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("CODE_GROUP");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.IsMilestone).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.IsMilestone)
-                    .IsRequired()
-                    .HasColumnName("IS_MILESTONE")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.IsTerminal)
-                    .IsRequired()
-                    .HasColumnName("IS_TERMINAL")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.Text)
-                    .IsRequired()
-                    .HasMaxLength(1000)
-                    .HasColumnName("TEXT");
+                entity.Property(e => e.IsTerminal).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsProjectTierType>(entity =>
@@ -6535,49 +1945,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ProjectTierTypeCode)
                     .HasName("PROJTR_PK");
 
-                entity.ToTable("PIMS_PROJECT_TIER_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.ProjectTierTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("PROJECT_TIER_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsProjectType>(entity =>
@@ -6585,49 +1963,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ProjectTypeCode)
                     .HasName("PRJTYP_PK");
 
-                entity.ToTable("PIMS_PROJECT_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.ProjectTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("PROJECT_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsProjectWorkflowModel>(entity =>
@@ -6635,86 +1981,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ProjectWorkflowModelId)
                     .HasName("PRWKMD_PK");
 
-                entity.ToTable("PIMS_PROJECT_WORKFLOW_MODEL");
+                entity.Property(e => e.ProjectWorkflowModelId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROJECT_WORKFLOW_MODEL_ID_SEQ])");
 
-                entity.HasIndex(e => e.ProjectId, "PRWKMD_PROJECT_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => new { e.ProjectId, e.WorkflowModelId }, "PRWKMD_PROJECT_WORKFLOW_MODEL_TUC")
-                    .IsUnique();
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.WorkflowModelId, "PRWKMD_WORKFLOW_MODEL_ID_IDX");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.ProjectWorkflowModelId)
-                    .HasColumnName("PROJECT_WORKFLOW_MODEL_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROJECT_WORKFLOW_MODEL_ID_SEQ])");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.IsDisabled)
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.ProjectId).HasColumnName("PROJECT_ID");
-
-                entity.Property(e => e.WorkflowModelId).HasColumnName("WORKFLOW_MODEL_ID");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
                 entity.HasOne(d => d.Project)
                     .WithMany(p => p.PimsProjectWorkflowModels)
@@ -6734,83 +2017,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ProjectWorkflowModelHistId)
                     .HasName("PIMS_PRWKMD_H_PK");
 
-                entity.ToTable("PIMS_PROJECT_WORKFLOW_MODEL_HIST");
+                entity.Property(e => e.ProjectWorkflowModelHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROJECT_WORKFLOW_MODEL_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.ProjectWorkflowModelHistId, e.EndDateHist }, "PIMS_PRWKMD_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.ProjectWorkflowModelHistId)
-                    .HasColumnName("_PROJECT_WORKFLOW_MODEL_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROJECT_WORKFLOW_MODEL_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.ProjectId).HasColumnName("PROJECT_ID");
-
-                entity.Property(e => e.ProjectWorkflowModelId).HasColumnName("PROJECT_WORKFLOW_MODEL_ID");
-
-                entity.Property(e => e.WorkflowModelId).HasColumnName("WORKFLOW_MODEL_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsProperty>(entity =>
@@ -6818,230 +2027,65 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyId)
                     .HasName("PRPRTY_PK");
 
-                entity.ToTable("PIMS_PROPERTY");
+                entity.Property(e => e.PropertyId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_ID_SEQ])");
 
-                entity.HasIndex(e => e.AddressId, "PRPRTY_ADDRESS_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.DistrictCode, "PRPRTY_DISTRICT_CODE_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.PropertyAreaUnitTypeCode, "PRPRTY_PROPERTY_AREA_UNIT_TYPE_CODE_IDX");
+                entity.Property(e => e.Boundary).HasComment("Spatial bundary of land");
 
-                entity.HasIndex(e => e.PropertyClassificationTypeCode, "PRPRTY_PROPERTY_CLASSIFICATION_TYPE_CODE_IDX");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.HasIndex(e => e.PropertyDataSourceTypeCode, "PRPRTY_PROPERTY_DATA_SOURCE_TYPE_CODE_IDX");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.PropertyManagerId, "PRPRTY_PROPERTY_MANAGER_ID_IDX");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.HasIndex(e => e.PropertyStatusTypeCode, "PRPRTY_PROPERTY_STATUS_TYPE_CODE_IDX");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.PropertyTenureTypeCode, "PRPRTY_PROPERTY_TENURE_TYPE_CODE_IDX");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.HasIndex(e => e.PropertyTypeCode, "PRPRTY_PROPERTY_TYPE_CODE_IDX");
+                entity.Property(e => e.Description).HasComment("Property description");
 
-                entity.HasIndex(e => e.PropMgmtOrgId, "PRPRTY_PROP_MGMT_ORG_ID_IDX");
-
-                entity.HasIndex(e => e.RegionCode, "PRPRTY_REGION_CODE_IDX");
-
-                entity.HasIndex(e => e.SurplusDeclarationTypeCode, "PRPRTY_SURPLUS_DECLARATION_TYPE_CODE_IDX");
-
-                entity.Property(e => e.PropertyId)
-                    .HasColumnName("PROPERTY_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_ID_SEQ])");
-
-                entity.Property(e => e.AddressId).HasColumnName("ADDRESS_ID");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.Boundary)
-                    .HasColumnType("geometry")
-                    .HasColumnName("BOUNDARY")
-                    .HasComment("Spatial bundary of land");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .HasMaxLength(2000)
-                    .HasColumnName("DESCRIPTION")
-                    .HasComment("Property description");
-
-                entity.Property(e => e.DistrictCode).HasColumnName("DISTRICT_CODE");
-
-                entity.Property(e => e.EncumbranceReason)
-                    .HasMaxLength(500)
-                    .HasColumnName("ENCUMBRANCE_REASON")
-                    .HasComment("reason for property encumbreance");
+                entity.Property(e => e.EncumbranceReason).HasComment("reason for property encumbreance");
 
                 entity.Property(e => e.IsOwned)
-                    .IsRequired()
-                    .HasColumnName("IS_OWNED")
                     .HasDefaultValueSql("(CONVERT([bit],(1)))")
                     .HasComment("Is the property currently owned?");
 
                 entity.Property(e => e.IsPropertyOfInterest)
-                    .IsRequired()
-                    .HasColumnName("IS_PROPERTY_OF_INTEREST")
                     .HasDefaultValueSql("(CONVERT([bit],(0)))")
                     .HasComment("Is this a property of interest to the Ministry?");
 
                 entity.Property(e => e.IsSensitive)
-                    .IsRequired()
-                    .HasColumnName("IS_SENSITIVE")
                     .HasDefaultValueSql("(CONVERT([bit],(0)))")
                     .HasComment("Is this a sensitive property?");
 
                 entity.Property(e => e.IsVisibleToOtherAgencies)
-                    .IsRequired()
-                    .HasColumnName("IS_VISIBLE_TO_OTHER_AGENCIES")
                     .HasDefaultValueSql("(CONVERT([bit],(0)))")
                     .HasComment("Is the property visible to other agencies?");
 
-                entity.Property(e => e.LandArea)
-                    .HasColumnName("LAND_AREA")
-                    .HasComment("Area occupied by property");
+                entity.Property(e => e.LandArea).HasComment("Area occupied by property");
 
-                entity.Property(e => e.LandLegalDescription)
-                    .HasColumnName("LAND_LEGAL_DESCRIPTION")
-                    .HasComment("Legal description of property");
+                entity.Property(e => e.LandLegalDescription).HasComment("Legal description of property");
 
-                entity.Property(e => e.Location)
-                    .HasColumnType("geometry")
-                    .HasColumnName("LOCATION")
-                    .HasComment("Geospatial location (pin) of property");
+                entity.Property(e => e.Location).HasComment("Geospatial location (pin) of property");
 
-                entity.Property(e => e.Name)
-                    .HasMaxLength(250)
-                    .HasColumnName("NAME")
-                    .HasComment("Property name");
+                entity.Property(e => e.Name).HasComment("Property name");
 
-                entity.Property(e => e.Pid)
-                    .HasColumnName("PID")
-                    .HasComment("Property ID");
+                entity.Property(e => e.Pid).HasComment("Property ID");
 
-                entity.Property(e => e.Pin)
-                    .HasColumnName("PIN")
-                    .HasComment("Property number");
+                entity.Property(e => e.Pin).HasComment("Property number");
 
-                entity.Property(e => e.PropMgmtOrgId).HasColumnName("PROP_MGMT_ORG_ID");
+                entity.Property(e => e.PropertyDataSourceEffectiveDate).HasComment("Date the property was officially registered");
 
-                entity.Property(e => e.PropertyAreaUnitTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_AREA_UNIT_TYPE_CODE");
+                entity.Property(e => e.SurplusDeclarationComment).HasComment("Comment regarding the surplus declaration");
 
-                entity.Property(e => e.PropertyClassificationTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_CLASSIFICATION_TYPE_CODE");
+                entity.Property(e => e.SurplusDeclarationDate).HasComment("Date the property was declared surplus");
 
-                entity.Property(e => e.PropertyDataSourceEffectiveDate)
-                    .HasColumnType("date")
-                    .HasColumnName("PROPERTY_DATA_SOURCE_EFFECTIVE_DATE")
-                    .HasComment("Date the property was officially registered");
+                entity.Property(e => e.Zoning).HasComment("Current property zoning");
 
-                entity.Property(e => e.PropertyDataSourceTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_DATA_SOURCE_TYPE_CODE");
-
-                entity.Property(e => e.PropertyManagerId).HasColumnName("PROPERTY_MANAGER_ID");
-
-                entity.Property(e => e.PropertyStatusTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_STATUS_TYPE_CODE");
-
-                entity.Property(e => e.PropertyTenureTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_TENURE_TYPE_CODE");
-
-                entity.Property(e => e.PropertyTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_TYPE_CODE");
-
-                entity.Property(e => e.RegionCode).HasColumnName("REGION_CODE");
-
-                entity.Property(e => e.SurplusDeclarationComment)
-                    .HasMaxLength(2000)
-                    .HasColumnName("SURPLUS_DECLARATION_COMMENT")
-                    .HasComment("Comment regarding the surplus declaration");
-
-                entity.Property(e => e.SurplusDeclarationDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("SURPLUS_DECLARATION_DATE")
-                    .HasComment("Date the property was declared surplus");
-
-                entity.Property(e => e.SurplusDeclarationTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("SURPLUS_DECLARATION_TYPE_CODE");
-
-                entity.Property(e => e.Zoning)
-                    .HasMaxLength(50)
-                    .HasColumnName("ZONING")
-                    .HasComment("Current property zoning");
-
-                entity.Property(e => e.ZoningPotential)
-                    .HasMaxLength(50)
-                    .HasColumnName("ZONING_POTENTIAL")
-                    .HasComment("Potential property zoning");
+                entity.Property(e => e.ZoningPotential).HasComment("Potential property zoning");
 
                 entity.HasOne(d => d.Address)
                     .WithMany(p => p.PimsProperties)
@@ -7119,86 +2163,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyActivityId)
                     .HasName("PRPACT_PK");
 
-                entity.ToTable("PIMS_PROPERTY_ACTIVITY");
+                entity.Property(e => e.PropertyActivityId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_ACTIVITY_ID_SEQ])");
 
-                entity.HasIndex(e => e.ActivityId, "PRPACT_ACTIVITY_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => new { e.PropertyId, e.ActivityId }, "PRPACT_PROPERTY_ACTIVITY_TUC")
-                    .IsUnique();
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.PropertyId, "PRPACT_PROPERTY_ID_IDX");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.PropertyActivityId)
-                    .HasColumnName("PROPERTY_ACTIVITY_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_ACTIVITY_ID_SEQ])");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ActivityId).HasColumnName("ACTIVITY_ID");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.IsDisabled)
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.PropertyId).HasColumnName("PROPERTY_ID");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
                 entity.HasOne(d => d.Activity)
                     .WithMany(p => p.PimsPropertyActivities)
@@ -7216,217 +2197,16 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyActivityHistId)
                     .HasName("PIMS_PRPACT_H_PK");
 
-                entity.ToTable("PIMS_PROPERTY_ACTIVITY_HIST");
+                entity.Property(e => e.PropertyActivityHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_ACTIVITY_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.PropertyActivityHistId, e.EndDateHist }, "PIMS_PRPACT_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.PropertyActivityHistId)
-                    .HasColumnName("_PROPERTY_ACTIVITY_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_ACTIVITY_H_ID_SEQ])");
-
-                entity.Property(e => e.ActivityId).HasColumnName("ACTIVITY_ID");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.PropertyActivityId).HasColumnName("PROPERTY_ACTIVITY_ID");
-
-                entity.Property(e => e.PropertyId).HasColumnName("PROPERTY_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsPropertyBoundaryVw>(entity =>
             {
-                entity.HasNoKey();
-
                 entity.ToView("PIMS_PROPERTY_BOUNDARY_VW");
 
-                entity.Property(e => e.AddressId).HasColumnName("ADDRESS_ID");
-
-                entity.Property(e => e.CountryCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("COUNTRY_CODE");
-
-                entity.Property(e => e.CountryName)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("COUNTRY_NAME");
-
-                entity.Property(e => e.Description)
-                    .HasMaxLength(2000)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DistrictCode).HasColumnName("DISTRICT_CODE");
-
-                entity.Property(e => e.EncumbranceReason)
-                    .HasMaxLength(500)
-                    .HasColumnName("ENCUMBRANCE_REASON");
-
-                entity.Property(e => e.Geometry)
-                    .HasColumnType("geometry")
-                    .HasColumnName("GEOMETRY");
-
-                entity.Property(e => e.IsOwned).HasColumnName("IS_OWNED");
-
-                entity.Property(e => e.IsPropertyOfInterest).HasColumnName("IS_PROPERTY_OF_INTEREST");
-
-                entity.Property(e => e.IsSensitive).HasColumnName("IS_SENSITIVE");
-
-                entity.Property(e => e.IsVisibleToOtherAgencies).HasColumnName("IS_VISIBLE_TO_OTHER_AGENCIES");
-
-                entity.Property(e => e.LandArea).HasColumnName("LAND_AREA");
-
-                entity.Property(e => e.LandLegalDescription).HasColumnName("LAND_LEGAL_DESCRIPTION");
-
-                entity.Property(e => e.MunicipalityName)
-                    .HasMaxLength(200)
-                    .HasColumnName("MUNICIPALITY_NAME");
-
-                entity.Property(e => e.Name)
-                    .HasMaxLength(250)
-                    .HasColumnName("NAME");
-
-                entity.Property(e => e.Pid).HasColumnName("PID");
-
-                entity.Property(e => e.PidPadded)
-                    .HasMaxLength(9)
-                    .IsUnicode(false)
-                    .HasColumnName("PID_PADDED");
-
-                entity.Property(e => e.Pin).HasColumnName("PIN");
-
-                entity.Property(e => e.PostalCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("POSTAL_CODE");
-
-                entity.Property(e => e.PropertyAreaUnitTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_AREA_UNIT_TYPE_CODE");
-
-                entity.Property(e => e.PropertyClassificationTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_CLASSIFICATION_TYPE_CODE");
-
-                entity.Property(e => e.PropertyDataSourceEffectiveDate)
-                    .HasColumnType("date")
-                    .HasColumnName("PROPERTY_DATA_SOURCE_EFFECTIVE_DATE");
-
-                entity.Property(e => e.PropertyDataSourceTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_DATA_SOURCE_TYPE_CODE");
-
-                entity.Property(e => e.PropertyId).HasColumnName("PROPERTY_ID");
-
-                entity.Property(e => e.PropertyStatusTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_STATUS_TYPE_CODE");
-
-                entity.Property(e => e.PropertyTenureTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_TENURE_TYPE_CODE");
-
-                entity.Property(e => e.PropertyTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_TYPE_CODE");
-
-                entity.Property(e => e.ProvinceName)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("PROVINCE_NAME");
-
-                entity.Property(e => e.ProvinceStateCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROVINCE_STATE_CODE");
-
-                entity.Property(e => e.RegionCode).HasColumnName("REGION_CODE");
-
-                entity.Property(e => e.StreetAddress1)
-                    .HasMaxLength(200)
-                    .HasColumnName("STREET_ADDRESS_1");
-
-                entity.Property(e => e.StreetAddress2)
-                    .HasMaxLength(200)
-                    .HasColumnName("STREET_ADDRESS_2");
-
-                entity.Property(e => e.StreetAddress3)
-                    .HasMaxLength(200)
-                    .HasColumnName("STREET_ADDRESS_3");
-
-                entity.Property(e => e.Zoning)
-                    .HasMaxLength(50)
-                    .HasColumnName("ZONING");
-
-                entity.Property(e => e.ZoningPotential)
-                    .HasMaxLength(50)
-                    .HasColumnName("ZONING_POTENTIAL");
+                entity.Property(e => e.PidPadded).IsUnicode(false);
             });
 
             modelBuilder.Entity<PimsPropertyClassificationType>(entity =>
@@ -7434,49 +2214,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyClassificationTypeCode)
                     .HasName("PRPCLT_PK");
 
-                entity.ToTable("PIMS_PROPERTY_CLASSIFICATION_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.PropertyClassificationTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_CLASSIFICATION_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsPropertyEvaluation>(entity =>
@@ -7484,89 +2232,21 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyEvaluationId)
                     .HasName("PRPEVL_PK");
 
-                entity.ToTable("PIMS_PROPERTY_EVALUATION");
+                entity.Property(e => e.PropertyEvaluationId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_EVALUATION_ID_SEQ])");
 
-                entity.HasIndex(e => e.PropertyId, "PRPEVL_PROPERTY_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.PropertyEvaluationId)
-                    .HasColumnName("PROPERTY_EVALUATION_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_EVALUATION_ID_SEQ])");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.EvaluationDate)
-                    .HasColumnType("date")
-                    .HasColumnName("EVALUATION_DATE");
-
-                entity.Property(e => e.Key).HasColumnName("KEY");
-
-                entity.Property(e => e.Note)
-                    .HasMaxLength(1000)
-                    .HasColumnName("NOTE");
-
-                entity.Property(e => e.PropertyId).HasColumnName("PROPERTY_ID");
-
-                entity.Property(e => e.Value)
-                    .HasColumnType("money")
-                    .HasColumnName("VALUE");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
                 entity.HasOne(d => d.Property)
                     .WithMany(p => p.PimsPropertyEvaluations)
@@ -7580,93 +2260,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyEvaluationHistId)
                     .HasName("PIMS_PRPEVL_H_PK");
 
-                entity.ToTable("PIMS_PROPERTY_EVALUATION_HIST");
+                entity.Property(e => e.PropertyEvaluationHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_EVALUATION_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.PropertyEvaluationHistId, e.EndDateHist }, "PIMS_PRPEVL_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.PropertyEvaluationHistId)
-                    .HasColumnName("_PROPERTY_EVALUATION_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_EVALUATION_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.EvaluationDate)
-                    .HasColumnType("date")
-                    .HasColumnName("EVALUATION_DATE");
-
-                entity.Property(e => e.Key).HasColumnName("KEY");
-
-                entity.Property(e => e.Note)
-                    .HasMaxLength(1000)
-                    .HasColumnName("NOTE");
-
-                entity.Property(e => e.PropertyEvaluationId).HasColumnName("PROPERTY_EVALUATION_ID");
-
-                entity.Property(e => e.PropertyId).HasColumnName("PROPERTY_ID");
-
-                entity.Property(e => e.Value)
-                    .HasColumnType("money")
-                    .HasColumnName("VALUE");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsPropertyHist>(entity =>
@@ -7674,168 +2270,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyHistId)
                     .HasName("PIMS_PRPRTY_H_PK");
 
-                entity.ToTable("PIMS_PROPERTY_HIST");
+                entity.Property(e => e.PropertyHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.PropertyHistId, e.EndDateHist }, "PIMS_PRPRTY_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.PropertyHistId)
-                    .HasColumnName("_PROPERTY_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_H_ID_SEQ])");
-
-                entity.Property(e => e.AddressId).HasColumnName("ADDRESS_ID");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.Description)
-                    .HasMaxLength(2000)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DistrictCode).HasColumnName("DISTRICT_CODE");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EncumbranceReason)
-                    .HasMaxLength(500)
-                    .HasColumnName("ENCUMBRANCE_REASON");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IsOwned).HasColumnName("IS_OWNED");
-
-                entity.Property(e => e.IsPropertyOfInterest).HasColumnName("IS_PROPERTY_OF_INTEREST");
-
-                entity.Property(e => e.IsSensitive).HasColumnName("IS_SENSITIVE");
-
-                entity.Property(e => e.IsVisibleToOtherAgencies).HasColumnName("IS_VISIBLE_TO_OTHER_AGENCIES");
-
-                entity.Property(e => e.LandArea).HasColumnName("LAND_AREA");
-
-                entity.Property(e => e.Name)
-                    .HasMaxLength(250)
-                    .HasColumnName("NAME");
-
-                entity.Property(e => e.Pid).HasColumnName("PID");
-
-                entity.Property(e => e.Pin).HasColumnName("PIN");
-
-                entity.Property(e => e.PropMgmtOrgId).HasColumnName("PROP_MGMT_ORG_ID");
-
-                entity.Property(e => e.PropertyAreaUnitTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_AREA_UNIT_TYPE_CODE");
-
-                entity.Property(e => e.PropertyClassificationTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_CLASSIFICATION_TYPE_CODE");
-
-                entity.Property(e => e.PropertyDataSourceEffectiveDate)
-                    .HasColumnType("date")
-                    .HasColumnName("PROPERTY_DATA_SOURCE_EFFECTIVE_DATE");
-
-                entity.Property(e => e.PropertyDataSourceTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_DATA_SOURCE_TYPE_CODE");
-
-                entity.Property(e => e.PropertyId).HasColumnName("PROPERTY_ID");
-
-                entity.Property(e => e.PropertyManagerId).HasColumnName("PROPERTY_MANAGER_ID");
-
-                entity.Property(e => e.PropertyStatusTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_STATUS_TYPE_CODE");
-
-                entity.Property(e => e.PropertyTenureTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_TENURE_TYPE_CODE");
-
-                entity.Property(e => e.PropertyTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_TYPE_CODE");
-
-                entity.Property(e => e.RegionCode).HasColumnName("REGION_CODE");
-
-                entity.Property(e => e.SurplusDeclarationComment)
-                    .HasMaxLength(2000)
-                    .HasColumnName("SURPLUS_DECLARATION_COMMENT");
-
-                entity.Property(e => e.SurplusDeclarationDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("SURPLUS_DECLARATION_DATE");
-
-                entity.Property(e => e.SurplusDeclarationTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("SURPLUS_DECLARATION_TYPE_CODE");
-
-                entity.Property(e => e.Zoning)
-                    .HasMaxLength(50)
-                    .HasColumnName("ZONING");
-
-                entity.Property(e => e.ZoningPotential)
-                    .HasMaxLength(50)
-                    .HasColumnName("ZONING_POTENTIAL");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsPropertyImprovement>(entity =>
@@ -7843,107 +2280,37 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyImprovementId)
                     .HasName("PIMPRV_PK");
 
-                entity.ToTable("PIMS_PROPERTY_IMPROVEMENT");
-
                 entity.HasComment("Description of property improvements associated with the lease.");
 
-                entity.HasIndex(e => new { e.LeaseId, e.PropertyImprovementTypeCode }, "PIMPRV_LEASE_IMPROVEMENT_TUC")
-                    .IsUnique();
+                entity.Property(e => e.PropertyImprovementId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_IMPROVEMENT_ID_SEQ])");
 
-                entity.HasIndex(e => e.PropertyImprovementTypeCode, "PIMPRV_PROPERTY_IMPROVEMENT_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.LeaseId, "PIMPRV_PROPERTY_LEASE_ID_IDX");
+                entity.Property(e => e.AppCreateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.PropertyImprovementId)
-                    .HasColumnName("PROPERTY_IMPROVEMENT_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_IMPROVEMENT_ID_SEQ])");
+                entity.Property(e => e.AppCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.AppLastUpdateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.AppLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.ImprovementDescription).HasComment("Description of the improvements");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.StructureSize).HasComment("Size of the structure (house, building, bridge, etc,) ");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.ImprovementDescription)
-                    .IsRequired()
-                    .HasMaxLength(2000)
-                    .HasColumnName("IMPROVEMENT_DESCRIPTION")
-                    .HasComment("Description of the improvements");
-
-                entity.Property(e => e.LeaseId).HasColumnName("LEASE_ID");
-
-                entity.Property(e => e.PropertyImprovementTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_IMPROVEMENT_TYPE_CODE");
-
-                entity.Property(e => e.StructureSize)
-                    .HasMaxLength(2000)
-                    .HasColumnName("STRUCTURE_SIZE")
-                    .HasComment("Size of the structure (house, building, bridge, etc,) ");
-
-                entity.Property(e => e.Unit)
-                    .HasMaxLength(2000)
-                    .HasColumnName("UNIT")
-                    .HasComment("Unit(s) affected");
+                entity.Property(e => e.Unit).HasComment("Unit(s) affected");
 
                 entity.HasOne(d => d.Lease)
                     .WithMany(p => p.PimsPropertyImprovements)
@@ -7963,97 +2330,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyImprovementHistId)
                     .HasName("PIMS_PIMPRV_H_PK");
 
-                entity.ToTable("PIMS_PROPERTY_IMPROVEMENT_HIST");
+                entity.Property(e => e.PropertyImprovementHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_IMPROVEMENT_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.PropertyImprovementHistId, e.EndDateHist }, "PIMS_PIMPRV_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.PropertyImprovementHistId)
-                    .HasColumnName("_PROPERTY_IMPROVEMENT_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_IMPROVEMENT_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.ImprovementDescription)
-                    .IsRequired()
-                    .HasMaxLength(2000)
-                    .HasColumnName("IMPROVEMENT_DESCRIPTION");
-
-                entity.Property(e => e.LeaseId).HasColumnName("LEASE_ID");
-
-                entity.Property(e => e.PropertyImprovementId).HasColumnName("PROPERTY_IMPROVEMENT_ID");
-
-                entity.Property(e => e.PropertyImprovementTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_IMPROVEMENT_TYPE_CODE");
-
-                entity.Property(e => e.StructureSize)
-                    .HasMaxLength(2000)
-                    .HasColumnName("STRUCTURE_SIZE");
-
-                entity.Property(e => e.Unit)
-                    .HasMaxLength(2000)
-                    .HasColumnName("UNIT");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsPropertyImprovementType>(entity =>
@@ -8061,52 +2340,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyImprovementTypeCode)
                     .HasName("PIMPRT_PK");
 
-                entity.ToTable("PIMS_PROPERTY_IMPROVEMENT_TYPE");
-
                 entity.HasComment("Description of the types of improvements made to a property during the lease.");
 
-                entity.Property(e => e.PropertyImprovementTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_IMPROVEMENT_TYPE_CODE")
-                    .HasComment("Code value of the types of improvements made to a property during the lease.");
+                entity.Property(e => e.PropertyImprovementTypeCode).HasComment("Code value of the types of improvements made to a property during the lease.");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION")
-                    .HasComment("Code description of the types of improvements made to a property during the lease.");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
+                entity.Property(e => e.Description).HasComment("Code description of the types of improvements made to a property during the lease.");
 
                 entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
                     .HasDefaultValueSql("(CONVERT([bit],(0)))")
                     .HasComment("Indicates if the code is disabled");
             });
@@ -8116,91 +2366,31 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyLeaseId)
                     .HasName("PROPLS_PK");
 
-                entity.ToTable("PIMS_PROPERTY_LEASE");
+                entity.Property(e => e.PropertyLeaseId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_LEASE_ID_SEQ])");
 
-                entity.HasIndex(e => e.LeaseId, "PROPLS_LEASE_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.PropertyId, "PROPLS_PROPERTY_ID_IDX");
+                entity.Property(e => e.AppCreateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.PropertyLeaseId)
-                    .HasColumnName("PROPERTY_LEASE_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_LEASE_ID_SEQ])");
+                entity.Property(e => e.AppCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.AppLastUpdateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.AppLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AreaUnitTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("AREA_UNIT_TYPE_CODE");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.LeaseArea)
-                    .HasColumnName("LEASE_AREA")
-                    .HasComment("Leased area measurement");
-
-                entity.Property(e => e.LeaseId).HasColumnName("LEASE_ID");
-
-                entity.Property(e => e.PropertyId).HasColumnName("PROPERTY_ID");
+                entity.Property(e => e.LeaseArea).HasComment("Leased area measurement");
 
                 entity.HasOne(d => d.AreaUnitTypeCodeNavigation)
                     .WithMany(p => p.PimsPropertyLeases)
@@ -8225,221 +2415,16 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyLeaseHistId)
                     .HasName("PIMS_PROPLS_H_PK");
 
-                entity.ToTable("PIMS_PROPERTY_LEASE_HIST");
+                entity.Property(e => e.PropertyLeaseHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_LEASE_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.PropertyLeaseHistId, e.EndDateHist }, "PIMS_PROPLS_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.PropertyLeaseHistId)
-                    .HasColumnName("_PROPERTY_LEASE_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_LEASE_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.AreaUnitTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("AREA_UNIT_TYPE_CODE");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.LeaseArea).HasColumnName("LEASE_AREA");
-
-                entity.Property(e => e.LeaseId).HasColumnName("LEASE_ID");
-
-                entity.Property(e => e.PropertyId).HasColumnName("PROPERTY_ID");
-
-                entity.Property(e => e.PropertyLeaseId).HasColumnName("PROPERTY_LEASE_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsPropertyLocationVw>(entity =>
             {
-                entity.HasNoKey();
-
                 entity.ToView("PIMS_PROPERTY_LOCATION_VW");
 
-                entity.Property(e => e.AddressId).HasColumnName("ADDRESS_ID");
-
-                entity.Property(e => e.CountryCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("COUNTRY_CODE");
-
-                entity.Property(e => e.CountryName)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("COUNTRY_NAME");
-
-                entity.Property(e => e.Description)
-                    .HasMaxLength(2000)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DistrictCode).HasColumnName("DISTRICT_CODE");
-
-                entity.Property(e => e.EncumbranceReason)
-                    .HasMaxLength(500)
-                    .HasColumnName("ENCUMBRANCE_REASON");
-
-                entity.Property(e => e.Geometry)
-                    .HasColumnType("geometry")
-                    .HasColumnName("GEOMETRY");
-
-                entity.Property(e => e.IsOwned).HasColumnName("IS_OWNED");
-
-                entity.Property(e => e.IsPropertyOfInterest).HasColumnName("IS_PROPERTY_OF_INTEREST");
-
-                entity.Property(e => e.IsSensitive).HasColumnName("IS_SENSITIVE");
-
-                entity.Property(e => e.IsVisibleToOtherAgencies).HasColumnName("IS_VISIBLE_TO_OTHER_AGENCIES");
-
-                entity.Property(e => e.LandArea).HasColumnName("LAND_AREA");
-
-                entity.Property(e => e.LandLegalDescription).HasColumnName("LAND_LEGAL_DESCRIPTION");
-
-                entity.Property(e => e.MunicipalityName)
-                    .HasMaxLength(200)
-                    .HasColumnName("MUNICIPALITY_NAME");
-
-                entity.Property(e => e.Name)
-                    .HasMaxLength(250)
-                    .HasColumnName("NAME");
-
-                entity.Property(e => e.Pid).HasColumnName("PID");
-
-                entity.Property(e => e.PidPadded)
-                    .HasMaxLength(9)
-                    .IsUnicode(false)
-                    .HasColumnName("PID_PADDED");
-
-                entity.Property(e => e.Pin).HasColumnName("PIN");
-
-                entity.Property(e => e.PostalCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("POSTAL_CODE");
-
-                entity.Property(e => e.PropertyAreaUnitTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_AREA_UNIT_TYPE_CODE");
-
-                entity.Property(e => e.PropertyClassificationTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_CLASSIFICATION_TYPE_CODE");
-
-                entity.Property(e => e.PropertyDataSourceEffectiveDate)
-                    .HasColumnType("date")
-                    .HasColumnName("PROPERTY_DATA_SOURCE_EFFECTIVE_DATE");
-
-                entity.Property(e => e.PropertyDataSourceTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_DATA_SOURCE_TYPE_CODE");
-
-                entity.Property(e => e.PropertyId).HasColumnName("PROPERTY_ID");
-
-                entity.Property(e => e.PropertyStatusTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_STATUS_TYPE_CODE");
-
-                entity.Property(e => e.PropertyTenureTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_TENURE_TYPE_CODE");
-
-                entity.Property(e => e.PropertyTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_TYPE_CODE");
-
-                entity.Property(e => e.ProvinceName)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("PROVINCE_NAME");
-
-                entity.Property(e => e.ProvinceStateCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROVINCE_STATE_CODE");
-
-                entity.Property(e => e.RegionCode).HasColumnName("REGION_CODE");
-
-                entity.Property(e => e.StreetAddress1)
-                    .HasMaxLength(200)
-                    .HasColumnName("STREET_ADDRESS_1");
-
-                entity.Property(e => e.StreetAddress2)
-                    .HasMaxLength(200)
-                    .HasColumnName("STREET_ADDRESS_2");
-
-                entity.Property(e => e.StreetAddress3)
-                    .HasMaxLength(200)
-                    .HasColumnName("STREET_ADDRESS_3");
-
-                entity.Property(e => e.Zoning)
-                    .HasMaxLength(50)
-                    .HasColumnName("ZONING");
-
-                entity.Property(e => e.ZoningPotential)
-                    .HasMaxLength(50)
-                    .HasColumnName("ZONING_POTENTIAL");
+                entity.Property(e => e.PidPadded).IsUnicode(false);
             });
 
             modelBuilder.Entity<PimsPropertyOrganization>(entity =>
@@ -8447,86 +2432,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyOrganizationId)
                     .HasName("PRPORG_PK");
 
-                entity.ToTable("PIMS_PROPERTY_ORGANIZATION");
+                entity.Property(e => e.PropertyOrganizationId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_ORGANIZATION_ID_SEQ])");
 
-                entity.HasIndex(e => e.OrganizationId, "PRPORG_ORGANIZATION_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.PropertyId, "PRPORG_PROPERTY_ID_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => new { e.PropertyId, e.OrganizationId }, "PRPORG_PROPERTY_ORGANIZATION_TUC")
-                    .IsUnique();
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.PropertyOrganizationId)
-                    .HasColumnName("PROPERTY_ORGANIZATION_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_ORGANIZATION_ID_SEQ])");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.IsDisabled)
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.OrganizationId).HasColumnName("ORGANIZATION_ID");
-
-                entity.Property(e => e.PropertyId).HasColumnName("PROPERTY_ID");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
                 entity.HasOne(d => d.Organization)
                     .WithMany(p => p.PimsPropertyOrganizations)
@@ -8546,83 +2468,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyOrganizationHistId)
                     .HasName("PIMS_PRPORG_H_PK");
 
-                entity.ToTable("PIMS_PROPERTY_ORGANIZATION_HIST");
+                entity.Property(e => e.PropertyOrganizationHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_ORGANIZATION_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.PropertyOrganizationHistId, e.EndDateHist }, "PIMS_PRPORG_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.PropertyOrganizationHistId)
-                    .HasColumnName("_PROPERTY_ORGANIZATION_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_ORGANIZATION_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.OrganizationId).HasColumnName("ORGANIZATION_ID");
-
-                entity.Property(e => e.PropertyId).HasColumnName("PROPERTY_ID");
-
-                entity.Property(e => e.PropertyOrganizationId).HasColumnName("PROPERTY_ORGANIZATION_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsPropertyPropertyServiceFile>(entity =>
@@ -8630,86 +2478,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyPropertyServiceFileId)
                     .HasName("PRPRSF_PK");
 
-                entity.ToTable("PIMS_PROPERTY_PROPERTY_SERVICE_FILE");
+                entity.Property(e => e.PropertyPropertyServiceFileId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_PROPERTY_SERVICE_FILE_ID_SEQ])");
 
-                entity.HasIndex(e => e.PropertyId, "PRPRSF_PROPERTY_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.PropertyServiceFileId, "PRPRSF_PROPERTY_SERVICE_FILE_ID_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => new { e.PropertyId, e.PropertyServiceFileId }, "PRPRSF_PROPERTY_SERVICE_FILE_TUC")
-                    .IsUnique();
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.PropertyPropertyServiceFileId)
-                    .HasColumnName("PROPERTY_PROPERTY_SERVICE_FILE_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_PROPERTY_SERVICE_FILE_ID_SEQ])");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.IsDisabled)
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.PropertyId).HasColumnName("PROPERTY_ID");
-
-                entity.Property(e => e.PropertyServiceFileId).HasColumnName("PROPERTY_SERVICE_FILE_ID");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
                 entity.HasOne(d => d.Property)
                     .WithMany(p => p.PimsPropertyPropertyServiceFiles)
@@ -8729,83 +2514,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyPropertyServiceFileHistId)
                     .HasName("PIMS_PRPRSF_H_PK");
 
-                entity.ToTable("PIMS_PROPERTY_PROPERTY_SERVICE_FILE_HIST");
+                entity.Property(e => e.PropertyPropertyServiceFileHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_PROPERTY_SERVICE_FILE_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.PropertyPropertyServiceFileHistId, e.EndDateHist }, "PIMS_PRPRSF_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.PropertyPropertyServiceFileHistId)
-                    .HasColumnName("_PROPERTY_PROPERTY_SERVICE_FILE_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_PROPERTY_SERVICE_FILE_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.PropertyId).HasColumnName("PROPERTY_ID");
-
-                entity.Property(e => e.PropertyPropertyServiceFileId).HasColumnName("PROPERTY_PROPERTY_SERVICE_FILE_ID");
-
-                entity.Property(e => e.PropertyServiceFileId).HasColumnName("PROPERTY_SERVICE_FILE_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsPropertyServiceFile>(entity =>
@@ -8813,78 +2524,21 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyServiceFileId)
                     .HasName("PRPSVC_PK");
 
-                entity.ToTable("PIMS_PROPERTY_SERVICE_FILE");
+                entity.Property(e => e.PropertyServiceFileId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_SERVICE_FILE_ID_SEQ])");
 
-                entity.HasIndex(e => e.PropertyServiceFileTypeCode, "PRPSVC_PROPERTY_SERVICE_FILE_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.PropertyServiceFileId)
-                    .HasColumnName("PROPERTY_SERVICE_FILE_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_SERVICE_FILE_ID_SEQ])");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.PropertyServiceFileTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_SERVICE_FILE_TYPE_CODE");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
                 entity.HasOne(d => d.PropertyServiceFileTypeCodeNavigation)
                     .WithMany(p => p.PimsPropertyServiceFiles)
@@ -8898,82 +2552,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyServiceFileHistId)
                     .HasName("PIMS_PRPSVC_H_PK");
 
-                entity.ToTable("PIMS_PROPERTY_SERVICE_FILE_HIST");
+                entity.Property(e => e.PropertyServiceFileHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_SERVICE_FILE_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.PropertyServiceFileHistId, e.EndDateHist }, "PIMS_PRPSVC_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.PropertyServiceFileHistId)
-                    .HasColumnName("_PROPERTY_SERVICE_FILE_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_SERVICE_FILE_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.PropertyServiceFileId).HasColumnName("PROPERTY_SERVICE_FILE_ID");
-
-                entity.Property(e => e.PropertyServiceFileTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_SERVICE_FILE_TYPE_CODE");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsPropertyServiceFileType>(entity =>
@@ -8981,49 +2562,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyServiceFileTypeCode)
                     .HasName("PRSVFT_PK");
 
-                entity.ToTable("PIMS_PROPERTY_SERVICE_FILE_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.PropertyServiceFileTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_SERVICE_FILE_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsPropertyStatusType>(entity =>
@@ -9031,49 +2580,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyStatusTypeCode)
                     .HasName("PRPSTS_PK");
 
-                entity.ToTable("PIMS_PROPERTY_STATUS_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.PropertyStatusTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_STATUS_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsPropertyTax>(entity =>
@@ -9081,108 +2598,31 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyTaxId)
                     .HasName("PRPTAX_PK");
 
-                entity.ToTable("PIMS_PROPERTY_TAX");
+                entity.Property(e => e.PropertyTaxId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_TAX_ID_SEQ])");
 
-                entity.HasIndex(e => e.PropertyId, "PRPTAX_PROPERTY_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.PropertyTaxRemitTypeCode, "PRPTAX_PROPERTY_TAX_REMIT_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.PropertyTaxId)
-                    .HasColumnName("PROPERTY_TAX_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_TAX_ID_SEQ])");
+                entity.Property(e => e.AppCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.AppLastUpdateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.AppLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.BctfaNotificationDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("BCTFA_NOTIFICATION_DATE");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.LastPaymentDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("LAST_PAYMENT_DATE");
-
-                entity.Property(e => e.PaymentAmount)
-                    .HasColumnType("money")
-                    .HasColumnName("PAYMENT_AMOUNT");
-
-                entity.Property(e => e.PaymentNotes)
-                    .HasColumnType("money")
-                    .HasColumnName("PAYMENT_NOTES");
-
-                entity.Property(e => e.PropertyId).HasColumnName("PROPERTY_ID");
-
-                entity.Property(e => e.PropertyTaxRemitTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_TAX_REMIT_TYPE_CODE");
-
-                entity.Property(e => e.TaxFolioNo)
-                    .IsRequired()
-                    .HasMaxLength(50)
-                    .HasColumnName("TAX_FOLIO_NO")
-                    .HasComment("Property tax folio number");
+                entity.Property(e => e.TaxFolioNo).HasComment("Property tax folio number");
 
                 entity.HasOne(d => d.Property)
                     .WithMany(p => p.PimsPropertyTaxes)
@@ -9202,105 +2642,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyTaxHistId)
                     .HasName("PIMS_PRPTAX_H_PK");
 
-                entity.ToTable("PIMS_PROPERTY_TAX_HIST");
+                entity.Property(e => e.PropertyTaxHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_TAX_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.PropertyTaxHistId, e.EndDateHist }, "PIMS_PRPTAX_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.PropertyTaxHistId)
-                    .HasColumnName("_PROPERTY_TAX_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_PROPERTY_TAX_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.BctfaNotificationDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("BCTFA_NOTIFICATION_DATE");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.LastPaymentDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("LAST_PAYMENT_DATE");
-
-                entity.Property(e => e.PaymentAmount)
-                    .HasColumnType("money")
-                    .HasColumnName("PAYMENT_AMOUNT");
-
-                entity.Property(e => e.PaymentNotes)
-                    .HasColumnType("money")
-                    .HasColumnName("PAYMENT_NOTES");
-
-                entity.Property(e => e.PropertyId).HasColumnName("PROPERTY_ID");
-
-                entity.Property(e => e.PropertyTaxId).HasColumnName("PROPERTY_TAX_ID");
-
-                entity.Property(e => e.PropertyTaxRemitTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_TAX_REMIT_TYPE_CODE");
-
-                entity.Property(e => e.TaxFolioNo)
-                    .IsRequired()
-                    .HasMaxLength(50)
-                    .HasColumnName("TAX_FOLIO_NO");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsPropertyTaxRemitType>(entity =>
@@ -9308,52 +2652,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyTaxRemitTypeCode)
                     .HasName("PTRMTT_PK");
 
-                entity.ToTable("PIMS_PROPERTY_TAX_REMIT_TYPE");
-
                 entity.HasComment("Description of property tax remittance types");
 
-                entity.Property(e => e.PropertyTaxRemitTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_TAX_REMIT_TYPE_CODE")
-                    .HasComment("Code value of property tax remittance types");
+                entity.Property(e => e.PropertyTaxRemitTypeCode).HasComment("Code value of property tax remittance types");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION")
-                    .HasComment("Code description of property tax remittance types");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
+                entity.Property(e => e.Description).HasComment("Code description of property tax remittance types");
 
                 entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
                     .HasDefaultValueSql("(CONVERT([bit],(0)))")
                     .HasComment("Is this code value disabled?");
             });
@@ -9363,51 +2678,19 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyTenureTypeCode)
                     .HasName("PRPTNR_PK");
 
-                entity.ToTable("PIMS_PROPERTY_TENURE_TYPE");
-
                 entity.HasComment("A code table to store property tenure codes. Tenure is defined as : \"The act, right, manner or term of holding something(as a landed property)\" In this case, tenure is required on Properties to indicate MoTI's legal tenure on the property. The land parcel still accurately describes the legal title of the land parcel but the individual properties each can have different tenures by MoTI.");
 
-                entity.Property(e => e.PropertyTenureTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_TENURE_TYPE_CODE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsPropertyType>(entity =>
@@ -9415,49 +2698,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.PropertyTypeCode)
                     .HasName("PRPTYP_PK");
 
-                entity.ToTable("PIMS_PROPERTY_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.PropertyTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("PROPERTY_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsProvinceState>(entity =>
@@ -9465,58 +2716,19 @@ namespace Pims.Dal
                 entity.HasKey(e => e.ProvinceStateId)
                     .HasName("PROVNC_PK");
 
-                entity.ToTable("PIMS_PROVINCE_STATE");
+                entity.Property(e => e.ProvinceStateId).ValueGeneratedNever();
 
-                entity.HasIndex(e => e.CountryId, "PROVNC_COUNTRY_ID_IDX");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.ProvinceStateId)
-                    .ValueGeneratedNever()
-                    .HasColumnName("PROVINCE_STATE_ID");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.CountryId).HasColumnName("COUNTRY_ID");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.ProvinceStateCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("PROVINCE_STATE_CODE");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
                 entity.HasOne(d => d.Country)
                     .WithMany(p => p.PimsProvinceStates)
@@ -9530,49 +2742,19 @@ namespace Pims.Dal
                 entity.HasKey(e => e.RegionCode)
                     .HasName("REGION_PK");
 
-                entity.ToTable("PIMS_REGION");
+                entity.Property(e => e.RegionCode).ValueGeneratedNever();
 
-                entity.Property(e => e.RegionCode)
-                    .ValueGeneratedNever()
-                    .HasColumnName("REGION_CODE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.RegionName)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("REGION_NAME");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsRole>(entity =>
@@ -9580,100 +2762,25 @@ namespace Pims.Dal
                 entity.HasKey(e => e.RoleId)
                     .HasName("ROLE_PK");
 
-                entity.ToTable("PIMS_ROLE");
+                entity.Property(e => e.RoleId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ROLE_ID_SEQ])");
 
-                entity.HasIndex(e => e.KeycloakGroupId, "ROLE_KEYCLOAK_GROUP_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.RoleUid, "ROLE_ROLE_UID_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.RoleId)
-                    .HasColumnName("ROLE_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ROLE_ID_SEQ])");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .HasMaxLength(500)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.IsPublic)
-                    .IsRequired()
-                    .HasColumnName("IS_PUBLIC")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.KeycloakGroupId).HasColumnName("KEYCLOAK_GROUP_ID");
-
-                entity.Property(e => e.Name)
-                    .IsRequired()
-                    .HasMaxLength(100)
-                    .HasColumnName("NAME");
-
-                entity.Property(e => e.RoleUid).HasColumnName("ROLE_UID");
-
-                entity.Property(e => e.SortOrder).HasColumnName("SORT_ORDER");
+                entity.Property(e => e.IsPublic).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsRoleClaim>(entity =>
@@ -9681,86 +2788,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.RoleClaimId)
                     .HasName("ROLCLM_PK");
 
-                entity.ToTable("PIMS_ROLE_CLAIM");
+                entity.Property(e => e.RoleClaimId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ROLE_CLAIM_ID_SEQ])");
 
-                entity.HasIndex(e => e.ClaimId, "ROLCLM_CLAIM_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => new { e.RoleId, e.ClaimId }, "ROLCLM_ROLE_CLAIM_TUC")
-                    .IsUnique();
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.RoleId, "ROLCLM_ROLE_ID_IDX");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.RoleClaimId)
-                    .HasColumnName("ROLE_CLAIM_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ROLE_CLAIM_ID_SEQ])");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ClaimId).HasColumnName("CLAIM_ID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.IsDisabled)
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.RoleId).HasColumnName("ROLE_ID");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
                 entity.HasOne(d => d.Claim)
                     .WithMany(p => p.PimsRoleClaims)
@@ -9780,83 +2824,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.RoleClaimHistId)
                     .HasName("PIMS_ROLCLM_H_PK");
 
-                entity.ToTable("PIMS_ROLE_CLAIM_HIST");
+                entity.Property(e => e.RoleClaimHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ROLE_CLAIM_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.RoleClaimHistId, e.EndDateHist }, "PIMS_ROLCLM_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.RoleClaimHistId)
-                    .HasColumnName("_ROLE_CLAIM_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ROLE_CLAIM_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ClaimId).HasColumnName("CLAIM_ID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.RoleClaimId).HasColumnName("ROLE_CLAIM_ID");
-
-                entity.Property(e => e.RoleId).HasColumnName("ROLE_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsRoleHist>(entity =>
@@ -9864,96 +2834,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.RoleHistId)
                     .HasName("PIMS_ROLE_H_PK");
 
-                entity.ToTable("PIMS_ROLE_HIST");
+                entity.Property(e => e.RoleHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ROLE_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.RoleHistId, e.EndDateHist }, "PIMS_ROLE_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.RoleHistId)
-                    .HasColumnName("_ROLE_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_ROLE_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.Description)
-                    .HasMaxLength(500)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.IsPublic).HasColumnName("IS_PUBLIC");
-
-                entity.Property(e => e.KeycloakGroupId).HasColumnName("KEYCLOAK_GROUP_ID");
-
-                entity.Property(e => e.Name)
-                    .IsRequired()
-                    .HasMaxLength(100)
-                    .HasColumnName("NAME");
-
-                entity.Property(e => e.RoleId).HasColumnName("ROLE_ID");
-
-                entity.Property(e => e.RoleUid).HasColumnName("ROLE_UID");
-
-                entity.Property(e => e.SortOrder).HasColumnName("SORT_ORDER");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsSecDepHolderType>(entity =>
@@ -9961,49 +2844,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.SecDepHolderTypeCode)
                     .HasName("SCHLDT_PK");
 
-                entity.ToTable("PIMS_SEC_DEP_HOLDER_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.SecDepHolderTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("SEC_DEP_HOLDER_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsSecurityDeposit>(entity =>
@@ -10011,114 +2862,29 @@ namespace Pims.Dal
                 entity.HasKey(e => e.SecurityDepositId)
                     .HasName("SECDEP_PK");
 
-                entity.ToTable("PIMS_SECURITY_DEPOSIT");
+                entity.Property(e => e.SecurityDepositId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_SECURITY_DEPOSIT_ID_SEQ])");
 
-                entity.HasIndex(e => e.LeaseId, "SECDEP_LEASE_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.SecurityDepositTypeCode, "SECDEP_SECURITY_DEPOSIT_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.HasIndex(e => e.SecDepHolderTypeCode, "SECDEP_SEC_DEP_HOLDER_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.SecurityDepositId)
-                    .HasColumnName("SECURITY_DEPOSIT_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_SECURITY_DEPOSIT_ID_SEQ])");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AmountPaid)
-                    .HasColumnType("money")
-                    .HasColumnName("AMOUNT_PAID");
+                entity.Property(e => e.AppLastUpdateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AnnualInterestRate)
-                    .HasColumnType("numeric(5, 2)")
-                    .HasColumnName("ANNUAL_INTEREST_RATE");
+                entity.Property(e => e.AppLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DepositDate)
-                    .HasColumnType("date")
-                    .HasColumnName("DEPOSIT_DATE");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(2000)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.LeaseId).HasColumnName("LEASE_ID");
-
-                entity.Property(e => e.OtherDepHolderTypeDesc)
-                    .HasMaxLength(100)
-                    .HasColumnName("OTHER_DEP_HOLDER_TYPE_DESC");
-
-                entity.Property(e => e.SecDepHolderTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("SEC_DEP_HOLDER_TYPE_CODE");
-
-                entity.Property(e => e.SecurityDepositTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("SECURITY_DEPOSIT_TYPE_CODE");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
                 entity.HasOne(d => d.Lease)
                     .WithMany(p => p.PimsSecurityDeposits)
@@ -10144,110 +2910,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.SecurityDepositHistId)
                     .HasName("PIMS_SECDEP_H_PK");
 
-                entity.ToTable("PIMS_SECURITY_DEPOSIT_HIST");
+                entity.Property(e => e.SecurityDepositHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_SECURITY_DEPOSIT_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.SecurityDepositHistId, e.EndDateHist }, "PIMS_SECDEP_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.SecurityDepositHistId)
-                    .HasColumnName("_SECURITY_DEPOSIT_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_SECURITY_DEPOSIT_H_ID_SEQ])");
-
-                entity.Property(e => e.AmountPaid)
-                    .HasColumnType("money")
-                    .HasColumnName("AMOUNT_PAID");
-
-                entity.Property(e => e.AnnualInterestRate)
-                    .HasColumnType("numeric(18, 0)")
-                    .HasColumnName("ANNUAL_INTEREST_RATE");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.DepositDate)
-                    .HasColumnType("date")
-                    .HasColumnName("DEPOSIT_DATE");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(2000)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.LeaseId).HasColumnName("LEASE_ID");
-
-                entity.Property(e => e.OtherDepHolderTypeDesc)
-                    .HasMaxLength(100)
-                    .HasColumnName("OTHER_DEP_HOLDER_TYPE_DESC");
-
-                entity.Property(e => e.SecDepHolderTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("SEC_DEP_HOLDER_TYPE_CODE");
-
-                entity.Property(e => e.SecurityDepositId).HasColumnName("SECURITY_DEPOSIT_ID");
-
-                entity.Property(e => e.SecurityDepositTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("SECURITY_DEPOSIT_TYPE_CODE");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsSecurityDepositReturn>(entity =>
@@ -10255,128 +2920,45 @@ namespace Pims.Dal
                 entity.HasKey(e => e.SecurityDepositReturnId)
                     .HasName("SDRTRN_PK");
 
-                entity.ToTable("PIMS_SECURITY_DEPOSIT_RETURN");
+                entity.Property(e => e.SecurityDepositReturnId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_SECURITY_DEPOSIT_RETURN_ID_SEQ])");
 
-                entity.HasIndex(e => e.LeaseId, "SDRTRN_LEASE_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.SecurityDepositTypeCode, "SDRTRN_SECURITY_DEPOSIT_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.SecurityDepositReturnId)
-                    .HasColumnName("SECURITY_DEPOSIT_RETURN_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_SECURITY_DEPOSIT_RETURN_ID_SEQ])");
+                entity.Property(e => e.AppCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.AppLastUpdateUserDirectory).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.AppLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.ChequeNumber).HasComment("Cheque number of the deposit return");
 
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.ClaimsAgainst).HasComment("Amount of claims against the deposit");
 
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.ChequeNumber)
-                    .IsRequired()
-                    .HasMaxLength(50)
-                    .HasColumnName("CHEQUE_NUMBER")
-                    .HasComment("Cheque number of the deposit return");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ClaimsAgainst)
-                    .HasColumnType("money")
-                    .HasColumnName("CLAIMS_AGAINST")
-                    .HasComment("Amount of claims against the deposit");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DepositTotal).HasComment("Total amount of the pet/security deposit (including interest)");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.PayeeAddress).HasComment("Address of cheque recipient");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.PayeeName).HasComment("Name of cheque recipient");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.ReturnAmount).HasComment("Amount returned minus claims");
 
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.ReturnDate).HasComment("Date of deposit return");
 
-                entity.Property(e => e.DepositTotal)
-                    .HasColumnType("money")
-                    .HasColumnName("DEPOSIT_TOTAL")
-                    .HasComment("Total amount of the pet/security deposit (including interest)");
-
-                entity.Property(e => e.LeaseId).HasColumnName("LEASE_ID");
-
-                entity.Property(e => e.PayeeAddress)
-                    .HasMaxLength(500)
-                    .HasColumnName("PAYEE_ADDRESS")
-                    .HasComment("Address of cheque recipient");
-
-                entity.Property(e => e.PayeeName)
-                    .IsRequired()
-                    .HasMaxLength(100)
-                    .HasColumnName("PAYEE_NAME")
-                    .HasComment("Name of cheque recipient");
-
-                entity.Property(e => e.ReturnAmount)
-                    .HasColumnType("money")
-                    .HasColumnName("RETURN_AMOUNT")
-                    .HasComment("Amount returned minus claims");
-
-                entity.Property(e => e.ReturnDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("RETURN_DATE")
-                    .HasComment("Date of deposit return");
-
-                entity.Property(e => e.SecurityDepositTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("SECURITY_DEPOSIT_TYPE_CODE");
-
-                entity.Property(e => e.TerminationDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("TERMINATION_DATE")
-                    .HasComment("Date the lease/license was terminated or surrendered");
+                entity.Property(e => e.TerminationDate).HasComment("Date the lease/license was terminated or surrendered");
 
                 entity.HasOne(d => d.Lease)
                     .WithMany(p => p.PimsSecurityDepositReturns)
@@ -10396,118 +2978,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.SecurityDepositReturnHistId)
                     .HasName("PIMS_SDRTRN_H_PK");
 
-                entity.ToTable("PIMS_SECURITY_DEPOSIT_RETURN_HIST");
+                entity.Property(e => e.SecurityDepositReturnHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_SECURITY_DEPOSIT_RETURN_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.SecurityDepositReturnHistId, e.EndDateHist }, "PIMS_SDRTRN_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.SecurityDepositReturnHistId)
-                    .HasColumnName("_SECURITY_DEPOSIT_RETURN_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_SECURITY_DEPOSIT_RETURN_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ChequeNumber)
-                    .IsRequired()
-                    .HasMaxLength(50)
-                    .HasColumnName("CHEQUE_NUMBER");
-
-                entity.Property(e => e.ClaimsAgainst)
-                    .HasColumnType("money")
-                    .HasColumnName("CLAIMS_AGAINST");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.DepositTotal)
-                    .HasColumnType("money")
-                    .HasColumnName("DEPOSIT_TOTAL");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.LeaseId).HasColumnName("LEASE_ID");
-
-                entity.Property(e => e.PayeeAddress)
-                    .HasMaxLength(500)
-                    .HasColumnName("PAYEE_ADDRESS");
-
-                entity.Property(e => e.PayeeName)
-                    .IsRequired()
-                    .HasMaxLength(100)
-                    .HasColumnName("PAYEE_NAME");
-
-                entity.Property(e => e.ReturnAmount)
-                    .HasColumnType("money")
-                    .HasColumnName("RETURN_AMOUNT");
-
-                entity.Property(e => e.ReturnDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("RETURN_DATE");
-
-                entity.Property(e => e.SecurityDepositReturnId).HasColumnName("SECURITY_DEPOSIT_RETURN_ID");
-
-                entity.Property(e => e.SecurityDepositTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("SECURITY_DEPOSIT_TYPE_CODE");
-
-                entity.Property(e => e.TerminationDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("TERMINATION_DATE");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsSecurityDepositType>(entity =>
@@ -10515,49 +2988,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.SecurityDepositTypeCode)
                     .HasName("SECDPT_PK");
 
-                entity.ToTable("PIMS_SECURITY_DEPOSIT_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.SecurityDepositTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("SECURITY_DEPOSIT_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsStaticVariable>(entity =>
@@ -10565,42 +3006,15 @@ namespace Pims.Dal
                 entity.HasKey(e => e.StaticVariableName)
                     .HasName("STAVBL_PK");
 
-                entity.ToTable("PIMS_STATIC_VARIABLE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.StaticVariableName)
-                    .HasMaxLength(100)
-                    .HasColumnName("STATIC_VARIABLE_NAME");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.StaticVariableValue)
-                    .IsRequired()
-                    .HasMaxLength(100)
-                    .HasColumnName("STATIC_VARIABLE_VALUE");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
             });
 
             modelBuilder.Entity<PimsSurplusDeclarationType>(entity =>
@@ -10608,52 +3022,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.SurplusDeclarationTypeCode)
                     .HasName("SPDCLT_PK");
 
-                entity.ToTable("PIMS_SURPLUS_DECLARATION_TYPE");
-
                 entity.HasComment("Description of the surplus property type.");
 
-                entity.Property(e => e.SurplusDeclarationTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("SURPLUS_DECLARATION_TYPE_CODE")
-                    .HasComment("Code value of the surplus property type");
+                entity.Property(e => e.SurplusDeclarationTypeCode).HasComment("Code value of the surplus property type");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION")
-                    .HasComment("Code description of the surplus property type");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
+                entity.Property(e => e.Description).HasComment("Code description of the surplus property type");
 
                 entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
                     .HasDefaultValueSql("(CONVERT([bit],(0)))")
                     .HasComment("Indicates that the code value is disabled");
             });
@@ -10663,86 +3048,21 @@ namespace Pims.Dal
                 entity.HasKey(e => e.TaskId)
                     .HasName("TASK_PK");
 
-                entity.ToTable("PIMS_TASK");
+                entity.Property(e => e.TaskId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_TASK_ID_SEQ])");
 
-                entity.HasIndex(e => e.ActivityId, "TASK_ACTIVITY_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.TaskTemplateId, "TASK_TASK_TEMPLATE_ID_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => new { e.UserId, e.ActivityId, e.TaskTemplateId }, "TASK_TEMPLATE_ACTIVITY_USER_TUC")
-                    .IsUnique();
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.HasIndex(e => e.UserId, "TASK_USER_ID_IDX");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.TaskId)
-                    .HasColumnName("TASK_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_TASK_ID_SEQ])");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.ActivityId).HasColumnName("ACTIVITY_ID");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.TaskTemplateId).HasColumnName("TASK_TEMPLATE_ID");
-
-                entity.Property(e => e.UserId).HasColumnName("USER_ID");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
                 entity.HasOne(d => d.Activity)
                     .WithMany(p => p.PimsTasks)
@@ -10767,83 +3087,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.TaskHistId)
                     .HasName("PIMS_TASK_H_PK");
 
-                entity.ToTable("PIMS_TASK_HIST");
+                entity.Property(e => e.TaskHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_TASK_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.TaskHistId, e.EndDateHist }, "PIMS_TASK_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.TaskHistId)
-                    .HasColumnName("_TASK_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_TASK_H_ID_SEQ])");
-
-                entity.Property(e => e.ActivityId).HasColumnName("ACTIVITY_ID");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.TaskId).HasColumnName("TASK_ID");
-
-                entity.Property(e => e.TaskTemplateId).HasColumnName("TASK_TEMPLATE_ID");
-
-                entity.Property(e => e.UserId).HasColumnName("USER_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsTaskTemplate>(entity =>
@@ -10851,83 +3097,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.TaskTemplateId)
                     .HasName("TSKTMP_PK");
 
-                entity.ToTable("PIMS_TASK_TEMPLATE");
+                entity.Property(e => e.TaskTemplateId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_TASK_TEMPLATE_ID_SEQ])");
 
-                entity.HasIndex(e => e.TaskTemplateTypeCode, "TSKTMP_TASK_TEMPLATE_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.TaskTemplateId)
-                    .HasColumnName("TASK_TEMPLATE_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_TASK_TEMPLATE_ID_SEQ])");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.TaskTemplateTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("TASK_TEMPLATE_TYPE_CODE");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
                 entity.HasOne(d => d.TaskTemplateTypeCodeNavigation)
                     .WithMany(p => p.PimsTaskTemplates)
@@ -10941,93 +3127,25 @@ namespace Pims.Dal
                 entity.HasKey(e => e.TaskTemplateActivityModelId)
                     .HasName("TSKTAM_PK");
 
-                entity.ToTable("PIMS_TASK_TEMPLATE_ACTIVITY_MODEL");
+                entity.Property(e => e.TaskTemplateActivityModelId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_TASK_TEMPLATE_ACTIVITY_MODEL_ID_SEQ])");
 
-                entity.HasIndex(e => e.ActivityModelId, "TSKTAM_ACTIVITY_MODEL_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => new { e.TaskTemplateId, e.ActivityModelId }, "TSKTAM_TASK_TEMPLATE_ACTIVITY_MODEL_TUC")
-                    .IsUnique();
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.TaskTemplateId, "TSKTAM_TASK_TEMPLATE_ID_IDX");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.TaskTemplateActivityModelId)
-                    .HasColumnName("TASK_TEMPLATE_ACTIVITY_MODEL_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_TASK_TEMPLATE_ACTIVITY_MODEL_ID_SEQ])");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ActivityModelId).HasColumnName("ACTIVITY_MODEL_ID");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.ImplementationOrder).HasColumnName("IMPLEMENTATION_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.IsMandatory)
-                    .IsRequired()
-                    .HasColumnName("IS_MANDATORY")
-                    .HasDefaultValueSql("(CONVERT([bit],(1)))");
-
-                entity.Property(e => e.TaskTemplateId).HasColumnName("TASK_TEMPLATE_ID");
+                entity.Property(e => e.IsMandatory).HasDefaultValueSql("(CONVERT([bit],(1)))");
 
                 entity.HasOne(d => d.ActivityModel)
                     .WithMany(p => p.PimsTaskTemplateActivityModels)
@@ -11047,87 +3165,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.TaskTemplateActivityModelHistId)
                     .HasName("PIMS_TSKTAM_H_PK");
 
-                entity.ToTable("PIMS_TASK_TEMPLATE_ACTIVITY_MODEL_HIST");
+                entity.Property(e => e.TaskTemplateActivityModelHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_TASK_TEMPLATE_ACTIVITY_MODEL_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.TaskTemplateActivityModelHistId, e.EndDateHist }, "PIMS_TSKTAM_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.TaskTemplateActivityModelHistId)
-                    .HasColumnName("_TASK_TEMPLATE_ACTIVITY_MODEL_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_TASK_TEMPLATE_ACTIVITY_MODEL_H_ID_SEQ])");
-
-                entity.Property(e => e.ActivityModelId).HasColumnName("ACTIVITY_MODEL_ID");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.ImplementationOrder).HasColumnName("IMPLEMENTATION_ORDER");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.IsMandatory).HasColumnName("IS_MANDATORY");
-
-                entity.Property(e => e.TaskTemplateActivityModelId).HasColumnName("TASK_TEMPLATE_ACTIVITY_MODEL_ID");
-
-                entity.Property(e => e.TaskTemplateId).HasColumnName("TASK_TEMPLATE_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsTaskTemplateHist>(entity =>
@@ -11135,84 +3175,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.TaskTemplateHistId)
                     .HasName("PIMS_TSKTMP_H_PK");
 
-                entity.ToTable("PIMS_TASK_TEMPLATE_HIST");
+                entity.Property(e => e.TaskTemplateHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_TASK_TEMPLATE_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.TaskTemplateHistId, e.EndDateHist }, "PIMS_TSKTMP_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.TaskTemplateHistId)
-                    .HasColumnName("_TASK_TEMPLATE_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_TASK_TEMPLATE_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.TaskTemplateId).HasColumnName("TASK_TEMPLATE_ID");
-
-                entity.Property(e => e.TaskTemplateTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("TASK_TEMPLATE_TYPE_CODE");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsTaskTemplateType>(entity =>
@@ -11220,106 +3185,47 @@ namespace Pims.Dal
                 entity.HasKey(e => e.TaskTemplateTypeCode)
                     .HasName("TSKTMT_PK");
 
-                entity.ToTable("PIMS_TASK_TEMPLATE_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.TaskTemplateTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("TASK_TEMPLATE_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.Entity<PimsTenant>(entity =>
             {
                 entity.HasKey(e => e.TenantId)
-                    .HasName("PK__PIMS_TEN__5E0E988A42D52538");
-
-                entity.ToTable("PIMS_TENANT");
+                    .HasName("PIMS_TENANT_PK");
 
                 entity.Property(e => e.TenantId)
-                    .HasColumnName("TENANT_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_TENANT_ID_SEQ])");
+                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_TENANT_ID_SEQ])")
+                    .HasComment("Auto-sequenced unique key value");
 
-                entity.Property(e => e.Code)
-                    .IsRequired()
-                    .HasMaxLength(6)
-                    .HasColumnName("CODE");
+                entity.Property(e => e.Code).HasComment("Code value for entry");
 
                 entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                    .HasDefaultValueSql("(CONVERT([bigint],(1)))")
+                    .HasComment("Concurrency control number");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.Description)
-                    .HasMaxLength(500)
-                    .HasColumnName("DESCRIPTION");
+                entity.Property(e => e.Description).HasComment("Description of the entry for display purposes");
 
-                entity.Property(e => e.Name)
-                    .IsRequired()
-                    .HasMaxLength(150)
-                    .HasColumnName("NAME");
+                entity.Property(e => e.Name).HasComment("Name of the entry for display purposes");
 
-                entity.Property(e => e.Settings)
-                    .IsRequired()
-                    .HasMaxLength(2000)
-                    .HasColumnName("SETTINGS");
+                entity.Property(e => e.Settings).HasComment("Serialized JSON value for the configuration");
             });
 
             modelBuilder.Entity<PimsUser>(entity =>
@@ -11327,114 +3233,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.UserId)
                     .HasName("USER_PK");
 
-                entity.ToTable("PIMS_USER");
+                entity.Property(e => e.UserId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_USER_ID_SEQ])");
 
-                entity.HasIndex(e => e.BusinessIdentifierValue, "USER_BUSINESS_IDENTIFIER_VALUE_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.GuidIdentifierValue, "USER_GUID_IDENTIFIER_VALUE_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.PersonId, "USER_PERSON_ID_IDX");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.UserId)
-                    .HasColumnName("USER_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_USER_ID_SEQ])");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ApprovedById)
-                    .HasMaxLength(30)
-                    .HasColumnName("APPROVED_BY_ID");
-
-                entity.Property(e => e.BusinessIdentifierValue)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("BUSINESS_IDENTIFIER_VALUE");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.ExpiryDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EXPIRY_DATE");
-
-                entity.Property(e => e.GuidIdentifierValue).HasColumnName("GUID_IDENTIFIER_VALUE");
-
-                entity.Property(e => e.IsDisabled)
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.IssueDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("ISSUE_DATE");
-
-                entity.Property(e => e.LastLogin)
-                    .HasColumnType("datetime")
-                    .HasColumnName("LAST_LOGIN");
-
-                entity.Property(e => e.Note)
-                    .HasMaxLength(1000)
-                    .HasColumnName("NOTE");
-
-                entity.Property(e => e.PersonId).HasColumnName("PERSON_ID");
-
-                entity.Property(e => e.Position)
-                    .HasMaxLength(100)
-                    .HasColumnName("POSITION");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
                 entity.HasOne(d => d.Person)
                     .WithMany(p => p.PimsUsers)
@@ -11448,112 +3263,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.UserHistId)
                     .HasName("PIMS_USER_H_PK");
 
-                entity.ToTable("PIMS_USER_HIST");
+                entity.Property(e => e.UserHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_USER_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.UserHistId, e.EndDateHist }, "PIMS_USER_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.UserHistId)
-                    .HasColumnName("_USER_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_USER_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ApprovedById)
-                    .HasMaxLength(30)
-                    .HasColumnName("APPROVED_BY_ID");
-
-                entity.Property(e => e.BusinessIdentifierValue)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("BUSINESS_IDENTIFIER_VALUE");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.ExpiryDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EXPIRY_DATE");
-
-                entity.Property(e => e.GuidIdentifierValue).HasColumnName("GUID_IDENTIFIER_VALUE");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.IssueDate)
-                    .HasColumnType("datetime")
-                    .HasColumnName("ISSUE_DATE");
-
-                entity.Property(e => e.LastLogin)
-                    .HasColumnType("datetime")
-                    .HasColumnName("LAST_LOGIN");
-
-                entity.Property(e => e.Note)
-                    .HasMaxLength(1000)
-                    .HasColumnName("NOTE");
-
-                entity.Property(e => e.PersonId).HasColumnName("PERSON_ID");
-
-                entity.Property(e => e.Position)
-                    .HasMaxLength(100)
-                    .HasColumnName("POSITION");
-
-                entity.Property(e => e.UserId).HasColumnName("USER_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsUserOrganization>(entity =>
@@ -11561,90 +3273,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.UserOrganizationId)
                     .HasName("USRORG_PK");
 
-                entity.ToTable("PIMS_USER_ORGANIZATION");
+                entity.Property(e => e.UserOrganizationId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_USER_ORGANIZATION_ID_SEQ])");
 
-                entity.HasIndex(e => e.OrganizationId, "USRORG_ORGANIZATION_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.RoleId, "USRORG_ROLE_ID_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.UserId, "USRORG_USER_ID_IDX");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.HasIndex(e => new { e.OrganizationId, e.UserId, e.RoleId }, "USRORG_USER_ROLE_ORGANIZATION_TUC")
-                    .IsUnique();
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.UserOrganizationId)
-                    .HasColumnName("USER_ORGANIZATION_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_USER_ORGANIZATION_ID_SEQ])");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.IsDisabled)
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.OrganizationId).HasColumnName("ORGANIZATION_ID");
-
-                entity.Property(e => e.RoleId).HasColumnName("ROLE_ID");
-
-                entity.Property(e => e.UserId).HasColumnName("USER_ID");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
                 entity.HasOne(d => d.Organization)
                     .WithMany(p => p.PimsUserOrganizations)
@@ -11670,85 +3315,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.UserOrganizationHistId)
                     .HasName("PIMS_USRORG_H_PK");
 
-                entity.ToTable("PIMS_USER_ORGANIZATION_HIST");
+                entity.Property(e => e.UserOrganizationHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_USER_ORGANIZATION_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.UserOrganizationHistId, e.EndDateHist }, "PIMS_USRORG_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.UserOrganizationHistId)
-                    .HasColumnName("_USER_ORGANIZATION_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_USER_ORGANIZATION_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.OrganizationId).HasColumnName("ORGANIZATION_ID");
-
-                entity.Property(e => e.RoleId).HasColumnName("ROLE_ID");
-
-                entity.Property(e => e.UserId).HasColumnName("USER_ID");
-
-                entity.Property(e => e.UserOrganizationId).HasColumnName("USER_ORGANIZATION_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsUserRole>(entity =>
@@ -11756,86 +3325,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.UserRoleId)
                     .HasName("USERRL_PK");
 
-                entity.ToTable("PIMS_USER_ROLE");
+                entity.Property(e => e.UserRoleId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_USER_ROLE_ID_SEQ])");
 
-                entity.HasIndex(e => e.RoleId, "USERRL_ROLE_ID_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => e.UserId, "USERRL_USER_ID_IDX");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.HasIndex(e => new { e.UserId, e.RoleId }, "USERRL_USER_ROLE_TUC")
-                    .IsUnique();
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.UserRoleId)
-                    .HasColumnName("USER_ROLE_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_USER_ROLE_ID_SEQ])");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.IsDisabled)
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.RoleId).HasColumnName("ROLE_ID");
-
-                entity.Property(e => e.UserId).HasColumnName("USER_ID");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
                 entity.HasOne(d => d.Role)
                     .WithMany(p => p.PimsUserRoles)
@@ -11855,83 +3361,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.UserRoleHistId)
                     .HasName("PIMS_USERRL_H_PK");
 
-                entity.ToTable("PIMS_USER_ROLE_HIST");
+                entity.Property(e => e.UserRoleHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_USER_ROLE_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.UserRoleHistId, e.EndDateHist }, "PIMS_USERRL_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.UserRoleHistId)
-                    .HasColumnName("_USER_ROLE_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_USER_ROLE_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.RoleId).HasColumnName("ROLE_ID");
-
-                entity.Property(e => e.UserId).HasColumnName("USER_ID");
-
-                entity.Property(e => e.UserRoleId).HasColumnName("USER_ROLE_ID");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsWorkflowModel>(entity =>
@@ -11939,83 +3371,23 @@ namespace Pims.Dal
                 entity.HasKey(e => e.WorkflowModelId)
                     .HasName("WFLMDL_PK");
 
-                entity.ToTable("PIMS_WORKFLOW_MODEL");
+                entity.Property(e => e.WorkflowModelId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_WORKFLOW_MODEL_ID_SEQ])");
 
-                entity.HasIndex(e => e.WorkflowModelTypeCode, "WFLMDL_WORKFLOW_MODEL_TYPE_CODE_IDX");
+                entity.Property(e => e.AppCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.WorkflowModelId)
-                    .HasColumnName("WORKFLOW_MODEL_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_WORKFLOW_MODEL_ID_SEQ])");
+                entity.Property(e => e.AppLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-
-                entity.Property(e => e.WorkflowModelTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("WORKFLOW_MODEL_TYPE_CODE");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
 
                 entity.HasOne(d => d.WorkflowModelTypeCodeNavigation)
                     .WithMany(p => p.PimsWorkflowModels)
@@ -12029,84 +3401,9 @@ namespace Pims.Dal
                 entity.HasKey(e => e.WorkflowModelHistId)
                     .HasName("PIMS_WFLMDL_H_PK");
 
-                entity.ToTable("PIMS_WORKFLOW_MODEL_HIST");
+                entity.Property(e => e.WorkflowModelHistId).HasDefaultValueSql("(NEXT VALUE FOR [PIMS_WORKFLOW_MODEL_H_ID_SEQ])");
 
-                entity.HasIndex(e => new { e.WorkflowModelHistId, e.EndDateHist }, "PIMS_WFLMDL_H_UK")
-                    .IsUnique();
-
-                entity.Property(e => e.WorkflowModelHistId)
-                    .HasColumnName("_WORKFLOW_MODEL_HIST_ID")
-                    .HasDefaultValueSql("(NEXT VALUE FOR [PIMS_WORKFLOW_MODEL_H_ID_SEQ])");
-
-                entity.Property(e => e.AppCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.AppCreateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppCreateUserGuid).HasColumnName("APP_CREATE_USER_GUID");
-
-                entity.Property(e => e.AppCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_CREATE_USERID");
-
-                entity.Property(e => e.AppLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("APP_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.AppLastUpdateUserDirectory)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USER_DIRECTORY");
-
-                entity.Property(e => e.AppLastUpdateUserGuid).HasColumnName("APP_LAST_UPDATE_USER_GUID");
-
-                entity.Property(e => e.AppLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("APP_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.ConcurrencyControlNumber).HasColumnName("CONCURRENCY_CONTROL_NUMBER");
-
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP");
-
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID");
-
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID");
-
-                entity.Property(e => e.EffectiveDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("EFFECTIVE_DATE_HIST")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.EndDateHist)
-                    .HasColumnType("datetime")
-                    .HasColumnName("END_DATE_HIST");
-
-                entity.Property(e => e.IsDisabled).HasColumnName("IS_DISABLED");
-
-                entity.Property(e => e.WorkflowModelId).HasColumnName("WORKFLOW_MODEL_ID");
-
-                entity.Property(e => e.WorkflowModelTypeCode)
-                    .IsRequired()
-                    .HasMaxLength(20)
-                    .HasColumnName("WORKFLOW_MODEL_TYPE_CODE");
+                entity.Property(e => e.EffectiveDateHist).HasDefaultValueSql("(getutcdate())");
             });
 
             modelBuilder.Entity<PimsWorkflowModelType>(entity =>
@@ -12114,70 +3411,17 @@ namespace Pims.Dal
                 entity.HasKey(e => e.WorkflowModelTypeCode)
                     .HasName("WFLMDT_PK");
 
-                entity.ToTable("PIMS_WORKFLOW_MODEL_TYPE");
+                entity.Property(e => e.ConcurrencyControlNumber).HasDefaultValueSql("((1))");
 
-                entity.Property(e => e.WorkflowModelTypeCode)
-                    .HasMaxLength(20)
-                    .HasColumnName("WORKFLOW_MODEL_TYPE_CODE");
+                entity.Property(e => e.DbCreateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.ConcurrencyControlNumber)
-                    .HasColumnName("CONCURRENCY_CONTROL_NUMBER")
-                    .HasDefaultValueSql("((1))");
+                entity.Property(e => e.DbCreateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbCreateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_CREATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
+                entity.Property(e => e.DbLastUpdateTimestamp).HasDefaultValueSql("(getutcdate())");
 
-                entity.Property(e => e.DbCreateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_CREATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
+                entity.Property(e => e.DbLastUpdateUserid).HasDefaultValueSql("(user_name())");
 
-                entity.Property(e => e.DbLastUpdateTimestamp)
-                    .HasColumnType("datetime")
-                    .HasColumnName("DB_LAST_UPDATE_TIMESTAMP")
-                    .HasDefaultValueSql("(getutcdate())");
-
-                entity.Property(e => e.DbLastUpdateUserid)
-                    .IsRequired()
-                    .HasMaxLength(30)
-                    .HasColumnName("DB_LAST_UPDATE_USERID")
-                    .HasDefaultValueSql("(user_name())");
-
-                entity.Property(e => e.Description)
-                    .IsRequired()
-                    .HasMaxLength(200)
-                    .HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.DisplayOrder).HasColumnName("DISPLAY_ORDER");
-
-                entity.Property(e => e.IsDisabled)
-                    .IsRequired()
-                    .HasColumnName("IS_DISABLED")
-                    .HasDefaultValueSql("(CONVERT([bit],(0)))");
-            });
-
-            modelBuilder.Entity<PimsxTableDefinition>(entity =>
-            {
-                entity.HasNoKey();
-
-                entity.ToTable("PIMSX_TableDefinitions");
-
-                entity.Property(e => e.Description).HasColumnName("DESCRIPTION");
-
-                entity.Property(e => e.HistRequired)
-                    .HasMaxLength(1)
-                    .HasColumnName("HIST_REQUIRED");
-
-                entity.Property(e => e.TableAlias)
-                    .HasMaxLength(255)
-                    .HasColumnName("TABLE_ALIAS");
-
-                entity.Property(e => e.TableName)
-                    .HasMaxLength(255)
-                    .HasColumnName("TABLE_NAME");
+                entity.Property(e => e.IsDisabled).HasDefaultValueSql("(CONVERT([bit],(0)))");
             });
 
             modelBuilder.HasSequence("PIMS_ACCESS_REQUEST_H_ID_SEQ")

--- a/backend/dal/PIMSContext.cs
+++ b/backend/dal/PIMSContext.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
+﻿using Microsoft.EntityFrameworkCore;
 using Pims.Dal.Entities;
 
 #nullable disable

--- a/backend/dal/Services/LeaseService.cs
+++ b/backend/dal/Services/LeaseService.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Security.Claims;
 using MapsterMapper;

--- a/backend/entities/AccessRequestOrganization.cs
+++ b/backend/entities/AccessRequestOrganization.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Pims.Dal.Entities
 {

--- a/backend/entities/Workflow.cs
+++ b/backend/entities/Workflow.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations.Schema;
 namespace Pims.Dal.Entities
 {
     /// <summary>

--- a/backend/entities/ef/PimsAccessRequest.cs
+++ b/backend/entities/ef/PimsAccessRequest.cs
@@ -1,10 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ACCESS_REQUEST")]
+    [Index(nameof(AccessRequestStatusTypeCode), Name = "ACRQST_ACCESS_REQUEST_STATUS_TYPE_CODE_IDX")]
+    [Index(nameof(RoleId), Name = "ACRQST_ROLE_ID_IDX")]
+    [Index(nameof(UserId), Name = "ACRQST_USER_ID_IDX")]
     public partial class PimsAccessRequest
     {
         public PimsAccessRequest()
@@ -12,28 +19,68 @@ namespace Pims.Dal.Entities
             PimsAccessRequestOrganizations = new HashSet<PimsAccessRequestOrganization>();
         }
 
+        [Key]
+        [Column("ACCESS_REQUEST_ID")]
         public long AccessRequestId { get; set; }
+        [Column("USER_ID")]
         public long UserId { get; set; }
+        [Column("ROLE_ID")]
         public long? RoleId { get; set; }
+        [Required]
+        [Column("ACCESS_REQUEST_STATUS_TYPE_CODE")]
+        [StringLength(20)]
         public string AccessRequestStatusTypeCode { get; set; }
+        [Column("NOTE")]
         public string Note { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(AccessRequestStatusTypeCode))]
+        [InverseProperty(nameof(PimsAccessRequestStatusType.PimsAccessRequests))]
         public virtual PimsAccessRequestStatusType AccessRequestStatusTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(RoleId))]
+        [InverseProperty(nameof(PimsRole.PimsAccessRequests))]
         public virtual PimsRole Role { get; set; }
+        [ForeignKey(nameof(UserId))]
+        [InverseProperty(nameof(PimsUser.PimsAccessRequests))]
         public virtual PimsUser User { get; set; }
+        [InverseProperty(nameof(PimsAccessRequestOrganization.AccessRequest))]
         public virtual ICollection<PimsAccessRequestOrganization> PimsAccessRequestOrganizations { get; set; }
     }
 }

--- a/backend/entities/ef/PimsAccessRequestHist.cs
+++ b/backend/entities/ef/PimsAccessRequestHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsAccessRequestHist.cs
+++ b/backend/entities/ef/PimsAccessRequestHist.cs
@@ -1,30 +1,71 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ACCESS_REQUEST_HIST")]
+    [Index(nameof(AccessRequestHistId), nameof(EndDateHist), Name = "PIMS_ACRQST_H_UK", IsUnique = true)]
     public partial class PimsAccessRequestHist
     {
+        [Key]
+        [Column("_ACCESS_REQUEST_HIST_ID")]
         public long AccessRequestHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("ACCESS_REQUEST_ID")]
         public long AccessRequestId { get; set; }
+        [Column("USER_ID")]
         public long UserId { get; set; }
+        [Column("ROLE_ID")]
         public long? RoleId { get; set; }
+        [Required]
+        [Column("ACCESS_REQUEST_STATUS_TYPE_CODE")]
+        [StringLength(20)]
         public string AccessRequestStatusTypeCode { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsAccessRequestOrganization.cs
+++ b/backend/entities/ef/PimsAccessRequestOrganization.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsAccessRequestOrganization.cs
+++ b/backend/entities/ef/PimsAccessRequestOrganization.cs
@@ -1,30 +1,72 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ACCESS_REQUEST_ORGANIZATION")]
+    [Index(nameof(AccessRequestId), Name = "ACRQOR_ACCESS_REQUEST_ID_IDX")]
+    [Index(nameof(OrganizationId), nameof(AccessRequestId), Name = "ACRQOR_ORGANIZATION_ACCESS_REQUEST_TUC", IsUnique = true)]
+    [Index(nameof(OrganizationId), Name = "ACRQOR_ORGANIZATION_ID_IDX")]
     public partial class PimsAccessRequestOrganization
     {
+        [Key]
+        [Column("ACCESS_REQUEST_ORGANIZATION_ID")]
         public long AccessRequestOrganizationId { get; set; }
+        [Column("ORGANIZATION_ID")]
         public long? OrganizationId { get; set; }
+        [Column("ACCESS_REQUEST_ID")]
         public long AccessRequestId { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(AccessRequestId))]
+        [InverseProperty(nameof(PimsAccessRequest.PimsAccessRequestOrganizations))]
         public virtual PimsAccessRequest AccessRequest { get; set; }
+        [ForeignKey(nameof(OrganizationId))]
+        [InverseProperty(nameof(PimsOrganization.PimsAccessRequestOrganizations))]
         public virtual PimsOrganization Organization { get; set; }
     }
 }

--- a/backend/entities/ef/PimsAccessRequestOrganizationHist.cs
+++ b/backend/entities/ef/PimsAccessRequestOrganizationHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsAccessRequestOrganizationHist.cs
+++ b/backend/entities/ef/PimsAccessRequestOrganizationHist.cs
@@ -1,30 +1,69 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ACCESS_REQUEST_ORGANIZATION_HIST")]
+    [Index(nameof(AccessRequestOrganizationHistId), nameof(EndDateHist), Name = "PIMS_ACRQOR_H_UK", IsUnique = true)]
     public partial class PimsAccessRequestOrganizationHist
     {
+        [Key]
+        [Column("_ACCESS_REQUEST_ORGANIZATION_HIST_ID")]
         public long AccessRequestOrganizationHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("ACCESS_REQUEST_ORGANIZATION_ID")]
         public long AccessRequestOrganizationId { get; set; }
+        [Column("ORGANIZATION_ID")]
         public long? OrganizationId { get; set; }
+        [Column("ACCESS_REQUEST_ID")]
         public long AccessRequestId { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsAccessRequestStatusType.cs
+++ b/backend/entities/ef/PimsAccessRequestStatusType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ACCESS_REQUEST_STATUS_TYPE")]
     public partial class PimsAccessRequestStatusType
     {
         public PimsAccessRequestStatusType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsAccessRequests = new HashSet<PimsAccessRequest>();
         }
 
+        [Key]
+        [Column("ACCESS_REQUEST_STATUS_TYPE_CODE")]
+        [StringLength(20)]
         public string AccessRequestStatusTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsAccessRequest.AccessRequestStatusTypeCodeNavigation))]
         public virtual ICollection<PimsAccessRequest> PimsAccessRequests { get; set; }
     }
 }

--- a/backend/entities/ef/PimsActivity.cs
+++ b/backend/entities/ef/PimsActivity.cs
@@ -1,10 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ACTIVITY")]
+    [Index(nameof(ActivityModelId), Name = "ACTVTY_ACTIVITY_MODEL_ID_IDX")]
+    [Index(nameof(ProjectId), Name = "ACTVTY_PROJECT_ID_IDX")]
+    [Index(nameof(WorkflowId), Name = "ACTVTY_WORKFLOW_ID_IDX")]
     public partial class PimsActivity
     {
         public PimsActivity()
@@ -13,28 +20,66 @@ namespace Pims.Dal.Entities
             PimsTasks = new HashSet<PimsTask>();
         }
 
+        [Key]
+        [Column("ACTIVITY_ID")]
         public long ActivityId { get; set; }
+        [Column("PROJECT_ID")]
         public long? ProjectId { get; set; }
+        [Column("WORKFLOW_ID")]
         public long? WorkflowId { get; set; }
+        [Column("ACTIVITY_MODEL_ID")]
         public long ActivityModelId { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(ActivityModelId))]
+        [InverseProperty(nameof(PimsActivityModel.PimsActivities))]
         public virtual PimsActivityModel ActivityModel { get; set; }
+        [ForeignKey(nameof(ProjectId))]
+        [InverseProperty(nameof(PimsProject.PimsActivities))]
         public virtual PimsProject Project { get; set; }
+        [ForeignKey(nameof(WorkflowId))]
+        [InverseProperty(nameof(PimsProjectWorkflowModel.PimsActivities))]
         public virtual PimsProjectWorkflowModel Workflow { get; set; }
+        [InverseProperty(nameof(PimsPropertyActivity.Activity))]
         public virtual ICollection<PimsPropertyActivity> PimsPropertyActivities { get; set; }
+        [InverseProperty(nameof(PimsTask.Activity))]
         public virtual ICollection<PimsTask> PimsTasks { get; set; }
     }
 }

--- a/backend/entities/ef/PimsActivityHist.cs
+++ b/backend/entities/ef/PimsActivityHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsActivityHist.cs
+++ b/backend/entities/ef/PimsActivityHist.cs
@@ -1,30 +1,69 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ACTIVITY_HIST")]
+    [Index(nameof(ActivityHistId), nameof(EndDateHist), Name = "PIMS_ACTVTY_H_UK", IsUnique = true)]
     public partial class PimsActivityHist
     {
+        [Key]
+        [Column("_ACTIVITY_HIST_ID")]
         public long ActivityHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("ACTIVITY_ID")]
         public long ActivityId { get; set; }
+        [Column("PROJECT_ID")]
         public long? ProjectId { get; set; }
+        [Column("WORKFLOW_ID")]
         public long? WorkflowId { get; set; }
+        [Column("ACTIVITY_MODEL_ID")]
         public long ActivityModelId { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsActivityModel.cs
+++ b/backend/entities/ef/PimsActivityModel.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ACTIVITY_MODEL")]
     public partial class PimsActivityModel
     {
         public PimsActivityModel()
@@ -13,24 +17,58 @@ namespace Pims.Dal.Entities
             PimsTaskTemplateActivityModels = new HashSet<PimsTaskTemplateActivityModel>();
         }
 
+        [Key]
+        [Column("ACTIVITY_MODEL_ID")]
         public long ActivityModelId { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsActivity.ActivityModel))]
         public virtual ICollection<PimsActivity> PimsActivities { get; set; }
+        [InverseProperty(nameof(PimsTaskTemplateActivityModel.ActivityModel))]
         public virtual ICollection<PimsTaskTemplateActivityModel> PimsTaskTemplateActivityModels { get; set; }
     }
 }

--- a/backend/entities/ef/PimsActivityModelHist.cs
+++ b/backend/entities/ef/PimsActivityModelHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsActivityModelHist.cs
+++ b/backend/entities/ef/PimsActivityModelHist.cs
@@ -1,29 +1,69 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ACTIVITY_MODEL_HIST")]
+    [Index(nameof(ActivityModelHistId), nameof(EndDateHist), Name = "PIMS_ACTMDL_H_UK", IsUnique = true)]
     public partial class PimsActivityModelHist
     {
+        [Key]
+        [Column("_ACTIVITY_MODEL_HIST_ID")]
         public long ActivityModelHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("ACTIVITY_MODEL_ID")]
         public long ActivityModelId { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Column("IS_DISABLED")]
         public bool IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsAddress.cs
+++ b/backend/entities/ef/PimsAddress.cs
@@ -1,10 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ADDRESS")]
+    [Index(nameof(CountryId), Name = "ADDRSS_COUNTRY_ID_IDX")]
+    [Index(nameof(DistrictCode), Name = "ADDRSS_DISTRICT_CODE_IDX")]
+    [Index(nameof(ProvinceStateId), Name = "ADDRSS_PROVINCE_STATE_ID_IDX")]
+    [Index(nameof(RegionCode), Name = "ADDRSS_REGION_CODE_IDX")]
     public partial class PimsAddress
     {
         public PimsAddress()
@@ -14,40 +22,98 @@ namespace Pims.Dal.Entities
             PimsProperties = new HashSet<PimsProperty>();
         }
 
+        [Key]
+        [Column("ADDRESS_ID")]
         public long AddressId { get; set; }
+        [Column("REGION_CODE")]
         public short? RegionCode { get; set; }
+        [Column("DISTRICT_CODE")]
         public short? DistrictCode { get; set; }
+        [Column("PROVINCE_STATE_ID")]
         public short ProvinceStateId { get; set; }
+        [Column("COUNTRY_ID")]
         public short? CountryId { get; set; }
+        [Column("STREET_ADDRESS_1")]
+        [StringLength(200)]
         public string StreetAddress1 { get; set; }
+        [Column("STREET_ADDRESS_2")]
+        [StringLength(200)]
         public string StreetAddress2 { get; set; }
+        [Column("STREET_ADDRESS_3")]
+        [StringLength(200)]
         public string StreetAddress3 { get; set; }
+        [Column("MUNICIPALITY_NAME")]
+        [StringLength(200)]
         public string MunicipalityName { get; set; }
+        [Column("POSTAL_CODE")]
+        [StringLength(20)]
         public string PostalCode { get; set; }
+        [Column("OTHER_COUNTRY")]
+        [StringLength(200)]
         public string OtherCountry { get; set; }
+        [Column("LATITUDE", TypeName = "numeric(8, 6)")]
         public decimal? Latitude { get; set; }
+        [Column("LONGITUDE", TypeName = "numeric(9, 6)")]
         public decimal? Longitude { get; set; }
+        [Column("COMMENT")]
+        [StringLength(2000)]
         public string Comment { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(CountryId))]
+        [InverseProperty(nameof(PimsCountry.PimsAddresses))]
         public virtual PimsCountry Country { get; set; }
+        [ForeignKey(nameof(DistrictCode))]
+        [InverseProperty(nameof(PimsDistrict.PimsAddresses))]
         public virtual PimsDistrict DistrictCodeNavigation { get; set; }
+        [ForeignKey(nameof(ProvinceStateId))]
+        [InverseProperty(nameof(PimsProvinceState.PimsAddresses))]
         public virtual PimsProvinceState ProvinceState { get; set; }
+        [ForeignKey(nameof(RegionCode))]
+        [InverseProperty(nameof(PimsRegion.PimsAddresses))]
         public virtual PimsRegion RegionCodeNavigation { get; set; }
+        [InverseProperty(nameof(PimsOrganizationAddress.Address))]
         public virtual ICollection<PimsOrganizationAddress> PimsOrganizationAddresses { get; set; }
+        [InverseProperty(nameof(PimsPersonAddress.Address))]
         public virtual ICollection<PimsPersonAddress> PimsPersonAddresses { get; set; }
+        [InverseProperty(nameof(PimsProperty.Address))]
         public virtual ICollection<PimsProperty> PimsProperties { get; set; }
     }
 }

--- a/backend/entities/ef/PimsAddressHist.cs
+++ b/backend/entities/ef/PimsAddressHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsAddressHist.cs
+++ b/backend/entities/ef/PimsAddressHist.cs
@@ -1,40 +1,96 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ADDRESS_HIST")]
+    [Index(nameof(AddressHistId), nameof(EndDateHist), Name = "PIMS_ADDRSS_H_UK", IsUnique = true)]
     public partial class PimsAddressHist
     {
+        [Key]
+        [Column("_ADDRESS_HIST_ID")]
         public long AddressHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("ADDRESS_ID")]
         public long AddressId { get; set; }
+        [Column("REGION_CODE")]
         public short? RegionCode { get; set; }
+        [Column("DISTRICT_CODE")]
         public short? DistrictCode { get; set; }
+        [Column("PROVINCE_STATE_ID")]
         public short ProvinceStateId { get; set; }
+        [Column("COUNTRY_ID")]
         public short? CountryId { get; set; }
+        [Column("STREET_ADDRESS_1")]
+        [StringLength(200)]
         public string StreetAddress1 { get; set; }
+        [Column("STREET_ADDRESS_2")]
+        [StringLength(200)]
         public string StreetAddress2 { get; set; }
+        [Column("STREET_ADDRESS_3")]
+        [StringLength(200)]
         public string StreetAddress3 { get; set; }
+        [Column("MUNICIPALITY_NAME")]
+        [StringLength(200)]
         public string MunicipalityName { get; set; }
+        [Column("POSTAL_CODE")]
+        [StringLength(20)]
         public string PostalCode { get; set; }
+        [Column("OTHER_COUNTRY")]
+        [StringLength(200)]
         public string OtherCountry { get; set; }
+        [Column("LATITUDE", TypeName = "numeric(18, 0)")]
         public decimal? Latitude { get; set; }
+        [Column("LONGITUDE", TypeName = "numeric(18, 0)")]
         public decimal? Longitude { get; set; }
+        [Column("COMMENT")]
+        [StringLength(2000)]
         public string Comment { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsAddressUsageType.cs
+++ b/backend/entities/ef/PimsAddressUsageType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ADDRESS_USAGE_TYPE")]
     public partial class PimsAddressUsageType
     {
         public PimsAddressUsageType()
@@ -13,17 +17,37 @@ namespace Pims.Dal.Entities
             PimsPersonAddresses = new HashSet<PimsPersonAddress>();
         }
 
+        [Key]
+        [Column("ADDRESS_USAGE_TYPE_CODE")]
+        [StringLength(20)]
         public string AddressUsageTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsOrganizationAddress.AddressUsageTypeCodeNavigation))]
         public virtual ICollection<PimsOrganizationAddress> PimsOrganizationAddresses { get; set; }
+        [InverseProperty(nameof(PimsPersonAddress.AddressUsageTypeCodeNavigation))]
         public virtual ICollection<PimsPersonAddress> PimsPersonAddresses { get; set; }
     }
 }

--- a/backend/entities/ef/PimsAreaUnitType.cs
+++ b/backend/entities/ef/PimsAreaUnitType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_AREA_UNIT_TYPE")]
     public partial class PimsAreaUnitType
     {
         public PimsAreaUnitType()
@@ -13,17 +17,37 @@ namespace Pims.Dal.Entities
             PimsPropertyLeases = new HashSet<PimsPropertyLease>();
         }
 
+        [Key]
+        [Column("AREA_UNIT_TYPE_CODE")]
+        [StringLength(20)]
         public string AreaUnitTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsProperty.PropertyAreaUnitTypeCodeNavigation))]
         public virtual ICollection<PimsProperty> PimsProperties { get; set; }
+        [InverseProperty(nameof(PimsPropertyLease.AreaUnitTypeCodeNavigation))]
         public virtual ICollection<PimsPropertyLease> PimsPropertyLeases { get; set; }
     }
 }

--- a/backend/entities/ef/PimsClaim.cs
+++ b/backend/entities/ef/PimsClaim.cs
@@ -1,10 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_CLAIM")]
+    [Index(nameof(ClaimUid), Name = "CLMTYP_CLAIM_UID_IDX")]
+    [Index(nameof(KeycloakRoleId), Name = "CLMTYP_KEYCLOAK_ROLE_ID_IDX")]
     public partial class PimsClaim
     {
         public PimsClaim()
@@ -12,26 +18,64 @@ namespace Pims.Dal.Entities
             PimsRoleClaims = new HashSet<PimsRoleClaim>();
         }
 
+        [Key]
+        [Column("CLAIM_ID")]
         public long ClaimId { get; set; }
+        [Column("CLAIM_UID")]
         public Guid ClaimUid { get; set; }
+        [Column("KEYCLOAK_ROLE_ID")]
         public Guid? KeycloakRoleId { get; set; }
+        [Required]
+        [Column("NAME")]
+        [StringLength(100)]
         public string Name { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(500)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsRoleClaim.Claim))]
         public virtual ICollection<PimsRoleClaim> PimsRoleClaims { get; set; }
     }
 }

--- a/backend/entities/ef/PimsClaimHist.cs
+++ b/backend/entities/ef/PimsClaimHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsClaimHist.cs
+++ b/backend/entities/ef/PimsClaimHist.cs
@@ -1,32 +1,77 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_CLAIM_HIST")]
+    [Index(nameof(ClaimHistId), nameof(EndDateHist), Name = "PIMS_CLMTYP_H_UK", IsUnique = true)]
     public partial class PimsClaimHist
     {
+        [Key]
+        [Column("_CLAIM_HIST_ID")]
         public long ClaimHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("CLAIM_ID")]
         public long ClaimId { get; set; }
+        [Column("CLAIM_UID")]
         public Guid ClaimUid { get; set; }
+        [Column("KEYCLOAK_ROLE_ID")]
         public Guid? KeycloakRoleId { get; set; }
+        [Required]
+        [Column("NAME")]
+        [StringLength(100)]
         public string Name { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(500)]
         public string Description { get; set; }
+        [Column("IS_DISABLED")]
         public bool IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsContactMethod.cs
+++ b/backend/entities/ef/PimsContactMethod.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsContactMethod.cs
+++ b/backend/entities/ef/PimsContactMethod.cs
@@ -1,33 +1,83 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_CONTACT_METHOD")]
+    [Index(nameof(ContactMethodTypeCode), Name = "CNTMTH_CONTACT_METHOD_TYPE_CODE_IDX")]
+    [Index(nameof(OrganizationId), Name = "CNTMTH_ORGANIZATION_ID_IDX")]
+    [Index(nameof(PersonId), Name = "CNTMTH_PERSON_ID_IDX")]
     public partial class PimsContactMethod
     {
+        [Key]
+        [Column("CONTACT_METHOD_ID")]
         public long ContactMethodId { get; set; }
+        [Required]
+        [Column("CONTACT_METHOD_TYPE_CODE")]
+        [StringLength(20)]
         public string ContactMethodTypeCode { get; set; }
+        [Column("PERSON_ID")]
         public long? PersonId { get; set; }
+        [Column("ORGANIZATION_ID")]
         public long? OrganizationId { get; set; }
+        [Required]
+        [Column("CONTACT_METHOD_VALUE")]
+        [StringLength(200)]
         public string ContactMethodValue { get; set; }
+        [Column("IS_PREFERRED_METHOD")]
         public bool? IsPreferredMethod { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(ContactMethodTypeCode))]
+        [InverseProperty(nameof(PimsContactMethodType.PimsContactMethods))]
         public virtual PimsContactMethodType ContactMethodTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(OrganizationId))]
+        [InverseProperty(nameof(PimsOrganization.PimsContactMethods))]
         public virtual PimsOrganization Organization { get; set; }
+        [ForeignKey(nameof(PersonId))]
+        [InverseProperty(nameof(PimsPerson.PimsContactMethods))]
         public virtual PimsPerson Person { get; set; }
     }
 }

--- a/backend/entities/ef/PimsContactMethodHist.cs
+++ b/backend/entities/ef/PimsContactMethodHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsContactMethodHist.cs
+++ b/backend/entities/ef/PimsContactMethodHist.cs
@@ -1,32 +1,77 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_CONTACT_METHOD_HIST")]
+    [Index(nameof(ContactMethodHistId), nameof(EndDateHist), Name = "PIMS_CNTMTH_H_UK", IsUnique = true)]
     public partial class PimsContactMethodHist
     {
+        [Key]
+        [Column("_CONTACT_METHOD_HIST_ID")]
         public long ContactMethodHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("CONTACT_METHOD_ID")]
         public long ContactMethodId { get; set; }
+        [Required]
+        [Column("CONTACT_METHOD_TYPE_CODE")]
+        [StringLength(20)]
         public string ContactMethodTypeCode { get; set; }
+        [Column("PERSON_ID")]
         public long? PersonId { get; set; }
+        [Column("ORGANIZATION_ID")]
         public long? OrganizationId { get; set; }
+        [Required]
+        [Column("CONTACT_METHOD_VALUE")]
+        [StringLength(200)]
         public string ContactMethodValue { get; set; }
+        [Column("IS_PREFERRED_METHOD")]
         public bool? IsPreferredMethod { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsContactMethodType.cs
+++ b/backend/entities/ef/PimsContactMethodType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_CONTACT_METHOD_TYPE")]
     public partial class PimsContactMethodType
     {
         public PimsContactMethodType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsContactMethods = new HashSet<PimsContactMethod>();
         }
 
+        [Key]
+        [Column("CONTACT_METHOD_TYPE_CODE")]
+        [StringLength(20)]
         public string ContactMethodTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsContactMethod.ContactMethodTypeCodeNavigation))]
         public virtual ICollection<PimsContactMethod> PimsContactMethods { get; set; }
     }
 }

--- a/backend/entities/ef/PimsContactMgrVw.cs
+++ b/backend/entities/ef/PimsContactMgrVw.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
+﻿
 #nullable disable
 
 namespace Pims.Dal.Entities

--- a/backend/entities/ef/PimsContactMgrVw.cs
+++ b/backend/entities/ef/PimsContactMgrVw.cs
@@ -1,22 +1,51 @@
-﻿
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Keyless]
     public partial class PimsContactMgrVw
     {
+        [Required]
+        [Column("ID")]
+        [StringLength(25)]
         public string Id { get; set; }
+        [Column("PERSON_ID")]
         public long? PersonId { get; set; }
+        [Column("ORGANIZATION_ID")]
         public long? OrganizationId { get; set; }
+        [Column("IS_DISABLED")]
         public bool IsDisabled { get; set; }
+        [Column("SUMMARY")]
+        [StringLength(302)]
         public string Summary { get; set; }
+        [Column("SURNAME")]
+        [StringLength(50)]
         public string Surname { get; set; }
+        [Column("FIRST_NAME")]
+        [StringLength(50)]
         public string FirstName { get; set; }
+        [Column("MIDDLE_NAMES")]
+        [StringLength(200)]
         public string MiddleNames { get; set; }
+        [Column("ORGANIZATION_NAME")]
+        [StringLength(200)]
         public string OrganizationName { get; set; }
+        [Column("ADDRESS_ID")]
         public long? AddressId { get; set; }
+        [Column("MAILING_ADDRESS")]
+        [StringLength(200)]
         public string MailingAddress { get; set; }
+        [Column("MUNICIPALITY_NAME")]
+        [StringLength(200)]
         public string MunicipalityName { get; set; }
+        [Column("PROVINCE_STATE")]
+        [StringLength(20)]
         public string ProvinceState { get; set; }
     }
 }

--- a/backend/entities/ef/PimsCountry.cs
+++ b/backend/entities/ef/PimsCountry.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_COUNTRY")]
     public partial class PimsCountry
     {
         public PimsCountry()
@@ -13,17 +17,37 @@ namespace Pims.Dal.Entities
             PimsProvinceStates = new HashSet<PimsProvinceState>();
         }
 
+        [Key]
+        [Column("COUNTRY_ID")]
         public short CountryId { get; set; }
+        [Required]
+        [Column("COUNTRY_CODE")]
+        [StringLength(20)]
         public string CountryCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsAddress.Country))]
         public virtual ICollection<PimsAddress> PimsAddresses { get; set; }
+        [InverseProperty(nameof(PimsProvinceState.Country))]
         public virtual ICollection<PimsProvinceState> PimsProvinceStates { get; set; }
     }
 }

--- a/backend/entities/ef/PimsDataSourceType.cs
+++ b/backend/entities/ef/PimsDataSourceType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_DATA_SOURCE_TYPE")]
     public partial class PimsDataSourceType
     {
         public PimsDataSourceType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsProperties = new HashSet<PimsProperty>();
         }
 
+        [Key]
+        [Column("DATA_SOURCE_TYPE_CODE")]
+        [StringLength(20)]
         public string DataSourceTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsProperty.PropertyDataSourceTypeCodeNavigation))]
         public virtual ICollection<PimsProperty> PimsProperties { get; set; }
     }
 }

--- a/backend/entities/ef/PimsDistrict.cs
+++ b/backend/entities/ef/PimsDistrict.cs
@@ -1,10 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_DISTRICT")]
+    [Index(nameof(RegionCode), Name = "DSTRCT_REGION_CODE_IDX")]
     public partial class PimsDistrict
     {
         public PimsDistrict()
@@ -14,20 +19,43 @@ namespace Pims.Dal.Entities
             PimsProperties = new HashSet<PimsProperty>();
         }
 
+        [Key]
+        [Column("DISTRICT_CODE")]
         public short DistrictCode { get; set; }
+        [Column("REGION_CODE")]
         public short RegionCode { get; set; }
+        [Required]
+        [Column("DISTRICT_NAME")]
+        [StringLength(200)]
         public string DistrictName { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(RegionCode))]
+        [InverseProperty(nameof(PimsRegion.PimsDistricts))]
         public virtual PimsRegion RegionCodeNavigation { get; set; }
+        [InverseProperty(nameof(PimsAddress.DistrictCodeNavigation))]
         public virtual ICollection<PimsAddress> PimsAddresses { get; set; }
+        [InverseProperty(nameof(PimsOrganization.DistrictCodeNavigation))]
         public virtual ICollection<PimsOrganization> PimsOrganizations { get; set; }
+        [InverseProperty(nameof(PimsProperty.DistrictCodeNavigation))]
         public virtual ICollection<PimsProperty> PimsProperties { get; set; }
     }
 }

--- a/backend/entities/ef/PimsInsurance.cs
+++ b/backend/entities/ef/PimsInsurance.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsInsurance.cs
+++ b/backend/entities/ef/PimsInsurance.cs
@@ -1,46 +1,119 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_INSURANCE")]
+    [Index(nameof(BctfaRiskMgmtContactId), Name = "INSRNC_BCTFA_RISK_MGMT_CONTACT_ID_IDX")]
+    [Index(nameof(InsurancePayeeTypeCode), Name = "INSRNC_INSURANCE_PAYEE_TYPE_CODE_IDX")]
+    [Index(nameof(InsuranceTypeCode), Name = "INSRNC_INSURANCE_TYPE_CODE_IDX")]
+    [Index(nameof(InsurerContactId), Name = "INSRNC_INSURER_CONTACT_ID_IDX")]
+    [Index(nameof(InsurerOrgId), Name = "INSRNC_INSURER_ORG_ID_IDX")]
+    [Index(nameof(LeaseId), Name = "INSRNC_LEASE_ID_IDX")]
+    [Index(nameof(MotiRiskMgmtContactId), Name = "INSRNC_MOTI_RISK_MGMT_CONTACT_ID_IDX")]
     public partial class PimsInsurance
     {
+        [Key]
+        [Column("INSURANCE_ID")]
         public long InsuranceId { get; set; }
+        [Column("LEASE_ID")]
         public long LeaseId { get; set; }
+        [Required]
+        [Column("INSURANCE_TYPE_CODE")]
+        [StringLength(20)]
         public string InsuranceTypeCode { get; set; }
+        [Column("INSURER_ORG_ID")]
         public long InsurerOrgId { get; set; }
+        [Column("INSURER_CONTACT_ID")]
         public long InsurerContactId { get; set; }
+        [Column("MOTI_RISK_MGMT_CONTACT_ID")]
         public long MotiRiskMgmtContactId { get; set; }
+        [Column("BCTFA_RISK_MGMT_CONTACT_ID")]
         public long BctfaRiskMgmtContactId { get; set; }
+        [Required]
+        [Column("INSURANCE_PAYEE_TYPE_CODE")]
+        [StringLength(20)]
         public string InsurancePayeeTypeCode { get; set; }
+        [Column("OTHER_INSURANCE_TYPE")]
+        [StringLength(200)]
         public string OtherInsuranceType { get; set; }
+        [Column("COVERAGE_DESCRIPTION")]
+        [StringLength(2000)]
         public string CoverageDescription { get; set; }
+        [Column("COVERAGE_LIMIT", TypeName = "money")]
         public decimal CoverageLimit { get; set; }
+        [Column("INSURED_VALUE", TypeName = "money")]
         public decimal InsuredValue { get; set; }
+        [Column("START_DATE", TypeName = "date")]
         public DateTime StartDate { get; set; }
+        [Column("EXPIRY_DATE", TypeName = "date")]
         public DateTime ExpiryDate { get; set; }
+        [Column("RISK ASSESSMENT_COMPLETED_DATE", TypeName = "datetime")]
         public DateTime? RiskAssessmentCompletedDate { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(BctfaRiskMgmtContactId))]
+        [InverseProperty(nameof(PimsPerson.PimsInsuranceBctfaRiskMgmtContacts))]
         public virtual PimsPerson BctfaRiskMgmtContact { get; set; }
+        [ForeignKey(nameof(InsurancePayeeTypeCode))]
+        [InverseProperty(nameof(PimsInsurancePayeeType.PimsInsurances))]
         public virtual PimsInsurancePayeeType InsurancePayeeTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(InsuranceTypeCode))]
+        [InverseProperty(nameof(PimsInsuranceType.PimsInsurances))]
         public virtual PimsInsuranceType InsuranceTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(InsurerContactId))]
+        [InverseProperty(nameof(PimsPerson.PimsInsuranceInsurerContacts))]
         public virtual PimsPerson InsurerContact { get; set; }
+        [ForeignKey(nameof(InsurerOrgId))]
+        [InverseProperty(nameof(PimsOrganization.PimsInsurances))]
         public virtual PimsOrganization InsurerOrg { get; set; }
+        [ForeignKey(nameof(LeaseId))]
+        [InverseProperty(nameof(PimsLease.PimsInsurances))]
         public virtual PimsLease Lease { get; set; }
+        [ForeignKey(nameof(MotiRiskMgmtContactId))]
+        [InverseProperty(nameof(PimsPerson.PimsInsuranceMotiRiskMgmtContacts))]
         public virtual PimsPerson MotiRiskMgmtContact { get; set; }
     }
 }

--- a/backend/entities/ef/PimsInsuranceHist.cs
+++ b/backend/entities/ef/PimsInsuranceHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsInsuranceHist.cs
+++ b/backend/entities/ef/PimsInsuranceHist.cs
@@ -1,41 +1,97 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_INSURANCE_HIST")]
+    [Index(nameof(InsuranceHistId), nameof(EndDateHist), Name = "PIMS_INSRNC_H_UK", IsUnique = true)]
     public partial class PimsInsuranceHist
     {
+        [Key]
+        [Column("_INSURANCE_HIST_ID")]
         public long InsuranceHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("INSURANCE_ID")]
         public long InsuranceId { get; set; }
+        [Column("LEASE_ID")]
         public long LeaseId { get; set; }
+        [Required]
+        [Column("INSURANCE_TYPE_CODE")]
+        [StringLength(20)]
         public string InsuranceTypeCode { get; set; }
+        [Column("INSURER_ORG_ID")]
         public long InsurerOrgId { get; set; }
+        [Column("INSURER_CONTACT_ID")]
         public long InsurerContactId { get; set; }
+        [Column("MOTI_RISK_MGMT_CONTACT_ID")]
         public long MotiRiskMgmtContactId { get; set; }
+        [Column("BCTFA_RISK_MGMT_CONTACT_ID")]
         public long BctfaRiskMgmtContactId { get; set; }
+        [Required]
+        [Column("INSURANCE_PAYEE_TYPE_CODE")]
+        [StringLength(20)]
         public string InsurancePayeeTypeCode { get; set; }
+        [Column("OTHER_INSURANCE_TYPE")]
+        [StringLength(200)]
         public string OtherInsuranceType { get; set; }
+        [Column("COVERAGE_DESCRIPTION")]
+        [StringLength(2000)]
         public string CoverageDescription { get; set; }
+        [Column("COVERAGE_LIMIT", TypeName = "money")]
         public decimal CoverageLimit { get; set; }
+        [Column("INSURED_VALUE", TypeName = "money")]
         public decimal InsuredValue { get; set; }
+        [Column("START_DATE", TypeName = "date")]
         public DateTime StartDate { get; set; }
+        [Column("EXPIRY_DATE", TypeName = "date")]
         public DateTime ExpiryDate { get; set; }
+        [Column("RISK ASSESSMENT_COMPLETED_DATE", TypeName = "datetime")]
         public DateTime? RiskAssessmentCompletedDate { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsInsurancePayeeType.cs
+++ b/backend/entities/ef/PimsInsurancePayeeType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_INSURANCE_PAYEE_TYPE")]
     public partial class PimsInsurancePayeeType
     {
         public PimsInsurancePayeeType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsInsurances = new HashSet<PimsInsurance>();
         }
 
+        [Key]
+        [Column("INSURANCE_PAYEE_TYPE_CODE")]
+        [StringLength(20)]
         public string InsurancePayeeTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsInsurance.InsurancePayeeTypeCodeNavigation))]
         public virtual ICollection<PimsInsurance> PimsInsurances { get; set; }
     }
 }

--- a/backend/entities/ef/PimsInsuranceType.cs
+++ b/backend/entities/ef/PimsInsuranceType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_INSURANCE_TYPE")]
     public partial class PimsInsuranceType
     {
         public PimsInsuranceType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsInsurances = new HashSet<PimsInsurance>();
         }
 
+        [Key]
+        [Column("INSURANCE_TYPE_CODE")]
+        [StringLength(20)]
         public string InsuranceTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsInsurance.InsuranceTypeCodeNavigation))]
         public virtual ICollection<PimsInsurance> PimsInsurances { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLease.cs
+++ b/backend/entities/ef/PimsLease.cs
@@ -1,10 +1,26 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE")]
+    [Index(nameof(LeaseCategoryTypeCode), Name = "LEASE_LEASE_CATEGORY_TYPE_CODE_IDX")]
+    [Index(nameof(LeaseInitiatorTypeCode), Name = "LEASE_LEASE_INITIATOR_TYPE_CODE_IDX")]
+    [Index(nameof(LeaseLicenseTypeCode), Name = "LEASE_LEASE_LICENSE_TYPE_CODE_IDX")]
+    [Index(nameof(LeasePayRvblTypeCode), Name = "LEASE_LEASE_PAY_RVBL_TYPE_CODE_IDX")]
+    [Index(nameof(LeasePmtFreqTypeCode), Name = "LEASE_LEASE_PMT_FREQ_TYPE_CODE_IDX")]
+    [Index(nameof(LeaseProgramTypeCode), Name = "LEASE_LEASE_PROGRAM_TYPE_CODE_IDX")]
+    [Index(nameof(LeasePurposeTypeCode), Name = "LEASE_LEASE_PURPOSE_TYPE_CODE_IDX")]
+    [Index(nameof(LeaseResponsibilityTypeCode), Name = "LEASE_LEASE_RESPONSIBILITY_TYPE_CODE_IDX")]
+    [Index(nameof(LeaseStatusTypeCode), Name = "LEASE_LEASE_STATUS_TYPE_CODE_IDX")]
+    [Index(nameof(LFileNo), Name = "LEASE_L_FILE_NO_IDX")]
+    [Index(nameof(PsFileNo), Name = "LEASE_PS_FILE_NO_IDX")]
+    [Index(nameof(TfaFileNo), Name = "LEASE_TFA_FILE_NO_IDX")]
     public partial class PimsLease
     {
         public PimsLease()
@@ -18,73 +34,195 @@ namespace Pims.Dal.Entities
             PimsSecurityDeposits = new HashSet<PimsSecurityDeposit>();
         }
 
+        [Key]
+        [Column("LEASE_ID")]
         public long LeaseId { get; set; }
+        [Required]
+        [Column("LEASE_PAY_RVBL_TYPE_CODE")]
+        [StringLength(20)]
         public string LeasePayRvblTypeCode { get; set; }
+        [Required]
+        [Column("LEASE_LICENSE_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseLicenseTypeCode { get; set; }
+        [Required]
+        [Column("LEASE_CATEGORY_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseCategoryTypeCode { get; set; }
+        [Required]
+        [Column("LEASE_PURPOSE_TYPE_CODE")]
+        [StringLength(20)]
         public string LeasePurposeTypeCode { get; set; }
+        [Required]
+        [Column("LEASE_PROGRAM_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseProgramTypeCode { get; set; }
+        [Required]
+        [Column("LEASE_INITIATOR_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseInitiatorTypeCode { get; set; }
+        [Required]
+        [Column("LEASE_RESPONSIBILITY_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseResponsibilityTypeCode { get; set; }
+        [Required]
+        [Column("LEASE_PMT_FREQ_TYPE_CODE")]
+        [StringLength(20)]
         public string LeasePmtFreqTypeCode { get; set; }
+        [Required]
+        [Column("LEASE_STATUS_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseStatusTypeCode { get; set; }
+        [Column("L_FILE_NO")]
+        [StringLength(50)]
         public string LFileNo { get; set; }
+        [Column("TFA_FILE_NO")]
         public int? TfaFileNo { get; set; }
+        [Column("PS_FILE_NO")]
+        [StringLength(50)]
         public string PsFileNo { get; set; }
+        [Column("LEASE_DESCRIPTION")]
         public string LeaseDescription { get; set; }
+        [Column("LEASE_CATEGORY_OTHER_DESC")]
+        [StringLength(200)]
         public string LeaseCategoryOtherDesc { get; set; }
+        [Column("LEASE_PURPOSE_OTHER_DESC")]
+        [StringLength(200)]
         public string LeasePurposeOtherDesc { get; set; }
+        [Column("LEASE_NOTES")]
         public string LeaseNotes { get; set; }
+        [Column("MOTI_CONTACT")]
+        [StringLength(200)]
         public string MotiContact { get; set; }
+        [Column("MOTI_REGION")]
+        [StringLength(200)]
         public string MotiRegion { get; set; }
+        [Column("DOCUMENTATION_REFERENCE")]
+        [StringLength(500)]
         public string DocumentationReference { get; set; }
+        [Column("RETURN_NOTES")]
         public string ReturnNotes { get; set; }
+        [Column("OTHER_LEASE_PROGRAM_TYPE")]
+        [StringLength(200)]
         public string OtherLeaseProgramType { get; set; }
+        [Column("OTHER_LEASE_LICENSE_TYPE")]
+        [StringLength(200)]
         public string OtherLeaseLicenseType { get; set; }
+        [Column("OTHER_LEASE_PURPOSE_TYPE")]
+        [StringLength(200)]
         public string OtherLeasePurposeType { get; set; }
+        [Column("ORIG_START_DATE", TypeName = "datetime")]
         public DateTime OrigStartDate { get; set; }
+        [Column("ORIG_EXPIRY_DATE", TypeName = "datetime")]
         public DateTime? OrigExpiryDate { get; set; }
+        [Column("LEASE_AMOUNT", TypeName = "money")]
         public decimal? LeaseAmount { get; set; }
+        [Column("RESPONSIBILITY_EFFECTIVE_DATE", TypeName = "datetime")]
         public DateTime? ResponsibilityEffectiveDate { get; set; }
+        [Column("INSPECTION_DATE", TypeName = "datetime")]
         public DateTime? InspectionDate { get; set; }
+        [Column("INSPECTION_NOTES")]
         public string InspectionNotes { get; set; }
+        [Column("IS_SUBJECT_TO_RTA")]
         public bool? IsSubjectToRta { get; set; }
+        [Column("IS_COMM_BLDG")]
         public bool? IsCommBldg { get; set; }
+        [Column("IS_OTHER_IMPROVEMENT")]
         public bool? IsOtherImprovement { get; set; }
+        [Required]
+        [Column("IS_EXPIRED")]
         public bool? IsExpired { get; set; }
+        [Required]
+        [Column("HAS_PHYSICAL_FILE")]
         public bool? HasPhysicalFile { get; set; }
+        [Required]
+        [Column("HAS_DIGITAL_FILE")]
         public bool? HasDigitalFile { get; set; }
+        [Required]
+        [Column("HAS_PHYSICIAL_LICENSE")]
         public bool? HasPhysicialLicense { get; set; }
+        [Required]
+        [Column("HAS_DIGITAL_LICENSE")]
         public bool? HasDigitalLicense { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(LeaseCategoryTypeCode))]
+        [InverseProperty(nameof(PimsLeaseCategoryType.PimsLeases))]
         public virtual PimsLeaseCategoryType LeaseCategoryTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(LeaseInitiatorTypeCode))]
+        [InverseProperty(nameof(PimsLeaseInitiatorType.PimsLeases))]
         public virtual PimsLeaseInitiatorType LeaseInitiatorTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(LeaseLicenseTypeCode))]
+        [InverseProperty(nameof(PimsLeaseLicenseType.PimsLeases))]
         public virtual PimsLeaseLicenseType LeaseLicenseTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(LeasePayRvblTypeCode))]
+        [InverseProperty(nameof(PimsLeasePayRvblType.PimsLeases))]
         public virtual PimsLeasePayRvblType LeasePayRvblTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(LeasePmtFreqTypeCode))]
+        [InverseProperty(nameof(PimsLeasePmtFreqType.PimsLeases))]
         public virtual PimsLeasePmtFreqType LeasePmtFreqTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(LeaseProgramTypeCode))]
+        [InverseProperty(nameof(PimsLeaseProgramType.PimsLeases))]
         public virtual PimsLeaseProgramType LeaseProgramTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(LeasePurposeTypeCode))]
+        [InverseProperty(nameof(PimsLeasePurposeType.PimsLeases))]
         public virtual PimsLeasePurposeType LeasePurposeTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(LeaseResponsibilityTypeCode))]
+        [InverseProperty(nameof(PimsLeaseResponsibilityType.PimsLeases))]
         public virtual PimsLeaseResponsibilityType LeaseResponsibilityTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(LeaseStatusTypeCode))]
+        [InverseProperty(nameof(PimsLeaseStatusType.PimsLeases))]
         public virtual PimsLeaseStatusType LeaseStatusTypeCodeNavigation { get; set; }
+        [InverseProperty(nameof(PimsInsurance.Lease))]
         public virtual ICollection<PimsInsurance> PimsInsurances { get; set; }
+        [InverseProperty(nameof(PimsLeaseTenant.Lease))]
         public virtual ICollection<PimsLeaseTenant> PimsLeaseTenants { get; set; }
+        [InverseProperty(nameof(PimsLeaseTerm.Lease))]
         public virtual ICollection<PimsLeaseTerm> PimsLeaseTerms { get; set; }
+        [InverseProperty(nameof(PimsPropertyImprovement.Lease))]
         public virtual ICollection<PimsPropertyImprovement> PimsPropertyImprovements { get; set; }
+        [InverseProperty(nameof(PimsPropertyLease.Lease))]
         public virtual ICollection<PimsPropertyLease> PimsPropertyLeases { get; set; }
+        [InverseProperty(nameof(PimsSecurityDepositReturn.Lease))]
         public virtual ICollection<PimsSecurityDepositReturn> PimsSecurityDepositReturns { get; set; }
+        [InverseProperty(nameof(PimsSecurityDeposit.Lease))]
         public virtual ICollection<PimsSecurityDeposit> PimsSecurityDeposits { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeaseCategoryType.cs
+++ b/backend/entities/ef/PimsLeaseCategoryType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_CATEGORY_TYPE")]
     public partial class PimsLeaseCategoryType
     {
         public PimsLeaseCategoryType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsLeases = new HashSet<PimsLease>();
         }
 
+        [Key]
+        [Column("LEASE_CATEGORY_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseCategoryTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsLease.LeaseCategoryTypeCodeNavigation))]
         public virtual ICollection<PimsLease> PimsLeases { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeaseHist.cs
+++ b/backend/entities/ef/PimsLeaseHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsLeaseHist.cs
+++ b/backend/entities/ef/PimsLeaseHist.cs
@@ -1,60 +1,157 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_HIST")]
+    [Index(nameof(LeaseHistId), nameof(EndDateHist), Name = "PIMS_LEASE_H_UK", IsUnique = true)]
     public partial class PimsLeaseHist
     {
+        [Key]
+        [Column("_LEASE_HIST_ID")]
         public long LeaseHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("LEASE_ID")]
         public long LeaseId { get; set; }
+        [Required]
+        [Column("LEASE_PAY_RVBL_TYPE_CODE")]
+        [StringLength(20)]
         public string LeasePayRvblTypeCode { get; set; }
+        [Required]
+        [Column("LEASE_LICENSE_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseLicenseTypeCode { get; set; }
+        [Required]
+        [Column("LEASE_CATEGORY_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseCategoryTypeCode { get; set; }
+        [Required]
+        [Column("LEASE_PURPOSE_TYPE_CODE")]
+        [StringLength(20)]
         public string LeasePurposeTypeCode { get; set; }
+        [Required]
+        [Column("LEASE_PROGRAM_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseProgramTypeCode { get; set; }
+        [Required]
+        [Column("LEASE_INITIATOR_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseInitiatorTypeCode { get; set; }
+        [Required]
+        [Column("LEASE_RESPONSIBILITY_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseResponsibilityTypeCode { get; set; }
+        [Required]
+        [Column("LEASE_PMT_FREQ_TYPE_CODE")]
+        [StringLength(20)]
         public string LeasePmtFreqTypeCode { get; set; }
+        [Required]
+        [Column("LEASE_STATUS_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseStatusTypeCode { get; set; }
+        [Column("L_FILE_NO")]
+        [StringLength(50)]
         public string LFileNo { get; set; }
+        [Column("TFA_FILE_NO")]
         public int? TfaFileNo { get; set; }
+        [Column("PS_FILE_NO")]
+        [StringLength(50)]
         public string PsFileNo { get; set; }
+        [Column("LEASE_CATEGORY_OTHER_DESC")]
+        [StringLength(200)]
         public string LeaseCategoryOtherDesc { get; set; }
+        [Column("LEASE_PURPOSE_OTHER_DESC")]
+        [StringLength(200)]
         public string LeasePurposeOtherDesc { get; set; }
+        [Column("MOTI_CONTACT")]
+        [StringLength(200)]
         public string MotiContact { get; set; }
+        [Column("MOTI_REGION")]
+        [StringLength(200)]
         public string MotiRegion { get; set; }
+        [Column("DOCUMENTATION_REFERENCE")]
+        [StringLength(500)]
         public string DocumentationReference { get; set; }
+        [Column("OTHER_LEASE_PROGRAM_TYPE")]
+        [StringLength(200)]
         public string OtherLeaseProgramType { get; set; }
+        [Column("OTHER_LEASE_LICENSE_TYPE")]
+        [StringLength(200)]
         public string OtherLeaseLicenseType { get; set; }
+        [Column("OTHER_LEASE_PURPOSE_TYPE")]
+        [StringLength(200)]
         public string OtherLeasePurposeType { get; set; }
+        [Column("ORIG_START_DATE", TypeName = "datetime")]
         public DateTime OrigStartDate { get; set; }
+        [Column("ORIG_EXPIRY_DATE", TypeName = "datetime")]
         public DateTime? OrigExpiryDate { get; set; }
+        [Column("LEASE_AMOUNT", TypeName = "money")]
         public decimal? LeaseAmount { get; set; }
+        [Column("RESPONSIBILITY_EFFECTIVE_DATE", TypeName = "datetime")]
         public DateTime? ResponsibilityEffectiveDate { get; set; }
+        [Column("INSPECTION_DATE", TypeName = "datetime")]
         public DateTime? InspectionDate { get; set; }
+        [Column("IS_SUBJECT_TO_RTA")]
         public bool? IsSubjectToRta { get; set; }
+        [Column("IS_COMM_BLDG")]
         public bool? IsCommBldg { get; set; }
+        [Column("IS_OTHER_IMPROVEMENT")]
         public bool? IsOtherImprovement { get; set; }
+        [Column("IS_EXPIRED")]
         public bool IsExpired { get; set; }
+        [Column("HAS_PHYSICAL_FILE")]
         public bool HasPhysicalFile { get; set; }
+        [Column("HAS_DIGITAL_FILE")]
         public bool HasDigitalFile { get; set; }
+        [Column("HAS_PHYSICIAL_LICENSE")]
         public bool HasPhysicialLicense { get; set; }
+        [Column("HAS_DIGITAL_LICENSE")]
         public bool HasDigitalLicense { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeaseInitiatorType.cs
+++ b/backend/entities/ef/PimsLeaseInitiatorType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_INITIATOR_TYPE")]
     public partial class PimsLeaseInitiatorType
     {
         public PimsLeaseInitiatorType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsLeases = new HashSet<PimsLease>();
         }
 
+        [Key]
+        [Column("LEASE_INITIATOR_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseInitiatorTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsLease.LeaseInitiatorTypeCodeNavigation))]
         public virtual ICollection<PimsLease> PimsLeases { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeaseLicenseType.cs
+++ b/backend/entities/ef/PimsLeaseLicenseType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_LICENSE_TYPE")]
     public partial class PimsLeaseLicenseType
     {
         public PimsLeaseLicenseType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsLeases = new HashSet<PimsLease>();
         }
 
+        [Key]
+        [Column("LEASE_LICENSE_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseLicenseTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsLease.LeaseLicenseTypeCodeNavigation))]
         public virtual ICollection<PimsLease> PimsLeases { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeasePayRvblType.cs
+++ b/backend/entities/ef/PimsLeasePayRvblType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_PAY_RVBL_TYPE")]
     public partial class PimsLeasePayRvblType
     {
         public PimsLeasePayRvblType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsLeases = new HashSet<PimsLease>();
         }
 
+        [Key]
+        [Column("LEASE_PAY_RVBL_TYPE_CODE")]
+        [StringLength(20)]
         public string LeasePayRvblTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsLease.LeasePayRvblTypeCodeNavigation))]
         public virtual ICollection<PimsLease> PimsLeases { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeasePayment.cs
+++ b/backend/entities/ef/PimsLeasePayment.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsLeasePayment.cs
+++ b/backend/entities/ef/PimsLeasePayment.cs
@@ -1,37 +1,90 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_PAYMENT")]
+    [Index(nameof(LeasePaymentMethodTypeCode), Name = "LSPYMT_LEASE_PAYMENT_METHOD_TYPE_CODE_IDX")]
+    [Index(nameof(LeasePaymentPeriodId), Name = "LSPYMT_LEASE_PAYMENT_PERIOD_ID_IDX")]
+    [Index(nameof(LeaseTermId), Name = "LSPYMT_LEASE_TERM_ID_IDX")]
     public partial class PimsLeasePayment
     {
+        [Key]
+        [Column("LEASE_PAYMENT_ID")]
         public long LeasePaymentId { get; set; }
+        [Column("LEASE_TERM_ID")]
         public long LeaseTermId { get; set; }
+        [Column("LEASE_PAYMENT_PERIOD_ID")]
         public long LeasePaymentPeriodId { get; set; }
+        [Required]
+        [Column("LEASE_PAYMENT_METHOD_TYPE_CODE")]
+        [StringLength(20)]
         public string LeasePaymentMethodTypeCode { get; set; }
+        [Column("PAYMENT_RECEIVED_DATE", TypeName = "datetime")]
         public DateTime PaymentReceivedDate { get; set; }
+        [Column("PAYMENT_AMOUNT_PRE_TAX", TypeName = "money")]
         public decimal PaymentAmountPreTax { get; set; }
+        [Column("PAYMENT_AMOUNT_PST", TypeName = "money")]
         public decimal PaymentAmountPst { get; set; }
+        [Column("PAYMENT_AMOUNT_GST", TypeName = "money")]
         public decimal PaymentAmountGst { get; set; }
+        [Column("PAYMENT_AMOUNT_TOTAL", TypeName = "money")]
         public decimal PaymentAmountTotal { get; set; }
+        [Column("NOTE")]
+        [StringLength(2000)]
         public string Note { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(LeasePaymentMethodTypeCode))]
+        [InverseProperty(nameof(PimsLeasePaymentMethodType.PimsLeasePayments))]
         public virtual PimsLeasePaymentMethodType LeasePaymentMethodTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(LeasePaymentPeriodId))]
+        [InverseProperty(nameof(PimsLeasePaymentPeriod.PimsLeasePayments))]
         public virtual PimsLeasePaymentPeriod LeasePaymentPeriod { get; set; }
+        [ForeignKey(nameof(LeaseTermId))]
+        [InverseProperty(nameof(PimsLeaseTerm.PimsLeasePayments))]
         public virtual PimsLeaseTerm LeaseTerm { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeasePaymentForecast.cs
+++ b/backend/entities/ef/PimsLeasePaymentForecast.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsLeasePaymentForecast.cs
+++ b/backend/entities/ef/PimsLeasePaymentForecast.cs
@@ -1,36 +1,87 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_PAYMENT_FORECAST")]
+    [Index(nameof(LeasePaymentPeriodId), Name = "LPFCST_LEASE_PAYMENT_PERIOD_ID_IDX")]
+    [Index(nameof(LeasePaymentStatusTypeCode), Name = "LPFCST_LEASE_PAYMENT_STATUS_TYPE_CODE_IDX")]
+    [Index(nameof(LeaseTermId), Name = "LPFCST_LEASE_TERM_ID_IDX")]
     public partial class PimsLeasePaymentForecast
     {
+        [Key]
+        [Column("LEASE_PAYMENT_FORECAST_ID")]
         public long LeasePaymentForecastId { get; set; }
+        [Column("LEASE_TERM_ID")]
         public long LeaseTermId { get; set; }
+        [Column("LEASE_PAYMENT_PERIOD_ID")]
         public long LeasePaymentPeriodId { get; set; }
+        [Required]
+        [Column("LEASE_PAYMENT_STATUS_TYPE_CODE")]
+        [StringLength(20)]
         public string LeasePaymentStatusTypeCode { get; set; }
+        [Column("PAYMENT_DUE_DATE", TypeName = "datetime")]
         public DateTime PaymentDueDate { get; set; }
+        [Column("FORECAST_PAYMENT_PRE_TAX", TypeName = "money")]
         public decimal ForecastPaymentPreTax { get; set; }
+        [Column("FORECAST_PAYMENT_PST", TypeName = "money")]
         public decimal ForecastPaymentPst { get; set; }
+        [Column("FORECAST_PAYMENT_GST", TypeName = "money")]
         public decimal ForecastPaymentGst { get; set; }
+        [Column("FORECAST_PAYMENT_TOTAL", TypeName = "money")]
         public decimal ForecastPaymentTotal { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(LeasePaymentPeriodId))]
+        [InverseProperty(nameof(PimsLeasePaymentPeriod.PimsLeasePaymentForecasts))]
         public virtual PimsLeasePaymentPeriod LeasePaymentPeriod { get; set; }
+        [ForeignKey(nameof(LeasePaymentStatusTypeCode))]
+        [InverseProperty(nameof(PimsLeasePaymentStatusType.PimsLeasePaymentForecasts))]
         public virtual PimsLeasePaymentStatusType LeasePaymentStatusTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(LeaseTermId))]
+        [InverseProperty(nameof(PimsLeaseTerm.PimsLeasePaymentForecasts))]
         public virtual PimsLeaseTerm LeaseTerm { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeasePaymentForecastHist.cs
+++ b/backend/entities/ef/PimsLeasePaymentForecastHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsLeasePaymentForecastHist.cs
+++ b/backend/entities/ef/PimsLeasePaymentForecastHist.cs
@@ -1,35 +1,81 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_PAYMENT_FORECAST_HIST")]
+    [Index(nameof(LeasePaymentForecastHistId), nameof(EndDateHist), Name = "PIMS_LPFCST_H_UK", IsUnique = true)]
     public partial class PimsLeasePaymentForecastHist
     {
+        [Key]
+        [Column("_LEASE_PAYMENT_FORECAST_HIST_ID")]
         public long LeasePaymentForecastHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("LEASE_PAYMENT_FORECAST_ID")]
         public long LeasePaymentForecastId { get; set; }
+        [Column("LEASE_TERM_ID")]
         public long LeaseTermId { get; set; }
+        [Column("LEASE_PAYMENT_PERIOD_ID")]
         public long LeasePaymentPeriodId { get; set; }
+        [Required]
+        [Column("LEASE_PAYMENT_STATUS_TYPE_CODE")]
+        [StringLength(20)]
         public string LeasePaymentStatusTypeCode { get; set; }
+        [Column("PAYMENT_DUE_DATE", TypeName = "datetime")]
         public DateTime PaymentDueDate { get; set; }
+        [Column("FORECAST_PAYMENT_PRE_TAX", TypeName = "money")]
         public decimal ForecastPaymentPreTax { get; set; }
+        [Column("FORECAST_PAYMENT_PST", TypeName = "money")]
         public decimal ForecastPaymentPst { get; set; }
+        [Column("FORECAST_PAYMENT_GST", TypeName = "money")]
         public decimal ForecastPaymentGst { get; set; }
+        [Column("FORECAST_PAYMENT_TOTAL", TypeName = "money")]
         public decimal ForecastPaymentTotal { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeasePaymentHist.cs
+++ b/backend/entities/ef/PimsLeasePaymentHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsLeasePaymentHist.cs
+++ b/backend/entities/ef/PimsLeasePaymentHist.cs
@@ -1,36 +1,84 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_PAYMENT_HIST")]
+    [Index(nameof(LeasePaymentHistId), nameof(EndDateHist), Name = "PIMS_LSPYMT_H_UK", IsUnique = true)]
     public partial class PimsLeasePaymentHist
     {
+        [Key]
+        [Column("_LEASE_PAYMENT_HIST_ID")]
         public long LeasePaymentHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("LEASE_PAYMENT_ID")]
         public long LeasePaymentId { get; set; }
+        [Column("LEASE_TERM_ID")]
         public long LeaseTermId { get; set; }
+        [Column("LEASE_PAYMENT_PERIOD_ID")]
         public long LeasePaymentPeriodId { get; set; }
+        [Required]
+        [Column("LEASE_PAYMENT_METHOD_TYPE_CODE")]
+        [StringLength(20)]
         public string LeasePaymentMethodTypeCode { get; set; }
+        [Column("PAYMENT_RECEIVED_DATE", TypeName = "datetime")]
         public DateTime PaymentReceivedDate { get; set; }
+        [Column("PAYMENT_AMOUNT_PRE_TAX", TypeName = "money")]
         public decimal PaymentAmountPreTax { get; set; }
+        [Column("PAYMENT_AMOUNT_PST", TypeName = "money")]
         public decimal PaymentAmountPst { get; set; }
+        [Column("PAYMENT_AMOUNT_GST", TypeName = "money")]
         public decimal PaymentAmountGst { get; set; }
+        [Column("PAYMENT_AMOUNT_TOTAL", TypeName = "money")]
         public decimal PaymentAmountTotal { get; set; }
+        [Column("NOTE")]
+        [StringLength(2000)]
         public string Note { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeasePaymentMethodType.cs
+++ b/backend/entities/ef/PimsLeasePaymentMethodType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_PAYMENT_METHOD_TYPE")]
     public partial class PimsLeasePaymentMethodType
     {
         public PimsLeasePaymentMethodType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsLeasePayments = new HashSet<PimsLeasePayment>();
         }
 
+        [Key]
+        [Column("LEASE_PAYMENT_METHOD_TYPE_CODE")]
+        [StringLength(20)]
         public string LeasePaymentMethodTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsLeasePayment.LeasePaymentMethodTypeCodeNavigation))]
         public virtual ICollection<PimsLeasePayment> PimsLeasePayments { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeasePaymentPeriod.cs
+++ b/backend/entities/ef/PimsLeasePaymentPeriod.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_PAYMENT_PERIOD")]
     public partial class PimsLeasePaymentPeriod
     {
         public PimsLeasePaymentPeriod()
@@ -13,24 +17,56 @@ namespace Pims.Dal.Entities
             PimsLeasePayments = new HashSet<PimsLeasePayment>();
         }
 
+        [Key]
+        [Column("LEASE_PAYMENT_PERIOD_ID")]
         public long LeasePaymentPeriodId { get; set; }
+        [Column("PERIOD_START_DATE", TypeName = "date")]
         public DateTime PeriodStartDate { get; set; }
+        [Required]
+        [Column("IS_PERIOD_CLOSED")]
         public bool? IsPeriodClosed { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsLeasePaymentForecast.LeasePaymentPeriod))]
         public virtual ICollection<PimsLeasePaymentForecast> PimsLeasePaymentForecasts { get; set; }
+        [InverseProperty(nameof(PimsLeasePayment.LeasePaymentPeriod))]
         public virtual ICollection<PimsLeasePayment> PimsLeasePayments { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeasePaymentPeriodHist.cs
+++ b/backend/entities/ef/PimsLeasePaymentPeriodHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsLeasePaymentPeriodHist.cs
+++ b/backend/entities/ef/PimsLeasePaymentPeriodHist.cs
@@ -1,29 +1,67 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_PAYMENT_PERIOD_HIST")]
+    [Index(nameof(LeasePaymentPeriodHistId), nameof(EndDateHist), Name = "PIMS_LPYPER_H_UK", IsUnique = true)]
     public partial class PimsLeasePaymentPeriodHist
     {
+        [Key]
+        [Column("_LEASE_PAYMENT_PERIOD_HIST_ID")]
         public long LeasePaymentPeriodHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("LEASE_PAYMENT_PERIOD_ID")]
         public long LeasePaymentPeriodId { get; set; }
+        [Column("PERIOD_START_DATE", TypeName = "date")]
         public DateTime PeriodStartDate { get; set; }
+        [Column("IS_PERIOD_CLOSED")]
         public bool IsPeriodClosed { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeasePaymentStatusType.cs
+++ b/backend/entities/ef/PimsLeasePaymentStatusType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_PAYMENT_STATUS_TYPE")]
     public partial class PimsLeasePaymentStatusType
     {
         public PimsLeasePaymentStatusType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsLeasePaymentForecasts = new HashSet<PimsLeasePaymentForecast>();
         }
 
+        [Key]
+        [Column("LEASE_PAYMENT_STATUS_TYPE_CODE")]
+        [StringLength(20)]
         public string LeasePaymentStatusTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsLeasePaymentForecast.LeasePaymentStatusTypeCodeNavigation))]
         public virtual ICollection<PimsLeasePaymentForecast> PimsLeasePaymentForecasts { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeasePmtFreqType.cs
+++ b/backend/entities/ef/PimsLeasePmtFreqType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_PMT_FREQ_TYPE")]
     public partial class PimsLeasePmtFreqType
     {
         public PimsLeasePmtFreqType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsLeases = new HashSet<PimsLease>();
         }
 
+        [Key]
+        [Column("LEASE_PMT_FREQ_TYPE_CODE")]
+        [StringLength(20)]
         public string LeasePmtFreqTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsLease.LeasePmtFreqTypeCodeNavigation))]
         public virtual ICollection<PimsLease> PimsLeases { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeaseProgramType.cs
+++ b/backend/entities/ef/PimsLeaseProgramType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_PROGRAM_TYPE")]
     public partial class PimsLeaseProgramType
     {
         public PimsLeaseProgramType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsLeases = new HashSet<PimsLease>();
         }
 
+        [Key]
+        [Column("LEASE_PROGRAM_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseProgramTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsLease.LeaseProgramTypeCodeNavigation))]
         public virtual ICollection<PimsLease> PimsLeases { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeasePurposeType.cs
+++ b/backend/entities/ef/PimsLeasePurposeType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_PURPOSE_TYPE")]
     public partial class PimsLeasePurposeType
     {
         public PimsLeasePurposeType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsLeases = new HashSet<PimsLease>();
         }
 
+        [Key]
+        [Column("LEASE_PURPOSE_TYPE_CODE")]
+        [StringLength(20)]
         public string LeasePurposeTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsLease.LeasePurposeTypeCodeNavigation))]
         public virtual ICollection<PimsLease> PimsLeases { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeaseResponsibilityType.cs
+++ b/backend/entities/ef/PimsLeaseResponsibilityType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_RESPONSIBILITY_TYPE")]
     public partial class PimsLeaseResponsibilityType
     {
         public PimsLeaseResponsibilityType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsLeases = new HashSet<PimsLease>();
         }
 
+        [Key]
+        [Column("LEASE_RESPONSIBILITY_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseResponsibilityTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsLease.LeaseResponsibilityTypeCodeNavigation))]
         public virtual ICollection<PimsLease> PimsLeases { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeaseStatusType.cs
+++ b/backend/entities/ef/PimsLeaseStatusType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_STATUS_TYPE")]
     public partial class PimsLeaseStatusType
     {
         public PimsLeaseStatusType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsLeases = new HashSet<PimsLease>();
         }
 
+        [Key]
+        [Column("LEASE_STATUS_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseStatusTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsLease.LeaseStatusTypeCodeNavigation))]
         public virtual ICollection<PimsLease> PimsLeases { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeaseTenant.cs
+++ b/backend/entities/ef/PimsLeaseTenant.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsLeaseTenant.cs
+++ b/backend/entities/ef/PimsLeaseTenant.cs
@@ -1,34 +1,86 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_TENANT")]
+    [Index(nameof(LeaseId), Name = "TENANT_LEASE_ID_IDX")]
+    [Index(nameof(LessorTypeCode), Name = "TENANT_LESSOR_TYPE_CODE_IDX")]
+    [Index(nameof(OrganizationId), Name = "TENANT_ORGANIZATION_ID_IDX")]
+    [Index(nameof(PersonId), Name = "TENANT_PERSON_ID_IDX")]
     public partial class PimsLeaseTenant
     {
+        [Key]
+        [Column("LEASE_TENANT_ID")]
         public long LeaseTenantId { get; set; }
+        [Column("LEASE_ID")]
         public long LeaseId { get; set; }
+        [Column("PERSON_ID")]
         public long? PersonId { get; set; }
+        [Column("ORGANIZATION_ID")]
         public long? OrganizationId { get; set; }
+        [Required]
+        [Column("LESSOR_TYPE_CODE")]
+        [StringLength(20)]
         public string LessorTypeCode { get; set; }
+        [Column("NOTE")]
+        [StringLength(2000)]
         public string Note { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(LeaseId))]
+        [InverseProperty(nameof(PimsLease.PimsLeaseTenants))]
         public virtual PimsLease Lease { get; set; }
+        [ForeignKey(nameof(LessorTypeCode))]
+        [InverseProperty(nameof(PimsLessorType.PimsLeaseTenants))]
         public virtual PimsLessorType LessorTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(OrganizationId))]
+        [InverseProperty(nameof(PimsOrganization.PimsLeaseTenants))]
         public virtual PimsOrganization Organization { get; set; }
+        [ForeignKey(nameof(PersonId))]
+        [InverseProperty(nameof(PimsPerson.PimsLeaseTenants))]
         public virtual PimsPerson Person { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeaseTenantHist.cs
+++ b/backend/entities/ef/PimsLeaseTenantHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsLeaseTenantHist.cs
+++ b/backend/entities/ef/PimsLeaseTenantHist.cs
@@ -1,32 +1,76 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_TENANT_HIST")]
+    [Index(nameof(LeaseTenantHistId), nameof(EndDateHist), Name = "PIMS_TENANT_H_UK", IsUnique = true)]
     public partial class PimsLeaseTenantHist
     {
+        [Key]
+        [Column("_LEASE_TENANT_HIST_ID")]
         public long LeaseTenantHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("LEASE_TENANT_ID")]
         public long LeaseTenantId { get; set; }
+        [Column("LEASE_ID")]
         public long LeaseId { get; set; }
+        [Column("PERSON_ID")]
         public long? PersonId { get; set; }
+        [Column("ORGANIZATION_ID")]
         public long? OrganizationId { get; set; }
+        [Required]
+        [Column("LESSOR_TYPE_CODE")]
+        [StringLength(20)]
         public string LessorTypeCode { get; set; }
+        [Column("NOTE")]
+        [StringLength(2000)]
         public string Note { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeaseTerm.cs
+++ b/backend/entities/ef/PimsLeaseTerm.cs
@@ -1,10 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_TERM")]
+    [Index(nameof(LeaseId), Name = "LSTERM_LEASE_ID_IDX")]
+    [Index(nameof(LeaseTermStatusTypeCode), Name = "LSTERM_LEASE_TERM_STATUS_TYPE_CODE_IDX")]
     public partial class PimsLeaseTerm
     {
         public PimsLeaseTerm()
@@ -13,29 +19,69 @@ namespace Pims.Dal.Entities
             PimsLeasePayments = new HashSet<PimsLeasePayment>();
         }
 
+        [Key]
+        [Column("LEASE_TERM_ID")]
         public long LeaseTermId { get; set; }
+        [Column("LEASE_ID")]
         public long LeaseId { get; set; }
+        [Required]
+        [Column("LEASE_TERM_STATUS_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseTermStatusTypeCode { get; set; }
+        [Column("TERM_START_DATE", TypeName = "datetime")]
         public DateTime TermStartDate { get; set; }
+        [Column("TERM_EXPIRY_DATE", TypeName = "datetime")]
         public DateTime? TermExpiryDate { get; set; }
+        [Column("TERM_RENEWAL_DATE", TypeName = "datetime")]
         public DateTime? TermRenewalDate { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(LeaseId))]
+        [InverseProperty(nameof(PimsLease.PimsLeaseTerms))]
         public virtual PimsLease Lease { get; set; }
+        [ForeignKey(nameof(LeaseTermStatusTypeCode))]
+        [InverseProperty(nameof(PimsLeaseTermStatusType.PimsLeaseTerms))]
         public virtual PimsLeaseTermStatusType LeaseTermStatusTypeCodeNavigation { get; set; }
+        [InverseProperty(nameof(PimsLeasePaymentForecast.LeaseTerm))]
         public virtual ICollection<PimsLeasePaymentForecast> PimsLeasePaymentForecasts { get; set; }
+        [InverseProperty(nameof(PimsLeasePayment.LeaseTerm))]
         public virtual ICollection<PimsLeasePayment> PimsLeasePayments { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeaseTermHist.cs
+++ b/backend/entities/ef/PimsLeaseTermHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsLeaseTermHist.cs
+++ b/backend/entities/ef/PimsLeaseTermHist.cs
@@ -1,32 +1,75 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_TERM_HIST")]
+    [Index(nameof(LeaseTermHistId), nameof(EndDateHist), Name = "PIMS_LSTERM_H_UK", IsUnique = true)]
     public partial class PimsLeaseTermHist
     {
+        [Key]
+        [Column("_LEASE_TERM_HIST_ID")]
         public long LeaseTermHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("LEASE_TERM_ID")]
         public long LeaseTermId { get; set; }
+        [Column("LEASE_ID")]
         public long LeaseId { get; set; }
+        [Required]
+        [Column("LEASE_TERM_STATUS_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseTermStatusTypeCode { get; set; }
+        [Column("TERM_START_DATE", TypeName = "datetime")]
         public DateTime TermStartDate { get; set; }
+        [Column("TERM_EXPIRY_DATE", TypeName = "datetime")]
         public DateTime? TermExpiryDate { get; set; }
+        [Column("TERM_RENEWAL_DATE", TypeName = "datetime")]
         public DateTime? TermRenewalDate { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLeaseTermStatusType.cs
+++ b/backend/entities/ef/PimsLeaseTermStatusType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LEASE_TERM_STATUS_TYPE")]
     public partial class PimsLeaseTermStatusType
     {
         public PimsLeaseTermStatusType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsLeaseTerms = new HashSet<PimsLeaseTerm>();
         }
 
+        [Key]
+        [Column("LEASE_TERM_STATUS_TYPE_CODE")]
+        [StringLength(20)]
         public string LeaseTermStatusTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsLeaseTerm.LeaseTermStatusTypeCodeNavigation))]
         public virtual ICollection<PimsLeaseTerm> PimsLeaseTerms { get; set; }
     }
 }

--- a/backend/entities/ef/PimsLessorType.cs
+++ b/backend/entities/ef/PimsLessorType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_LESSOR_TYPE")]
     public partial class PimsLessorType
     {
         public PimsLessorType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsLeaseTenants = new HashSet<PimsLeaseTenant>();
         }
 
+        [Key]
+        [Column("LESSOR_TYPE_CODE")]
+        [StringLength(20)]
         public string LessorTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsLeaseTenant.LessorTypeCodeNavigation))]
         public virtual ICollection<PimsLeaseTenant> PimsLeaseTenants { get; set; }
     }
 }

--- a/backend/entities/ef/PimsOrgIdentifierType.cs
+++ b/backend/entities/ef/PimsOrgIdentifierType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ORG_IDENTIFIER_TYPE")]
     public partial class PimsOrgIdentifierType
     {
         public PimsOrgIdentifierType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsOrganizations = new HashSet<PimsOrganization>();
         }
 
+        [Key]
+        [Column("ORG_IDENTIFIER_TYPE_CODE")]
+        [StringLength(20)]
         public string OrgIdentifierTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsOrganization.OrgIdentifierTypeCodeNavigation))]
         public virtual ICollection<PimsOrganization> PimsOrganizations { get; set; }
     }
 }

--- a/backend/entities/ef/PimsOrganization.cs
+++ b/backend/entities/ef/PimsOrganization.cs
@@ -1,10 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ORGANIZATION")]
+    [Index(nameof(DistrictCode), Name = "ORG_DISTRICT_CODE_IDX")]
+    [Index(nameof(OrganizationTypeCode), Name = "ORG_ORGANIZATION_TYPE_CODE_IDX")]
+    [Index(nameof(OrgIdentifierTypeCode), Name = "ORG_ORG_IDENTIFIER_TYPE_CODE_IDX")]
+    [Index(nameof(PrntOrganizationId), Name = "ORG_PRNT_ORGANIZATION_ID_IDX")]
+    [Index(nameof(RegionCode), Name = "ORG_REGION_CODE_IDX")]
     public partial class PimsOrganization
     {
         public PimsOrganization()
@@ -21,47 +30,118 @@ namespace Pims.Dal.Entities
             PimsUserOrganizations = new HashSet<PimsUserOrganization>();
         }
 
+        [Key]
+        [Column("ORGANIZATION_ID")]
         public long OrganizationId { get; set; }
+        [Column("PRNT_ORGANIZATION_ID")]
         public long? PrntOrganizationId { get; set; }
+        [Column("REGION_CODE")]
         public short? RegionCode { get; set; }
+        [Column("DISTRICT_CODE")]
         public short? DistrictCode { get; set; }
+        [Required]
+        [Column("ORGANIZATION_TYPE_CODE")]
+        [StringLength(20)]
         public string OrganizationTypeCode { get; set; }
+        [Required]
+        [Column("ORG_IDENTIFIER_TYPE_CODE")]
+        [StringLength(20)]
         public string OrgIdentifierTypeCode { get; set; }
+        [Column("ORGANIZATION_IDENTIFIER")]
+        [StringLength(100)]
         public string OrganizationIdentifier { get; set; }
+        [Required]
+        [Column("ORGANIZATION_NAME")]
+        [StringLength(200)]
         public string OrganizationName { get; set; }
+        [Column("ORGANIZATION_ALIAS")]
+        [StringLength(200)]
         public string OrganizationAlias { get; set; }
+        [Column("INCORPORATION_NUMBER")]
+        [StringLength(50)]
         public string IncorporationNumber { get; set; }
+        [Column("WEBSITE")]
+        [StringLength(200)]
         public string Website { get; set; }
+        [Column("COMMENT")]
+        [StringLength(2000)]
         public string Comment { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(DistrictCode))]
+        [InverseProperty(nameof(PimsDistrict.PimsOrganizations))]
         public virtual PimsDistrict DistrictCodeNavigation { get; set; }
+        [ForeignKey(nameof(OrgIdentifierTypeCode))]
+        [InverseProperty(nameof(PimsOrgIdentifierType.PimsOrganizations))]
         public virtual PimsOrgIdentifierType OrgIdentifierTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(OrganizationTypeCode))]
+        [InverseProperty(nameof(PimsOrganizationType.PimsOrganizations))]
         public virtual PimsOrganizationType OrganizationTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(PrntOrganizationId))]
+        [InverseProperty(nameof(PimsOrganization.InversePrntOrganization))]
         public virtual PimsOrganization PrntOrganization { get; set; }
+        [ForeignKey(nameof(RegionCode))]
+        [InverseProperty(nameof(PimsRegion.PimsOrganizations))]
         public virtual PimsRegion RegionCodeNavigation { get; set; }
+        [InverseProperty(nameof(PimsOrganization.PrntOrganization))]
         public virtual ICollection<PimsOrganization> InversePrntOrganization { get; set; }
+        [InverseProperty(nameof(PimsAccessRequestOrganization.Organization))]
         public virtual ICollection<PimsAccessRequestOrganization> PimsAccessRequestOrganizations { get; set; }
+        [InverseProperty(nameof(PimsContactMethod.Organization))]
         public virtual ICollection<PimsContactMethod> PimsContactMethods { get; set; }
+        [InverseProperty(nameof(PimsInsurance.InsurerOrg))]
         public virtual ICollection<PimsInsurance> PimsInsurances { get; set; }
+        [InverseProperty(nameof(PimsLeaseTenant.Organization))]
         public virtual ICollection<PimsLeaseTenant> PimsLeaseTenants { get; set; }
+        [InverseProperty(nameof(PimsOrganizationAddress.Organization))]
         public virtual ICollection<PimsOrganizationAddress> PimsOrganizationAddresses { get; set; }
+        [InverseProperty(nameof(PimsPersonOrganization.Organization))]
         public virtual ICollection<PimsPersonOrganization> PimsPersonOrganizations { get; set; }
+        [InverseProperty(nameof(PimsProperty.PropMgmtOrg))]
         public virtual ICollection<PimsProperty> PimsProperties { get; set; }
+        [InverseProperty(nameof(PimsPropertyOrganization.Organization))]
         public virtual ICollection<PimsPropertyOrganization> PimsPropertyOrganizations { get; set; }
+        [InverseProperty(nameof(PimsUserOrganization.Organization))]
         public virtual ICollection<PimsUserOrganization> PimsUserOrganizations { get; set; }
     }
 }

--- a/backend/entities/ef/PimsOrganizationAddress.cs
+++ b/backend/entities/ef/PimsOrganizationAddress.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsOrganizationAddress.cs
+++ b/backend/entities/ef/PimsOrganizationAddress.cs
@@ -1,32 +1,81 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ORGANIZATION_ADDRESS")]
+    [Index(nameof(AddressId), Name = "ORGADD_ADDRESS_ID_IDX")]
+    [Index(nameof(AddressUsageTypeCode), Name = "ORGADD_ADDRESS_USAGE_TYPE_CODE_IDX")]
+    [Index(nameof(OrganizationId), Name = "ORGADD_ORGANIZATION_ID_IDX")]
+    [Index(nameof(OrganizationId), nameof(AddressId), nameof(AddressUsageTypeCode), Name = "ORGADD_UNQ_ADDR_TYPE_TUC", IsUnique = true)]
     public partial class PimsOrganizationAddress
     {
+        [Key]
+        [Column("ORGANIZATION_ADDRESS_ID")]
         public long OrganizationAddressId { get; set; }
+        [Column("ORGANIZATION_ID")]
         public long OrganizationId { get; set; }
+        [Column("ADDRESS_ID")]
         public long AddressId { get; set; }
+        [Required]
+        [Column("ADDRESS_USAGE_TYPE_CODE")]
+        [StringLength(20)]
         public string AddressUsageTypeCode { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(AddressId))]
+        [InverseProperty(nameof(PimsAddress.PimsOrganizationAddresses))]
         public virtual PimsAddress Address { get; set; }
+        [ForeignKey(nameof(AddressUsageTypeCode))]
+        [InverseProperty(nameof(PimsAddressUsageType.PimsOrganizationAddresses))]
         public virtual PimsAddressUsageType AddressUsageTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(OrganizationId))]
+        [InverseProperty(nameof(PimsOrganization.PimsOrganizationAddresses))]
         public virtual PimsOrganization Organization { get; set; }
     }
 }

--- a/backend/entities/ef/PimsOrganizationAddressHist.cs
+++ b/backend/entities/ef/PimsOrganizationAddressHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsOrganizationAddressHist.cs
+++ b/backend/entities/ef/PimsOrganizationAddressHist.cs
@@ -1,31 +1,73 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ORGANIZATION_ADDRESS_HIST")]
+    [Index(nameof(OrganizationAddressHistId), nameof(EndDateHist), Name = "PIMS_ORGADD_H_UK", IsUnique = true)]
     public partial class PimsOrganizationAddressHist
     {
+        [Key]
+        [Column("_ORGANIZATION_ADDRESS_HIST_ID")]
         public long OrganizationAddressHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("ORGANIZATION_ADDRESS_ID")]
         public long OrganizationAddressId { get; set; }
+        [Column("ORGANIZATION_ID")]
         public long OrganizationId { get; set; }
+        [Column("ADDRESS_ID")]
         public long AddressId { get; set; }
+        [Required]
+        [Column("ADDRESS_USAGE_TYPE_CODE")]
+        [StringLength(20)]
         public string AddressUsageTypeCode { get; set; }
+        [Column("IS_DISABLED")]
         public bool IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsOrganizationHist.cs
+++ b/backend/entities/ef/PimsOrganizationHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsOrganizationHist.cs
+++ b/backend/entities/ef/PimsOrganizationHist.cs
@@ -1,39 +1,98 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ORGANIZATION_HIST")]
+    [Index(nameof(OrganizationHistId), nameof(EndDateHist), Name = "PIMS_ORG_H_UK", IsUnique = true)]
     public partial class PimsOrganizationHist
     {
+        [Key]
+        [Column("_ORGANIZATION_HIST_ID")]
         public long OrganizationHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("ORGANIZATION_ID")]
         public long OrganizationId { get; set; }
+        [Column("PRNT_ORGANIZATION_ID")]
         public long? PrntOrganizationId { get; set; }
+        [Column("REGION_CODE")]
         public short? RegionCode { get; set; }
+        [Column("DISTRICT_CODE")]
         public short? DistrictCode { get; set; }
+        [Required]
+        [Column("ORGANIZATION_TYPE_CODE")]
+        [StringLength(20)]
         public string OrganizationTypeCode { get; set; }
+        [Required]
+        [Column("ORG_IDENTIFIER_TYPE_CODE")]
+        [StringLength(20)]
         public string OrgIdentifierTypeCode { get; set; }
+        [Column("ORGANIZATION_IDENTIFIER")]
+        [StringLength(100)]
         public string OrganizationIdentifier { get; set; }
+        [Required]
+        [Column("ORGANIZATION_NAME")]
+        [StringLength(200)]
         public string OrganizationName { get; set; }
+        [Column("ORGANIZATION_ALIAS")]
+        [StringLength(200)]
         public string OrganizationAlias { get; set; }
+        [Column("INCORPORATION_NUMBER")]
+        [StringLength(50)]
         public string IncorporationNumber { get; set; }
+        [Column("WEBSITE")]
+        [StringLength(200)]
         public string Website { get; set; }
+        [Column("COMMENT")]
+        [StringLength(2000)]
         public string Comment { get; set; }
+        [Column("IS_DISABLED")]
         public bool IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsOrganizationType.cs
+++ b/backend/entities/ef/PimsOrganizationType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ORGANIZATION_TYPE")]
     public partial class PimsOrganizationType
     {
         public PimsOrganizationType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsOrganizations = new HashSet<PimsOrganization>();
         }
 
+        [Key]
+        [Column("ORGANIZATION_TYPE_CODE")]
+        [StringLength(20)]
         public string OrganizationTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsOrganization.OrganizationTypeCodeNavigation))]
         public virtual ICollection<PimsOrganization> PimsOrganizations { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPerson.cs
+++ b/backend/entities/ef/PimsPerson.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PERSON")]
     public partial class PimsPerson
     {
         public PimsPerson()
@@ -20,37 +24,90 @@ namespace Pims.Dal.Entities
             PimsUsers = new HashSet<PimsUser>();
         }
 
+        [Key]
+        [Column("PERSON_ID")]
         public long PersonId { get; set; }
+        [Required]
+        [Column("SURNAME")]
+        [StringLength(50)]
         public string Surname { get; set; }
+        [Required]
+        [Column("FIRST_NAME")]
+        [StringLength(50)]
         public string FirstName { get; set; }
+        [Column("MIDDLE_NAMES")]
+        [StringLength(200)]
         public string MiddleNames { get; set; }
+        [Column("NAME_SUFFIX")]
+        [StringLength(50)]
         public string NameSuffix { get; set; }
+        [Column("PREFERRED_NAME")]
+        [StringLength(200)]
         public string PreferredName { get; set; }
+        [Column("BIRTH_DATE", TypeName = "date")]
         public DateTime? BirthDate { get; set; }
+        [Column("COMMENT")]
+        [StringLength(2000)]
         public string Comment { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsContactMethod.Person))]
         public virtual ICollection<PimsContactMethod> PimsContactMethods { get; set; }
+        [InverseProperty(nameof(PimsInsurance.BctfaRiskMgmtContact))]
         public virtual ICollection<PimsInsurance> PimsInsuranceBctfaRiskMgmtContacts { get; set; }
+        [InverseProperty(nameof(PimsInsurance.InsurerContact))]
         public virtual ICollection<PimsInsurance> PimsInsuranceInsurerContacts { get; set; }
+        [InverseProperty(nameof(PimsInsurance.MotiRiskMgmtContact))]
         public virtual ICollection<PimsInsurance> PimsInsuranceMotiRiskMgmtContacts { get; set; }
+        [InverseProperty(nameof(PimsLeaseTenant.Person))]
         public virtual ICollection<PimsLeaseTenant> PimsLeaseTenants { get; set; }
+        [InverseProperty(nameof(PimsPersonAddress.Person))]
         public virtual ICollection<PimsPersonAddress> PimsPersonAddresses { get; set; }
+        [InverseProperty(nameof(PimsPersonOrganization.Person))]
         public virtual ICollection<PimsPersonOrganization> PimsPersonOrganizations { get; set; }
+        [InverseProperty(nameof(PimsProperty.PropertyManager))]
         public virtual ICollection<PimsProperty> PimsProperties { get; set; }
+        [InverseProperty(nameof(PimsUser.Person))]
         public virtual ICollection<PimsUser> PimsUsers { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPersonAddress.cs
+++ b/backend/entities/ef/PimsPersonAddress.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPersonAddress.cs
+++ b/backend/entities/ef/PimsPersonAddress.cs
@@ -1,32 +1,81 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PERSON_ADDRESS")]
+    [Index(nameof(AddressId), Name = "PERADD_ADDRESS_ID_IDX")]
+    [Index(nameof(AddressUsageTypeCode), Name = "PERADD_ADDRESS_USAGE_TYPE_CODE_IDX")]
+    [Index(nameof(PersonId), Name = "PERADD_PERSON_ID_IDX")]
+    [Index(nameof(PersonId), nameof(AddressId), nameof(AddressUsageTypeCode), Name = "PERADD_UNQ_ADDR_TYPE_TUC", IsUnique = true)]
     public partial class PimsPersonAddress
     {
+        [Key]
+        [Column("PERSON_ADDRESS_ID")]
         public long PersonAddressId { get; set; }
+        [Column("PERSON_ID")]
         public long PersonId { get; set; }
+        [Column("ADDRESS_ID")]
         public long AddressId { get; set; }
+        [Required]
+        [Column("ADDRESS_USAGE_TYPE_CODE")]
+        [StringLength(20)]
         public string AddressUsageTypeCode { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(AddressId))]
+        [InverseProperty(nameof(PimsAddress.PimsPersonAddresses))]
         public virtual PimsAddress Address { get; set; }
+        [ForeignKey(nameof(AddressUsageTypeCode))]
+        [InverseProperty(nameof(PimsAddressUsageType.PimsPersonAddresses))]
         public virtual PimsAddressUsageType AddressUsageTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(PersonId))]
+        [InverseProperty(nameof(PimsPerson.PimsPersonAddresses))]
         public virtual PimsPerson Person { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPersonAddressHist.cs
+++ b/backend/entities/ef/PimsPersonAddressHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPersonAddressHist.cs
+++ b/backend/entities/ef/PimsPersonAddressHist.cs
@@ -1,31 +1,73 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PERSON_ADDRESS_HIST")]
+    [Index(nameof(PersonAddressHistId), nameof(EndDateHist), Name = "PIMS_PERADD_H_UK", IsUnique = true)]
     public partial class PimsPersonAddressHist
     {
+        [Key]
+        [Column("_PERSON_ADDRESS_HIST_ID")]
         public long PersonAddressHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("PERSON_ADDRESS_ID")]
         public long PersonAddressId { get; set; }
+        [Column("PERSON_ID")]
         public long PersonId { get; set; }
+        [Column("ADDRESS_ID")]
         public long AddressId { get; set; }
+        [Required]
+        [Column("ADDRESS_USAGE_TYPE_CODE")]
+        [StringLength(20)]
         public string AddressUsageTypeCode { get; set; }
+        [Column("IS_DISABLED")]
         public bool IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPersonHist.cs
+++ b/backend/entities/ef/PimsPersonHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPersonHist.cs
+++ b/backend/entities/ef/PimsPersonHist.cs
@@ -1,35 +1,87 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PERSON_HIST")]
+    [Index(nameof(PersonHistId), nameof(EndDateHist), Name = "PIMS_PERSON_H_UK", IsUnique = true)]
     public partial class PimsPersonHist
     {
+        [Key]
+        [Column("_PERSON_HIST_ID")]
         public long PersonHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("PERSON_ID")]
         public long PersonId { get; set; }
+        [Required]
+        [Column("SURNAME")]
+        [StringLength(50)]
         public string Surname { get; set; }
+        [Required]
+        [Column("FIRST_NAME")]
+        [StringLength(50)]
         public string FirstName { get; set; }
+        [Column("MIDDLE_NAMES")]
+        [StringLength(200)]
         public string MiddleNames { get; set; }
+        [Column("NAME_SUFFIX")]
+        [StringLength(50)]
         public string NameSuffix { get; set; }
+        [Column("PREFERRED_NAME")]
+        [StringLength(200)]
         public string PreferredName { get; set; }
+        [Column("BIRTH_DATE", TypeName = "date")]
         public DateTime? BirthDate { get; set; }
+        [Column("COMMENT")]
+        [StringLength(2000)]
         public string Comment { get; set; }
+        [Column("IS_DISABLED")]
         public bool IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPersonOrganization.cs
+++ b/backend/entities/ef/PimsPersonOrganization.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPersonOrganization.cs
+++ b/backend/entities/ef/PimsPersonOrganization.cs
@@ -1,30 +1,72 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PERSON_ORGANIZATION")]
+    [Index(nameof(OrganizationId), Name = "PERORG_ORGANIZATION_ID_IDX")]
+    [Index(nameof(PersonId), Name = "PERORG_PERSON_ID_IDX")]
+    [Index(nameof(OrganizationId), nameof(PersonId), Name = "PERORG_PERSON_ORGANIZATION_TUC", IsUnique = true)]
     public partial class PimsPersonOrganization
     {
+        [Key]
+        [Column("PERSON_ORGANIZATION_ID")]
         public long PersonOrganizationId { get; set; }
+        [Column("PERSON_ID")]
         public long? PersonId { get; set; }
+        [Column("ORGANIZATION_ID")]
         public long? OrganizationId { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(OrganizationId))]
+        [InverseProperty(nameof(PimsOrganization.PimsPersonOrganizations))]
         public virtual PimsOrganization Organization { get; set; }
+        [ForeignKey(nameof(PersonId))]
+        [InverseProperty(nameof(PimsPerson.PimsPersonOrganizations))]
         public virtual PimsPerson Person { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPersonOrganizationHist.cs
+++ b/backend/entities/ef/PimsPersonOrganizationHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPersonOrganizationHist.cs
+++ b/backend/entities/ef/PimsPersonOrganizationHist.cs
@@ -1,30 +1,69 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PERSON_ORGANIZATION_HIST")]
+    [Index(nameof(PersonOrganizationHistId), nameof(EndDateHist), Name = "PIMS_PERORG_H_UK", IsUnique = true)]
     public partial class PimsPersonOrganizationHist
     {
+        [Key]
+        [Column("_PERSON_ORGANIZATION_HIST_ID")]
         public long PersonOrganizationHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("PERSON_ORGANIZATION_ID")]
         public long PersonOrganizationId { get; set; }
+        [Column("PERSON_ID")]
         public long? PersonId { get; set; }
+        [Column("ORGANIZATION_ID")]
         public long? OrganizationId { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsProject.cs
+++ b/backend/entities/ef/PimsProject.cs
@@ -1,10 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROJECT")]
+    [Index(nameof(ProjectRiskTypeCode), Name = "PROJCT_PROJECT_RISK_TYPE_CODE_IDX")]
+    [Index(nameof(ProjectStatusTypeCode), Name = "PROJCT_PROJECT_STATUS_TYPE_CODE_IDX")]
+    [Index(nameof(ProjectTierTypeCode), Name = "PROJCT_PROJECT_TIER_TYPE_CODE_IDX")]
+    [Index(nameof(ProjectTypeCode), Name = "PROJCT_PROJECT_TYPE_CODE_IDX")]
     public partial class PimsProject
     {
         public PimsProject()
@@ -15,32 +23,83 @@ namespace Pims.Dal.Entities
             PimsProjectWorkflowModels = new HashSet<PimsProjectWorkflowModel>();
         }
 
+        [Key]
+        [Column("PROJECT_ID")]
         public long ProjectId { get; set; }
+        [Required]
+        [Column("PROJECT_TYPE_CODE")]
+        [StringLength(20)]
         public string ProjectTypeCode { get; set; }
+        [Required]
+        [Column("PROJECT_STATUS_TYPE_CODE")]
+        [StringLength(20)]
         public string ProjectStatusTypeCode { get; set; }
+        [Required]
+        [Column("PROJECT_RISK_TYPE_CODE")]
+        [StringLength(20)]
         public string ProjectRiskTypeCode { get; set; }
+        [Required]
+        [Column("PROJECT_TIER_TYPE_CODE")]
+        [StringLength(20)]
         public string ProjectTierTypeCode { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(ProjectRiskTypeCode))]
+        [InverseProperty(nameof(PimsProjectRiskType.PimsProjects))]
         public virtual PimsProjectRiskType ProjectRiskTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(ProjectStatusTypeCode))]
+        [InverseProperty(nameof(PimsProjectStatusType.PimsProjects))]
         public virtual PimsProjectStatusType ProjectStatusTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(ProjectTierTypeCode))]
+        [InverseProperty(nameof(PimsProjectTierType.PimsProjects))]
         public virtual PimsProjectTierType ProjectTierTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(ProjectTypeCode))]
+        [InverseProperty(nameof(PimsProjectType.PimsProjects))]
         public virtual PimsProjectType ProjectTypeCodeNavigation { get; set; }
+        [InverseProperty(nameof(PimsActivity.Project))]
         public virtual ICollection<PimsActivity> PimsActivities { get; set; }
+        [InverseProperty(nameof(PimsProjectNote.Project))]
         public virtual ICollection<PimsProjectNote> PimsProjectNotes { get; set; }
+        [InverseProperty(nameof(PimsProjectProperty.Project))]
         public virtual ICollection<PimsProjectProperty> PimsProjectProperties { get; set; }
+        [InverseProperty(nameof(PimsProjectWorkflowModel.Project))]
         public virtual ICollection<PimsProjectWorkflowModel> PimsProjectWorkflowModels { get; set; }
     }
 }

--- a/backend/entities/ef/PimsProjectHist.cs
+++ b/backend/entities/ef/PimsProjectHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsProjectHist.cs
+++ b/backend/entities/ef/PimsProjectHist.cs
@@ -1,31 +1,79 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROJECT_HIST")]
+    [Index(nameof(ProjectHistId), nameof(EndDateHist), Name = "PIMS_PROJCT_H_UK", IsUnique = true)]
     public partial class PimsProjectHist
     {
+        [Key]
+        [Column("_PROJECT_HIST_ID")]
         public long ProjectHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("PROJECT_ID")]
         public long ProjectId { get; set; }
+        [Required]
+        [Column("PROJECT_TYPE_CODE")]
+        [StringLength(20)]
         public string ProjectTypeCode { get; set; }
+        [Required]
+        [Column("PROJECT_STATUS_TYPE_CODE")]
+        [StringLength(20)]
         public string ProjectStatusTypeCode { get; set; }
+        [Required]
+        [Column("PROJECT_RISK_TYPE_CODE")]
+        [StringLength(20)]
         public string ProjectRiskTypeCode { get; set; }
+        [Required]
+        [Column("PROJECT_TIER_TYPE_CODE")]
+        [StringLength(20)]
         public string ProjectTierTypeCode { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsProjectNote.cs
+++ b/backend/entities/ef/PimsProjectNote.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsProjectNote.cs
+++ b/backend/entities/ef/PimsProjectNote.cs
@@ -1,27 +1,63 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROJECT_NOTE")]
+    [Index(nameof(ProjectId), Name = "PROJNT_PROJECT_ID_IDX")]
     public partial class PimsProjectNote
     {
+        [Key]
+        [Column("PROJECT_NOTE_ID")]
         public long ProjectNoteId { get; set; }
+        [Column("PROJECT_ID")]
         public long ProjectId { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(ProjectId))]
+        [InverseProperty(nameof(PimsProject.PimsProjectNotes))]
         public virtual PimsProject Project { get; set; }
     }
 }

--- a/backend/entities/ef/PimsProjectNoteHist.cs
+++ b/backend/entities/ef/PimsProjectNoteHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsProjectNoteHist.cs
+++ b/backend/entities/ef/PimsProjectNoteHist.cs
@@ -1,28 +1,65 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROJECT_NOTE_HIST")]
+    [Index(nameof(ProjectNoteHistId), nameof(EndDateHist), Name = "PIMS_PROJNT_H_UK", IsUnique = true)]
     public partial class PimsProjectNoteHist
     {
+        [Key]
+        [Column("_PROJECT_NOTE_HIST_ID")]
         public long ProjectNoteHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("PROJECT_NOTE_ID")]
         public long ProjectNoteId { get; set; }
+        [Column("PROJECT_ID")]
         public long ProjectId { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsProjectProperty.cs
+++ b/backend/entities/ef/PimsProjectProperty.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsProjectProperty.cs
+++ b/backend/entities/ef/PimsProjectProperty.cs
@@ -1,30 +1,72 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROJECT_PROPERTY")]
+    [Index(nameof(ProjectId), Name = "PRJPRP_PROJECT_ID_IDX")]
+    [Index(nameof(PropertyId), nameof(ProjectId), Name = "PRJPRP_PROJECT_PROPERTY_TUC", IsUnique = true)]
+    [Index(nameof(PropertyId), Name = "PRJPRP_PROPERTY_ID_IDX")]
     public partial class PimsProjectProperty
     {
+        [Key]
+        [Column("PROJECT_PROPERTY_ID")]
         public long ProjectPropertyId { get; set; }
+        [Column("PROJECT_ID")]
         public long ProjectId { get; set; }
+        [Column("PROPERTY_ID")]
         public long PropertyId { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(ProjectId))]
+        [InverseProperty(nameof(PimsProject.PimsProjectProperties))]
         public virtual PimsProject Project { get; set; }
+        [ForeignKey(nameof(PropertyId))]
+        [InverseProperty(nameof(PimsProperty.PimsProjectProperties))]
         public virtual PimsProperty Property { get; set; }
     }
 }

--- a/backend/entities/ef/PimsProjectPropertyHist.cs
+++ b/backend/entities/ef/PimsProjectPropertyHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsProjectPropertyHist.cs
+++ b/backend/entities/ef/PimsProjectPropertyHist.cs
@@ -1,30 +1,69 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROJECT_PROPERTY_HIST")]
+    [Index(nameof(ProjectPropertyHistId), nameof(EndDateHist), Name = "PIMS_PRJPRP_H_UK", IsUnique = true)]
     public partial class PimsProjectPropertyHist
     {
+        [Key]
+        [Column("_PROJECT_PROPERTY_HIST_ID")]
         public long ProjectPropertyHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("PROJECT_PROPERTY_ID")]
         public long ProjectPropertyId { get; set; }
+        [Column("PROJECT_ID")]
         public long ProjectId { get; set; }
+        [Column("PROPERTY_ID")]
         public long PropertyId { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsProjectRiskType.cs
+++ b/backend/entities/ef/PimsProjectRiskType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROJECT_RISK_TYPE")]
     public partial class PimsProjectRiskType
     {
         public PimsProjectRiskType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsProjects = new HashSet<PimsProject>();
         }
 
+        [Key]
+        [Column("PROJECT_RISK_TYPE_CODE")]
+        [StringLength(20)]
         public string ProjectRiskTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsProject.ProjectRiskTypeCodeNavigation))]
         public virtual ICollection<PimsProject> PimsProjects { get; set; }
     }
 }

--- a/backend/entities/ef/PimsProjectStatusType.cs
+++ b/backend/entities/ef/PimsProjectStatusType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROJECT_STATUS_TYPE")]
     public partial class PimsProjectStatusType
     {
         public PimsProjectStatusType()
@@ -12,20 +16,49 @@ namespace Pims.Dal.Entities
             PimsProjects = new HashSet<PimsProject>();
         }
 
+        [Key]
+        [Column("PROJECT_STATUS_TYPE_CODE")]
+        [StringLength(20)]
         public string ProjectStatusTypeCode { get; set; }
+        [Required]
+        [Column("CODE_GROUP")]
+        [StringLength(20)]
         public string CodeGroup { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("TEXT")]
+        [StringLength(1000)]
         public string Text { get; set; }
+        [Required]
+        [Column("IS_MILESTONE")]
         public bool? IsMilestone { get; set; }
+        [Required]
+        [Column("IS_TERMINAL")]
         public bool? IsTerminal { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsProject.ProjectStatusTypeCodeNavigation))]
         public virtual ICollection<PimsProject> PimsProjects { get; set; }
     }
 }

--- a/backend/entities/ef/PimsProjectTierType.cs
+++ b/backend/entities/ef/PimsProjectTierType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROJECT_TIER_TYPE")]
     public partial class PimsProjectTierType
     {
         public PimsProjectTierType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsProjects = new HashSet<PimsProject>();
         }
 
+        [Key]
+        [Column("PROJECT_TIER_TYPE_CODE")]
+        [StringLength(20)]
         public string ProjectTierTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsProject.ProjectTierTypeCodeNavigation))]
         public virtual ICollection<PimsProject> PimsProjects { get; set; }
     }
 }

--- a/backend/entities/ef/PimsProjectType.cs
+++ b/backend/entities/ef/PimsProjectType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROJECT_TYPE")]
     public partial class PimsProjectType
     {
         public PimsProjectType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsProjects = new HashSet<PimsProject>();
         }
 
+        [Key]
+        [Column("PROJECT_TYPE_CODE")]
+        [StringLength(20)]
         public string ProjectTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsProject.ProjectTypeCodeNavigation))]
         public virtual ICollection<PimsProject> PimsProjects { get; set; }
     }
 }

--- a/backend/entities/ef/PimsProjectWorkflowModel.cs
+++ b/backend/entities/ef/PimsProjectWorkflowModel.cs
@@ -1,10 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROJECT_WORKFLOW_MODEL")]
+    [Index(nameof(ProjectId), Name = "PRWKMD_PROJECT_ID_IDX")]
+    [Index(nameof(ProjectId), nameof(WorkflowModelId), Name = "PRWKMD_PROJECT_WORKFLOW_MODEL_TUC", IsUnique = true)]
+    [Index(nameof(WorkflowModelId), Name = "PRWKMD_WORKFLOW_MODEL_ID_IDX")]
     public partial class PimsProjectWorkflowModel
     {
         public PimsProjectWorkflowModel()
@@ -12,26 +19,61 @@ namespace Pims.Dal.Entities
             PimsActivities = new HashSet<PimsActivity>();
         }
 
+        [Key]
+        [Column("PROJECT_WORKFLOW_MODEL_ID")]
         public long ProjectWorkflowModelId { get; set; }
+        [Column("PROJECT_ID")]
         public long ProjectId { get; set; }
+        [Column("WORKFLOW_MODEL_ID")]
         public long WorkflowModelId { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(ProjectId))]
+        [InverseProperty(nameof(PimsProject.PimsProjectWorkflowModels))]
         public virtual PimsProject Project { get; set; }
+        [ForeignKey(nameof(WorkflowModelId))]
+        [InverseProperty(nameof(PimsWorkflowModel.PimsProjectWorkflowModels))]
         public virtual PimsWorkflowModel WorkflowModel { get; set; }
+        [InverseProperty(nameof(PimsActivity.Workflow))]
         public virtual ICollection<PimsActivity> PimsActivities { get; set; }
     }
 }

--- a/backend/entities/ef/PimsProjectWorkflowModelHist.cs
+++ b/backend/entities/ef/PimsProjectWorkflowModelHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsProjectWorkflowModelHist.cs
+++ b/backend/entities/ef/PimsProjectWorkflowModelHist.cs
@@ -1,30 +1,69 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROJECT_WORKFLOW_MODEL_HIST")]
+    [Index(nameof(ProjectWorkflowModelHistId), nameof(EndDateHist), Name = "PIMS_PRWKMD_H_UK", IsUnique = true)]
     public partial class PimsProjectWorkflowModelHist
     {
+        [Key]
+        [Column("_PROJECT_WORKFLOW_MODEL_HIST_ID")]
         public long ProjectWorkflowModelHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("PROJECT_WORKFLOW_MODEL_ID")]
         public long ProjectWorkflowModelId { get; set; }
+        [Column("PROJECT_ID")]
         public long ProjectId { get; set; }
+        [Column("WORKFLOW_MODEL_ID")]
         public long WorkflowModelId { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsProperty.cs
+++ b/backend/entities/ef/PimsProperty.cs
@@ -1,11 +1,27 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 using NetTopologySuite.Geometries;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY")]
+    [Index(nameof(AddressId), Name = "PRPRTY_ADDRESS_ID_IDX")]
+    [Index(nameof(DistrictCode), Name = "PRPRTY_DISTRICT_CODE_IDX")]
+    [Index(nameof(PropertyAreaUnitTypeCode), Name = "PRPRTY_PROPERTY_AREA_UNIT_TYPE_CODE_IDX")]
+    [Index(nameof(PropertyClassificationTypeCode), Name = "PRPRTY_PROPERTY_CLASSIFICATION_TYPE_CODE_IDX")]
+    [Index(nameof(PropertyDataSourceTypeCode), Name = "PRPRTY_PROPERTY_DATA_SOURCE_TYPE_CODE_IDX")]
+    [Index(nameof(PropertyManagerId), Name = "PRPRTY_PROPERTY_MANAGER_ID_IDX")]
+    [Index(nameof(PropertyStatusTypeCode), Name = "PRPRTY_PROPERTY_STATUS_TYPE_CODE_IDX")]
+    [Index(nameof(PropertyTenureTypeCode), Name = "PRPRTY_PROPERTY_TENURE_TYPE_CODE_IDX")]
+    [Index(nameof(PropertyTypeCode), Name = "PRPRTY_PROPERTY_TYPE_CODE_IDX")]
+    [Index(nameof(PropMgmtOrgId), Name = "PRPRTY_PROP_MGMT_ORG_ID_IDX")]
+    [Index(nameof(RegionCode), Name = "PRPRTY_REGION_CODE_IDX")]
+    [Index(nameof(SurplusDeclarationTypeCode), Name = "PRPRTY_SURPLUS_DECLARATION_TYPE_CODE_IDX")]
     public partial class PimsProperty
     {
         public PimsProperty()
@@ -19,69 +35,181 @@ namespace Pims.Dal.Entities
             PimsPropertyTaxes = new HashSet<PimsPropertyTax>();
         }
 
+        [Key]
+        [Column("PROPERTY_ID")]
         public long PropertyId { get; set; }
+        [Column("PROPERTY_MANAGER_ID")]
         public long? PropertyManagerId { get; set; }
+        [Column("PROP_MGMT_ORG_ID")]
         public long? PropMgmtOrgId { get; set; }
+        [Required]
+        [Column("PROPERTY_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyTypeCode { get; set; }
+        [Required]
+        [Column("PROPERTY_CLASSIFICATION_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyClassificationTypeCode { get; set; }
+        [Column("ADDRESS_ID")]
         public long AddressId { get; set; }
+        [Column("REGION_CODE")]
         public short RegionCode { get; set; }
+        [Column("DISTRICT_CODE")]
         public short DistrictCode { get; set; }
+        [Required]
+        [Column("PROPERTY_TENURE_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyTenureTypeCode { get; set; }
+        [Required]
+        [Column("PROPERTY_AREA_UNIT_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyAreaUnitTypeCode { get; set; }
+        [Required]
+        [Column("PROPERTY_STATUS_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyStatusTypeCode { get; set; }
+        [Required]
+        [Column("SURPLUS_DECLARATION_TYPE_CODE")]
+        [StringLength(20)]
         public string SurplusDeclarationTypeCode { get; set; }
+        [Required]
+        [Column("PROPERTY_DATA_SOURCE_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyDataSourceTypeCode { get; set; }
+        [Column("PROPERTY_DATA_SOURCE_EFFECTIVE_DATE", TypeName = "date")]
         public DateTime PropertyDataSourceEffectiveDate { get; set; }
+        [Column("NAME")]
+        [StringLength(250)]
         public string Name { get; set; }
+        [Column("DESCRIPTION")]
+        [StringLength(2000)]
         public string Description { get; set; }
+        [Column("PID")]
         public int Pid { get; set; }
+        [Column("PIN")]
         public int? Pin { get; set; }
+        [Column("LAND_AREA")]
         public float LandArea { get; set; }
+        [Column("LAND_LEGAL_DESCRIPTION")]
         public string LandLegalDescription { get; set; }
+        [Column("BOUNDARY", TypeName = "geometry")]
         public Geometry Boundary { get; set; }
+        [Column("LOCATION", TypeName = "geometry")]
         public Geometry Location { get; set; }
+        [Column("ENCUMBRANCE_REASON")]
+        [StringLength(500)]
         public string EncumbranceReason { get; set; }
+        [Column("SURPLUS_DECLARATION_COMMENT")]
+        [StringLength(2000)]
         public string SurplusDeclarationComment { get; set; }
+        [Column("SURPLUS_DECLARATION_DATE", TypeName = "datetime")]
         public DateTime? SurplusDeclarationDate { get; set; }
+        [Required]
+        [Column("IS_OWNED")]
         public bool? IsOwned { get; set; }
+        [Required]
+        [Column("IS_PROPERTY_OF_INTEREST")]
         public bool? IsPropertyOfInterest { get; set; }
+        [Required]
+        [Column("IS_VISIBLE_TO_OTHER_AGENCIES")]
         public bool? IsVisibleToOtherAgencies { get; set; }
+        [Required]
+        [Column("IS_SENSITIVE")]
         public bool? IsSensitive { get; set; }
+        [Column("ZONING")]
+        [StringLength(50)]
         public string Zoning { get; set; }
+        [Column("ZONING_POTENTIAL")]
+        [StringLength(50)]
         public string ZoningPotential { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(AddressId))]
+        [InverseProperty(nameof(PimsAddress.PimsProperties))]
         public virtual PimsAddress Address { get; set; }
+        [ForeignKey(nameof(DistrictCode))]
+        [InverseProperty(nameof(PimsDistrict.PimsProperties))]
         public virtual PimsDistrict DistrictCodeNavigation { get; set; }
+        [ForeignKey(nameof(PropMgmtOrgId))]
+        [InverseProperty(nameof(PimsOrganization.PimsProperties))]
         public virtual PimsOrganization PropMgmtOrg { get; set; }
+        [ForeignKey(nameof(PropertyAreaUnitTypeCode))]
+        [InverseProperty(nameof(PimsAreaUnitType.PimsProperties))]
         public virtual PimsAreaUnitType PropertyAreaUnitTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(PropertyClassificationTypeCode))]
+        [InverseProperty(nameof(PimsPropertyClassificationType.PimsProperties))]
         public virtual PimsPropertyClassificationType PropertyClassificationTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(PropertyDataSourceTypeCode))]
+        [InverseProperty(nameof(PimsDataSourceType.PimsProperties))]
         public virtual PimsDataSourceType PropertyDataSourceTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(PropertyManagerId))]
+        [InverseProperty(nameof(PimsPerson.PimsProperties))]
         public virtual PimsPerson PropertyManager { get; set; }
+        [ForeignKey(nameof(PropertyStatusTypeCode))]
+        [InverseProperty(nameof(PimsPropertyStatusType.PimsProperties))]
         public virtual PimsPropertyStatusType PropertyStatusTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(PropertyTenureTypeCode))]
+        [InverseProperty(nameof(PimsPropertyTenureType.PimsProperties))]
         public virtual PimsPropertyTenureType PropertyTenureTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(PropertyTypeCode))]
+        [InverseProperty(nameof(PimsPropertyType.PimsProperties))]
         public virtual PimsPropertyType PropertyTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(RegionCode))]
+        [InverseProperty(nameof(PimsRegion.PimsProperties))]
         public virtual PimsRegion RegionCodeNavigation { get; set; }
+        [ForeignKey(nameof(SurplusDeclarationTypeCode))]
+        [InverseProperty(nameof(PimsSurplusDeclarationType.PimsProperties))]
         public virtual PimsSurplusDeclarationType SurplusDeclarationTypeCodeNavigation { get; set; }
+        [InverseProperty(nameof(PimsProjectProperty.Property))]
         public virtual ICollection<PimsProjectProperty> PimsProjectProperties { get; set; }
+        [InverseProperty(nameof(PimsPropertyActivity.Property))]
         public virtual ICollection<PimsPropertyActivity> PimsPropertyActivities { get; set; }
+        [InverseProperty(nameof(PimsPropertyEvaluation.Property))]
         public virtual ICollection<PimsPropertyEvaluation> PimsPropertyEvaluations { get; set; }
+        [InverseProperty(nameof(PimsPropertyLease.Property))]
         public virtual ICollection<PimsPropertyLease> PimsPropertyLeases { get; set; }
+        [InverseProperty(nameof(PimsPropertyOrganization.Property))]
         public virtual ICollection<PimsPropertyOrganization> PimsPropertyOrganizations { get; set; }
+        [InverseProperty(nameof(PimsPropertyPropertyServiceFile.Property))]
         public virtual ICollection<PimsPropertyPropertyServiceFile> PimsPropertyPropertyServiceFiles { get; set; }
+        [InverseProperty(nameof(PimsPropertyTax.Property))]
         public virtual ICollection<PimsPropertyTax> PimsPropertyTaxes { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyActivity.cs
+++ b/backend/entities/ef/PimsPropertyActivity.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPropertyActivity.cs
+++ b/backend/entities/ef/PimsPropertyActivity.cs
@@ -1,30 +1,72 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_ACTIVITY")]
+    [Index(nameof(ActivityId), Name = "PRPACT_ACTIVITY_ID_IDX")]
+    [Index(nameof(PropertyId), nameof(ActivityId), Name = "PRPACT_PROPERTY_ACTIVITY_TUC", IsUnique = true)]
+    [Index(nameof(PropertyId), Name = "PRPACT_PROPERTY_ID_IDX")]
     public partial class PimsPropertyActivity
     {
+        [Key]
+        [Column("PROPERTY_ACTIVITY_ID")]
         public long PropertyActivityId { get; set; }
+        [Column("ACTIVITY_ID")]
         public long? ActivityId { get; set; }
+        [Column("PROPERTY_ID")]
         public long? PropertyId { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(ActivityId))]
+        [InverseProperty(nameof(PimsActivity.PimsPropertyActivities))]
         public virtual PimsActivity Activity { get; set; }
+        [ForeignKey(nameof(PropertyId))]
+        [InverseProperty(nameof(PimsProperty.PimsPropertyActivities))]
         public virtual PimsProperty Property { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyActivityHist.cs
+++ b/backend/entities/ef/PimsPropertyActivityHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPropertyActivityHist.cs
+++ b/backend/entities/ef/PimsPropertyActivityHist.cs
@@ -1,30 +1,69 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_ACTIVITY_HIST")]
+    [Index(nameof(PropertyActivityHistId), nameof(EndDateHist), Name = "PIMS_PRPACT_H_UK", IsUnique = true)]
     public partial class PimsPropertyActivityHist
     {
+        [Key]
+        [Column("_PROPERTY_ACTIVITY_HIST_ID")]
         public long PropertyActivityHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("PROPERTY_ACTIVITY_ID")]
         public long PropertyActivityId { get; set; }
+        [Column("ACTIVITY_ID")]
         public long? ActivityId { get; set; }
+        [Column("PROPERTY_ID")]
         public long? PropertyId { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyBoundaryVw.cs
+++ b/backend/entities/ef/PimsPropertyBoundaryVw.cs
@@ -1,46 +1,117 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 using NetTopologySuite.Geometries;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Keyless]
     public partial class PimsPropertyBoundaryVw
     {
+        [Column("PROPERTY_ID")]
         public long PropertyId { get; set; }
+        [Column("PID")]
         public int Pid { get; set; }
+        [Column("PID_PADDED")]
+        [StringLength(9)]
         public string PidPadded { get; set; }
+        [Column("PIN")]
         public int? Pin { get; set; }
+        [Required]
+        [Column("PROPERTY_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyTypeCode { get; set; }
+        [Required]
+        [Column("PROPERTY_STATUS_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyStatusTypeCode { get; set; }
+        [Required]
+        [Column("PROPERTY_DATA_SOURCE_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyDataSourceTypeCode { get; set; }
+        [Column("PROPERTY_DATA_SOURCE_EFFECTIVE_DATE", TypeName = "date")]
         public DateTime PropertyDataSourceEffectiveDate { get; set; }
+        [Required]
+        [Column("PROPERTY_CLASSIFICATION_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyClassificationTypeCode { get; set; }
+        [Required]
+        [Column("PROPERTY_TENURE_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyTenureTypeCode { get; set; }
+        [Column("STREET_ADDRESS_1")]
+        [StringLength(200)]
         public string StreetAddress1 { get; set; }
+        [Column("STREET_ADDRESS_2")]
+        [StringLength(200)]
         public string StreetAddress2 { get; set; }
+        [Column("STREET_ADDRESS_3")]
+        [StringLength(200)]
         public string StreetAddress3 { get; set; }
+        [Column("MUNICIPALITY_NAME")]
+        [StringLength(200)]
         public string MunicipalityName { get; set; }
+        [Column("POSTAL_CODE")]
+        [StringLength(20)]
         public string PostalCode { get; set; }
+        [Required]
+        [Column("PROVINCE_STATE_CODE")]
+        [StringLength(20)]
         public string ProvinceStateCode { get; set; }
+        [Required]
+        [Column("PROVINCE_NAME")]
+        [StringLength(200)]
         public string ProvinceName { get; set; }
+        [Required]
+        [Column("COUNTRY_CODE")]
+        [StringLength(20)]
         public string CountryCode { get; set; }
+        [Required]
+        [Column("COUNTRY_NAME")]
+        [StringLength(200)]
         public string CountryName { get; set; }
+        [Column("NAME")]
+        [StringLength(250)]
         public string Name { get; set; }
+        [Column("DESCRIPTION")]
+        [StringLength(2000)]
         public string Description { get; set; }
+        [Column("ADDRESS_ID")]
         public long AddressId { get; set; }
+        [Column("REGION_CODE")]
         public short RegionCode { get; set; }
+        [Column("DISTRICT_CODE")]
         public short DistrictCode { get; set; }
+        [Column("GEOMETRY", TypeName = "geometry")]
         public Geometry Geometry { get; set; }
+        [Required]
+        [Column("PROPERTY_AREA_UNIT_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyAreaUnitTypeCode { get; set; }
+        [Column("LAND_AREA")]
         public float LandArea { get; set; }
+        [Column("LAND_LEGAL_DESCRIPTION")]
         public string LandLegalDescription { get; set; }
+        [Column("ENCUMBRANCE_REASON")]
+        [StringLength(500)]
         public string EncumbranceReason { get; set; }
+        [Column("IS_SENSITIVE")]
         public bool IsSensitive { get; set; }
+        [Column("IS_OWNED")]
         public bool IsOwned { get; set; }
+        [Column("IS_PROPERTY_OF_INTEREST")]
         public bool IsPropertyOfInterest { get; set; }
+        [Column("IS_VISIBLE_TO_OTHER_AGENCIES")]
         public bool IsVisibleToOtherAgencies { get; set; }
+        [Column("ZONING")]
+        [StringLength(50)]
         public string Zoning { get; set; }
+        [Column("ZONING_POTENTIAL")]
+        [StringLength(50)]
         public string ZoningPotential { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyBoundaryVw.cs
+++ b/backend/entities/ef/PimsPropertyBoundaryVw.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using NetTopologySuite.Geometries;
 
 #nullable disable

--- a/backend/entities/ef/PimsPropertyClassificationType.cs
+++ b/backend/entities/ef/PimsPropertyClassificationType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_CLASSIFICATION_TYPE")]
     public partial class PimsPropertyClassificationType
     {
         public PimsPropertyClassificationType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsProperties = new HashSet<PimsProperty>();
         }
 
+        [Key]
+        [Column("PROPERTY_CLASSIFICATION_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyClassificationTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsProperty.PropertyClassificationTypeCodeNavigation))]
         public virtual ICollection<PimsProperty> PimsProperties { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyEvaluation.cs
+++ b/backend/entities/ef/PimsPropertyEvaluation.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPropertyEvaluation.cs
+++ b/backend/entities/ef/PimsPropertyEvaluation.cs
@@ -1,31 +1,72 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_EVALUATION")]
+    [Index(nameof(PropertyId), Name = "PRPEVL_PROPERTY_ID_IDX")]
     public partial class PimsPropertyEvaluation
     {
+        [Key]
+        [Column("PROPERTY_EVALUATION_ID")]
         public long PropertyEvaluationId { get; set; }
+        [Column("PROPERTY_ID")]
         public long PropertyId { get; set; }
+        [Column("EVALUATION_DATE", TypeName = "date")]
         public DateTime EvaluationDate { get; set; }
+        [Column("KEY")]
         public int Key { get; set; }
+        [Column("VALUE", TypeName = "money")]
         public decimal Value { get; set; }
+        [Column("NOTE")]
+        [StringLength(1000)]
         public string Note { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(PropertyId))]
+        [InverseProperty(nameof(PimsProperty.PimsPropertyEvaluations))]
         public virtual PimsProperty Property { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyEvaluationHist.cs
+++ b/backend/entities/ef/PimsPropertyEvaluationHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPropertyEvaluationHist.cs
+++ b/backend/entities/ef/PimsPropertyEvaluationHist.cs
@@ -1,32 +1,74 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_EVALUATION_HIST")]
+    [Index(nameof(PropertyEvaluationHistId), nameof(EndDateHist), Name = "PIMS_PRPEVL_H_UK", IsUnique = true)]
     public partial class PimsPropertyEvaluationHist
     {
+        [Key]
+        [Column("_PROPERTY_EVALUATION_HIST_ID")]
         public long PropertyEvaluationHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("PROPERTY_EVALUATION_ID")]
         public long PropertyEvaluationId { get; set; }
+        [Column("PROPERTY_ID")]
         public long PropertyId { get; set; }
+        [Column("EVALUATION_DATE", TypeName = "date")]
         public DateTime EvaluationDate { get; set; }
+        [Column("KEY")]
         public int Key { get; set; }
+        [Column("VALUE", TypeName = "money")]
         public decimal Value { get; set; }
+        [Column("NOTE")]
+        [StringLength(1000)]
         public string Note { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyHist.cs
+++ b/backend/entities/ef/PimsPropertyHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPropertyHist.cs
+++ b/backend/entities/ef/PimsPropertyHist.cs
@@ -1,54 +1,137 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_HIST")]
+    [Index(nameof(PropertyHistId), nameof(EndDateHist), Name = "PIMS_PRPRTY_H_UK", IsUnique = true)]
     public partial class PimsPropertyHist
     {
+        [Key]
+        [Column("_PROPERTY_HIST_ID")]
         public long PropertyHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("PROPERTY_ID")]
         public long PropertyId { get; set; }
+        [Column("PROPERTY_MANAGER_ID")]
         public long? PropertyManagerId { get; set; }
+        [Column("PROP_MGMT_ORG_ID")]
         public long? PropMgmtOrgId { get; set; }
+        [Required]
+        [Column("PROPERTY_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyTypeCode { get; set; }
+        [Required]
+        [Column("PROPERTY_CLASSIFICATION_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyClassificationTypeCode { get; set; }
+        [Column("ADDRESS_ID")]
         public long AddressId { get; set; }
+        [Column("REGION_CODE")]
         public short RegionCode { get; set; }
+        [Column("DISTRICT_CODE")]
         public short DistrictCode { get; set; }
+        [Required]
+        [Column("PROPERTY_TENURE_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyTenureTypeCode { get; set; }
+        [Required]
+        [Column("PROPERTY_AREA_UNIT_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyAreaUnitTypeCode { get; set; }
+        [Required]
+        [Column("PROPERTY_STATUS_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyStatusTypeCode { get; set; }
+        [Required]
+        [Column("SURPLUS_DECLARATION_TYPE_CODE")]
+        [StringLength(20)]
         public string SurplusDeclarationTypeCode { get; set; }
+        [Required]
+        [Column("PROPERTY_DATA_SOURCE_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyDataSourceTypeCode { get; set; }
+        [Column("PROPERTY_DATA_SOURCE_EFFECTIVE_DATE", TypeName = "date")]
         public DateTime PropertyDataSourceEffectiveDate { get; set; }
+        [Column("NAME")]
+        [StringLength(250)]
         public string Name { get; set; }
+        [Column("DESCRIPTION")]
+        [StringLength(2000)]
         public string Description { get; set; }
+        [Column("PID")]
         public int Pid { get; set; }
+        [Column("PIN")]
         public int? Pin { get; set; }
+        [Column("LAND_AREA")]
         public float LandArea { get; set; }
+        [Column("ENCUMBRANCE_REASON")]
+        [StringLength(500)]
         public string EncumbranceReason { get; set; }
+        [Column("SURPLUS_DECLARATION_COMMENT")]
+        [StringLength(2000)]
         public string SurplusDeclarationComment { get; set; }
+        [Column("SURPLUS_DECLARATION_DATE", TypeName = "datetime")]
         public DateTime? SurplusDeclarationDate { get; set; }
+        [Column("IS_OWNED")]
         public bool IsOwned { get; set; }
+        [Column("IS_PROPERTY_OF_INTEREST")]
         public bool IsPropertyOfInterest { get; set; }
+        [Column("IS_VISIBLE_TO_OTHER_AGENCIES")]
         public bool IsVisibleToOtherAgencies { get; set; }
+        [Column("IS_SENSITIVE")]
         public bool IsSensitive { get; set; }
+        [Column("ZONING")]
+        [StringLength(50)]
         public string Zoning { get; set; }
+        [Column("ZONING_POTENTIAL")]
+        [StringLength(50)]
         public string ZoningPotential { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyImprovement.cs
+++ b/backend/entities/ef/PimsPropertyImprovement.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPropertyImprovement.cs
+++ b/backend/entities/ef/PimsPropertyImprovement.cs
@@ -1,32 +1,82 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_IMPROVEMENT")]
+    [Index(nameof(LeaseId), nameof(PropertyImprovementTypeCode), Name = "PIMPRV_LEASE_IMPROVEMENT_TUC", IsUnique = true)]
+    [Index(nameof(PropertyImprovementTypeCode), Name = "PIMPRV_PROPERTY_IMPROVEMENT_TYPE_CODE_IDX")]
+    [Index(nameof(LeaseId), Name = "PIMPRV_PROPERTY_LEASE_ID_IDX")]
     public partial class PimsPropertyImprovement
     {
+        [Key]
+        [Column("PROPERTY_IMPROVEMENT_ID")]
         public long PropertyImprovementId { get; set; }
+        [Column("LEASE_ID")]
         public long LeaseId { get; set; }
+        [Required]
+        [Column("PROPERTY_IMPROVEMENT_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyImprovementTypeCode { get; set; }
+        [Required]
+        [Column("IMPROVEMENT_DESCRIPTION")]
+        [StringLength(2000)]
         public string ImprovementDescription { get; set; }
+        [Column("STRUCTURE_SIZE")]
+        [StringLength(2000)]
         public string StructureSize { get; set; }
+        [Column("UNIT")]
+        [StringLength(2000)]
         public string Unit { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(LeaseId))]
+        [InverseProperty(nameof(PimsLease.PimsPropertyImprovements))]
         public virtual PimsLease Lease { get; set; }
+        [ForeignKey(nameof(PropertyImprovementTypeCode))]
+        [InverseProperty(nameof(PimsPropertyImprovementType.PimsPropertyImprovements))]
         public virtual PimsPropertyImprovementType PropertyImprovementTypeCodeNavigation { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyImprovementHist.cs
+++ b/backend/entities/ef/PimsPropertyImprovementHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPropertyImprovementHist.cs
+++ b/backend/entities/ef/PimsPropertyImprovementHist.cs
@@ -1,32 +1,79 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_IMPROVEMENT_HIST")]
+    [Index(nameof(PropertyImprovementHistId), nameof(EndDateHist), Name = "PIMS_PIMPRV_H_UK", IsUnique = true)]
     public partial class PimsPropertyImprovementHist
     {
+        [Key]
+        [Column("_PROPERTY_IMPROVEMENT_HIST_ID")]
         public long PropertyImprovementHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("PROPERTY_IMPROVEMENT_ID")]
         public long PropertyImprovementId { get; set; }
+        [Column("LEASE_ID")]
         public long LeaseId { get; set; }
+        [Required]
+        [Column("PROPERTY_IMPROVEMENT_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyImprovementTypeCode { get; set; }
+        [Required]
+        [Column("IMPROVEMENT_DESCRIPTION")]
+        [StringLength(2000)]
         public string ImprovementDescription { get; set; }
+        [Column("STRUCTURE_SIZE")]
+        [StringLength(2000)]
         public string StructureSize { get; set; }
+        [Column("UNIT")]
+        [StringLength(2000)]
         public string Unit { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyImprovementType.cs
+++ b/backend/entities/ef/PimsPropertyImprovementType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_IMPROVEMENT_TYPE")]
     public partial class PimsPropertyImprovementType
     {
         public PimsPropertyImprovementType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsPropertyImprovements = new HashSet<PimsPropertyImprovement>();
         }
 
+        [Key]
+        [Column("PROPERTY_IMPROVEMENT_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyImprovementTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsPropertyImprovement.PropertyImprovementTypeCodeNavigation))]
         public virtual ICollection<PimsPropertyImprovement> PimsPropertyImprovements { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyLease.cs
+++ b/backend/entities/ef/PimsPropertyLease.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPropertyLease.cs
+++ b/backend/entities/ef/PimsPropertyLease.cs
@@ -1,32 +1,77 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_LEASE")]
+    [Index(nameof(LeaseId), Name = "PROPLS_LEASE_ID_IDX")]
+    [Index(nameof(PropertyId), Name = "PROPLS_PROPERTY_ID_IDX")]
     public partial class PimsPropertyLease
     {
+        [Key]
+        [Column("PROPERTY_LEASE_ID")]
         public long PropertyLeaseId { get; set; }
+        [Column("PROPERTY_ID")]
         public long PropertyId { get; set; }
+        [Column("LEASE_ID")]
         public long LeaseId { get; set; }
+        [Column("AREA_UNIT_TYPE_CODE")]
+        [StringLength(20)]
         public string AreaUnitTypeCode { get; set; }
+        [Column("LEASE_AREA")]
         public float? LeaseArea { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(AreaUnitTypeCode))]
+        [InverseProperty(nameof(PimsAreaUnitType.PimsPropertyLeases))]
         public virtual PimsAreaUnitType AreaUnitTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(LeaseId))]
+        [InverseProperty(nameof(PimsLease.PimsPropertyLeases))]
         public virtual PimsLease Lease { get; set; }
+        [ForeignKey(nameof(PropertyId))]
+        [InverseProperty(nameof(PimsProperty.PimsPropertyLeases))]
         public virtual PimsProperty Property { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyLeaseHist.cs
+++ b/backend/entities/ef/PimsPropertyLeaseHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPropertyLeaseHist.cs
+++ b/backend/entities/ef/PimsPropertyLeaseHist.cs
@@ -1,31 +1,72 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_LEASE_HIST")]
+    [Index(nameof(PropertyLeaseHistId), nameof(EndDateHist), Name = "PIMS_PROPLS_H_UK", IsUnique = true)]
     public partial class PimsPropertyLeaseHist
     {
+        [Key]
+        [Column("_PROPERTY_LEASE_HIST_ID")]
         public long PropertyLeaseHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("PROPERTY_LEASE_ID")]
         public long PropertyLeaseId { get; set; }
+        [Column("PROPERTY_ID")]
         public long PropertyId { get; set; }
+        [Column("LEASE_ID")]
         public long LeaseId { get; set; }
+        [Column("AREA_UNIT_TYPE_CODE")]
+        [StringLength(20)]
         public string AreaUnitTypeCode { get; set; }
+        [Column("LEASE_AREA")]
         public float? LeaseArea { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyLocationVw.cs
+++ b/backend/entities/ef/PimsPropertyLocationVw.cs
@@ -1,46 +1,117 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 using NetTopologySuite.Geometries;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Keyless]
     public partial class PimsPropertyLocationVw
     {
+        [Column("PROPERTY_ID")]
         public long PropertyId { get; set; }
+        [Column("PID")]
         public int Pid { get; set; }
+        [Column("PID_PADDED")]
+        [StringLength(9)]
         public string PidPadded { get; set; }
+        [Column("PIN")]
         public int? Pin { get; set; }
+        [Required]
+        [Column("PROPERTY_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyTypeCode { get; set; }
+        [Required]
+        [Column("PROPERTY_STATUS_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyStatusTypeCode { get; set; }
+        [Required]
+        [Column("PROPERTY_DATA_SOURCE_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyDataSourceTypeCode { get; set; }
+        [Column("PROPERTY_DATA_SOURCE_EFFECTIVE_DATE", TypeName = "date")]
         public DateTime PropertyDataSourceEffectiveDate { get; set; }
+        [Required]
+        [Column("PROPERTY_CLASSIFICATION_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyClassificationTypeCode { get; set; }
+        [Required]
+        [Column("PROPERTY_TENURE_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyTenureTypeCode { get; set; }
+        [Column("STREET_ADDRESS_1")]
+        [StringLength(200)]
         public string StreetAddress1 { get; set; }
+        [Column("STREET_ADDRESS_2")]
+        [StringLength(200)]
         public string StreetAddress2 { get; set; }
+        [Column("STREET_ADDRESS_3")]
+        [StringLength(200)]
         public string StreetAddress3 { get; set; }
+        [Column("MUNICIPALITY_NAME")]
+        [StringLength(200)]
         public string MunicipalityName { get; set; }
+        [Column("POSTAL_CODE")]
+        [StringLength(20)]
         public string PostalCode { get; set; }
+        [Required]
+        [Column("PROVINCE_STATE_CODE")]
+        [StringLength(20)]
         public string ProvinceStateCode { get; set; }
+        [Required]
+        [Column("PROVINCE_NAME")]
+        [StringLength(200)]
         public string ProvinceName { get; set; }
+        [Required]
+        [Column("COUNTRY_CODE")]
+        [StringLength(20)]
         public string CountryCode { get; set; }
+        [Required]
+        [Column("COUNTRY_NAME")]
+        [StringLength(200)]
         public string CountryName { get; set; }
+        [Column("NAME")]
+        [StringLength(250)]
         public string Name { get; set; }
+        [Column("DESCRIPTION")]
+        [StringLength(2000)]
         public string Description { get; set; }
+        [Column("ADDRESS_ID")]
         public long AddressId { get; set; }
+        [Column("REGION_CODE")]
         public short RegionCode { get; set; }
+        [Column("DISTRICT_CODE")]
         public short DistrictCode { get; set; }
+        [Column("GEOMETRY", TypeName = "geometry")]
         public Geometry Geometry { get; set; }
+        [Required]
+        [Column("PROPERTY_AREA_UNIT_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyAreaUnitTypeCode { get; set; }
+        [Column("LAND_AREA")]
         public float LandArea { get; set; }
+        [Column("LAND_LEGAL_DESCRIPTION")]
         public string LandLegalDescription { get; set; }
+        [Column("ENCUMBRANCE_REASON")]
+        [StringLength(500)]
         public string EncumbranceReason { get; set; }
+        [Column("IS_SENSITIVE")]
         public bool IsSensitive { get; set; }
+        [Column("IS_OWNED")]
         public bool IsOwned { get; set; }
+        [Column("IS_PROPERTY_OF_INTEREST")]
         public bool IsPropertyOfInterest { get; set; }
+        [Column("IS_VISIBLE_TO_OTHER_AGENCIES")]
         public bool IsVisibleToOtherAgencies { get; set; }
+        [Column("ZONING")]
+        [StringLength(50)]
         public string Zoning { get; set; }
+        [Column("ZONING_POTENTIAL")]
+        [StringLength(50)]
         public string ZoningPotential { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyLocationVw.cs
+++ b/backend/entities/ef/PimsPropertyLocationVw.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using NetTopologySuite.Geometries;
 
 #nullable disable

--- a/backend/entities/ef/PimsPropertyOrganization.cs
+++ b/backend/entities/ef/PimsPropertyOrganization.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPropertyOrganization.cs
+++ b/backend/entities/ef/PimsPropertyOrganization.cs
@@ -1,30 +1,72 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_ORGANIZATION")]
+    [Index(nameof(OrganizationId), Name = "PRPORG_ORGANIZATION_ID_IDX")]
+    [Index(nameof(PropertyId), Name = "PRPORG_PROPERTY_ID_IDX")]
+    [Index(nameof(PropertyId), nameof(OrganizationId), Name = "PRPORG_PROPERTY_ORGANIZATION_TUC", IsUnique = true)]
     public partial class PimsPropertyOrganization
     {
+        [Key]
+        [Column("PROPERTY_ORGANIZATION_ID")]
         public long PropertyOrganizationId { get; set; }
+        [Column("PROPERTY_ID")]
         public long PropertyId { get; set; }
+        [Column("ORGANIZATION_ID")]
         public long OrganizationId { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
 
+        [ForeignKey(nameof(OrganizationId))]
+        [InverseProperty(nameof(PimsOrganization.PimsPropertyOrganizations))]
         public virtual PimsOrganization Organization { get; set; }
+        [ForeignKey(nameof(PropertyId))]
+        [InverseProperty(nameof(PimsProperty.PimsPropertyOrganizations))]
         public virtual PimsProperty Property { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyOrganizationHist.cs
+++ b/backend/entities/ef/PimsPropertyOrganizationHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPropertyOrganizationHist.cs
+++ b/backend/entities/ef/PimsPropertyOrganizationHist.cs
@@ -1,30 +1,69 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_ORGANIZATION_HIST")]
+    [Index(nameof(PropertyOrganizationHistId), nameof(EndDateHist), Name = "PIMS_PRPORG_H_UK", IsUnique = true)]
     public partial class PimsPropertyOrganizationHist
     {
+        [Key]
+        [Column("_PROPERTY_ORGANIZATION_HIST_ID")]
         public long PropertyOrganizationHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("PROPERTY_ORGANIZATION_ID")]
         public long PropertyOrganizationId { get; set; }
+        [Column("PROPERTY_ID")]
         public long PropertyId { get; set; }
+        [Column("ORGANIZATION_ID")]
         public long OrganizationId { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyPropertyServiceFile.cs
+++ b/backend/entities/ef/PimsPropertyPropertyServiceFile.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPropertyPropertyServiceFile.cs
+++ b/backend/entities/ef/PimsPropertyPropertyServiceFile.cs
@@ -1,30 +1,72 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_PROPERTY_SERVICE_FILE")]
+    [Index(nameof(PropertyId), Name = "PRPRSF_PROPERTY_ID_IDX")]
+    [Index(nameof(PropertyServiceFileId), Name = "PRPRSF_PROPERTY_SERVICE_FILE_ID_IDX")]
+    [Index(nameof(PropertyId), nameof(PropertyServiceFileId), Name = "PRPRSF_PROPERTY_SERVICE_FILE_TUC", IsUnique = true)]
     public partial class PimsPropertyPropertyServiceFile
     {
+        [Key]
+        [Column("PROPERTY_PROPERTY_SERVICE_FILE_ID")]
         public long PropertyPropertyServiceFileId { get; set; }
+        [Column("PROPERTY_ID")]
         public long PropertyId { get; set; }
+        [Column("PROPERTY_SERVICE_FILE_ID")]
         public long PropertyServiceFileId { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(PropertyId))]
+        [InverseProperty(nameof(PimsProperty.PimsPropertyPropertyServiceFiles))]
         public virtual PimsProperty Property { get; set; }
+        [ForeignKey(nameof(PropertyServiceFileId))]
+        [InverseProperty(nameof(PimsPropertyServiceFile.PimsPropertyPropertyServiceFiles))]
         public virtual PimsPropertyServiceFile PropertyServiceFile { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyPropertyServiceFileHist.cs
+++ b/backend/entities/ef/PimsPropertyPropertyServiceFileHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPropertyPropertyServiceFileHist.cs
+++ b/backend/entities/ef/PimsPropertyPropertyServiceFileHist.cs
@@ -1,30 +1,69 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_PROPERTY_SERVICE_FILE_HIST")]
+    [Index(nameof(PropertyPropertyServiceFileHistId), nameof(EndDateHist), Name = "PIMS_PRPRSF_H_UK", IsUnique = true)]
     public partial class PimsPropertyPropertyServiceFileHist
     {
+        [Key]
+        [Column("_PROPERTY_PROPERTY_SERVICE_FILE_HIST_ID")]
         public long PropertyPropertyServiceFileHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("PROPERTY_PROPERTY_SERVICE_FILE_ID")]
         public long PropertyPropertyServiceFileId { get; set; }
+        [Column("PROPERTY_ID")]
         public long PropertyId { get; set; }
+        [Column("PROPERTY_SERVICE_FILE_ID")]
         public long PropertyServiceFileId { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyServiceFile.cs
+++ b/backend/entities/ef/PimsPropertyServiceFile.cs
@@ -1,10 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_SERVICE_FILE")]
+    [Index(nameof(PropertyServiceFileTypeCode), Name = "PRPSVC_PROPERTY_SERVICE_FILE_TYPE_CODE_IDX")]
     public partial class PimsPropertyServiceFile
     {
         public PimsPropertyServiceFile()
@@ -12,23 +17,56 @@ namespace Pims.Dal.Entities
             PimsPropertyPropertyServiceFiles = new HashSet<PimsPropertyPropertyServiceFile>();
         }
 
+        [Key]
+        [Column("PROPERTY_SERVICE_FILE_ID")]
         public long PropertyServiceFileId { get; set; }
+        [Required]
+        [Column("PROPERTY_SERVICE_FILE_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyServiceFileTypeCode { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(PropertyServiceFileTypeCode))]
+        [InverseProperty(nameof(PimsPropertyServiceFileType.PimsPropertyServiceFiles))]
         public virtual PimsPropertyServiceFileType PropertyServiceFileTypeCodeNavigation { get; set; }
+        [InverseProperty(nameof(PimsPropertyPropertyServiceFile.PropertyServiceFile))]
         public virtual ICollection<PimsPropertyPropertyServiceFile> PimsPropertyPropertyServiceFiles { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyServiceFileHist.cs
+++ b/backend/entities/ef/PimsPropertyServiceFileHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPropertyServiceFileHist.cs
+++ b/backend/entities/ef/PimsPropertyServiceFileHist.cs
@@ -1,28 +1,67 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_SERVICE_FILE_HIST")]
+    [Index(nameof(PropertyServiceFileHistId), nameof(EndDateHist), Name = "PIMS_PRPSVC_H_UK", IsUnique = true)]
     public partial class PimsPropertyServiceFileHist
     {
+        [Key]
+        [Column("_PROPERTY_SERVICE_FILE_HIST_ID")]
         public long PropertyServiceFileHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("PROPERTY_SERVICE_FILE_ID")]
         public long PropertyServiceFileId { get; set; }
+        [Required]
+        [Column("PROPERTY_SERVICE_FILE_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyServiceFileTypeCode { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyServiceFileType.cs
+++ b/backend/entities/ef/PimsPropertyServiceFileType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_SERVICE_FILE_TYPE")]
     public partial class PimsPropertyServiceFileType
     {
         public PimsPropertyServiceFileType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsPropertyServiceFiles = new HashSet<PimsPropertyServiceFile>();
         }
 
+        [Key]
+        [Column("PROPERTY_SERVICE_FILE_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyServiceFileTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsPropertyServiceFile.PropertyServiceFileTypeCodeNavigation))]
         public virtual ICollection<PimsPropertyServiceFile> PimsPropertyServiceFiles { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyStatusType.cs
+++ b/backend/entities/ef/PimsPropertyStatusType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_STATUS_TYPE")]
     public partial class PimsPropertyStatusType
     {
         public PimsPropertyStatusType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsProperties = new HashSet<PimsProperty>();
         }
 
+        [Key]
+        [Column("PROPERTY_STATUS_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyStatusTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsProperty.PropertyStatusTypeCodeNavigation))]
         public virtual ICollection<PimsProperty> PimsProperties { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyTax.cs
+++ b/backend/entities/ef/PimsPropertyTax.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPropertyTax.cs
+++ b/backend/entities/ef/PimsPropertyTax.cs
@@ -1,34 +1,83 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_TAX")]
+    [Index(nameof(PropertyId), Name = "PRPTAX_PROPERTY_ID_IDX")]
+    [Index(nameof(PropertyTaxRemitTypeCode), Name = "PRPTAX_PROPERTY_TAX_REMIT_TYPE_CODE_IDX")]
     public partial class PimsPropertyTax
     {
+        [Key]
+        [Column("PROPERTY_TAX_ID")]
         public long PropertyTaxId { get; set; }
+        [Column("PROPERTY_ID")]
         public long PropertyId { get; set; }
+        [Required]
+        [Column("PROPERTY_TAX_REMIT_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyTaxRemitTypeCode { get; set; }
+        [Required]
+        [Column("TAX_FOLIO_NO")]
+        [StringLength(50)]
         public string TaxFolioNo { get; set; }
+        [Column("PAYMENT_AMOUNT", TypeName = "money")]
         public decimal PaymentAmount { get; set; }
+        [Column("LAST_PAYMENT_DATE", TypeName = "datetime")]
         public DateTime? LastPaymentDate { get; set; }
+        [Column("PAYMENT_NOTES", TypeName = "money")]
         public decimal? PaymentNotes { get; set; }
+        [Column("BCTFA_NOTIFICATION_DATE", TypeName = "datetime")]
         public DateTime? BctfaNotificationDate { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(PropertyId))]
+        [InverseProperty(nameof(PimsProperty.PimsPropertyTaxes))]
         public virtual PimsProperty Property { get; set; }
+        [ForeignKey(nameof(PropertyTaxRemitTypeCode))]
+        [InverseProperty(nameof(PimsPropertyTaxRemitType.PimsPropertyTaxes))]
         public virtual PimsPropertyTaxRemitType PropertyTaxRemitTypeCodeNavigation { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyTaxHist.cs
+++ b/backend/entities/ef/PimsPropertyTaxHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsPropertyTaxHist.cs
+++ b/backend/entities/ef/PimsPropertyTaxHist.cs
@@ -1,34 +1,81 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_TAX_HIST")]
+    [Index(nameof(PropertyTaxHistId), nameof(EndDateHist), Name = "PIMS_PRPTAX_H_UK", IsUnique = true)]
     public partial class PimsPropertyTaxHist
     {
+        [Key]
+        [Column("_PROPERTY_TAX_HIST_ID")]
         public long PropertyTaxHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("PROPERTY_TAX_ID")]
         public long PropertyTaxId { get; set; }
+        [Column("PROPERTY_ID")]
         public long PropertyId { get; set; }
+        [Required]
+        [Column("PROPERTY_TAX_REMIT_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyTaxRemitTypeCode { get; set; }
+        [Required]
+        [Column("TAX_FOLIO_NO")]
+        [StringLength(50)]
         public string TaxFolioNo { get; set; }
+        [Column("PAYMENT_AMOUNT", TypeName = "money")]
         public decimal PaymentAmount { get; set; }
+        [Column("LAST_PAYMENT_DATE", TypeName = "datetime")]
         public DateTime? LastPaymentDate { get; set; }
+        [Column("PAYMENT_NOTES", TypeName = "money")]
         public decimal? PaymentNotes { get; set; }
+        [Column("BCTFA_NOTIFICATION_DATE", TypeName = "datetime")]
         public DateTime? BctfaNotificationDate { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyTaxRemitType.cs
+++ b/backend/entities/ef/PimsPropertyTaxRemitType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_TAX_REMIT_TYPE")]
     public partial class PimsPropertyTaxRemitType
     {
         public PimsPropertyTaxRemitType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsPropertyTaxes = new HashSet<PimsPropertyTax>();
         }
 
+        [Key]
+        [Column("PROPERTY_TAX_REMIT_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyTaxRemitTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsPropertyTax.PropertyTaxRemitTypeCodeNavigation))]
         public virtual ICollection<PimsPropertyTax> PimsPropertyTaxes { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyTenureType.cs
+++ b/backend/entities/ef/PimsPropertyTenureType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_TENURE_TYPE")]
     public partial class PimsPropertyTenureType
     {
         public PimsPropertyTenureType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsProperties = new HashSet<PimsProperty>();
         }
 
+        [Key]
+        [Column("PROPERTY_TENURE_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyTenureTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsProperty.PropertyTenureTypeCodeNavigation))]
         public virtual ICollection<PimsProperty> PimsProperties { get; set; }
     }
 }

--- a/backend/entities/ef/PimsPropertyType.cs
+++ b/backend/entities/ef/PimsPropertyType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROPERTY_TYPE")]
     public partial class PimsPropertyType
     {
         public PimsPropertyType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsProperties = new HashSet<PimsProperty>();
         }
 
+        [Key]
+        [Column("PROPERTY_TYPE_CODE")]
+        [StringLength(20)]
         public string PropertyTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsProperty.PropertyTypeCodeNavigation))]
         public virtual ICollection<PimsProperty> PimsProperties { get; set; }
     }
 }

--- a/backend/entities/ef/PimsProvinceState.cs
+++ b/backend/entities/ef/PimsProvinceState.cs
@@ -1,10 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_PROVINCE_STATE")]
+    [Index(nameof(CountryId), Name = "PROVNC_COUNTRY_ID_IDX")]
     public partial class PimsProvinceState
     {
         public PimsProvinceState()
@@ -12,19 +17,43 @@ namespace Pims.Dal.Entities
             PimsAddresses = new HashSet<PimsAddress>();
         }
 
+        [Key]
+        [Column("PROVINCE_STATE_ID")]
         public short ProvinceStateId { get; set; }
+        [Column("COUNTRY_ID")]
         public short CountryId { get; set; }
+        [Required]
+        [Column("PROVINCE_STATE_CODE")]
+        [StringLength(20)]
         public string ProvinceStateCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(CountryId))]
+        [InverseProperty(nameof(PimsCountry.PimsProvinceStates))]
         public virtual PimsCountry Country { get; set; }
+        [InverseProperty(nameof(PimsAddress.ProvinceState))]
         public virtual ICollection<PimsAddress> PimsAddresses { get; set; }
     }
 }

--- a/backend/entities/ef/PimsRegion.cs
+++ b/backend/entities/ef/PimsRegion.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_REGION")]
     public partial class PimsRegion
     {
         public PimsRegion()
@@ -15,19 +19,40 @@ namespace Pims.Dal.Entities
             PimsProperties = new HashSet<PimsProperty>();
         }
 
+        [Key]
+        [Column("REGION_CODE")]
         public short RegionCode { get; set; }
+        [Required]
+        [Column("REGION_NAME")]
+        [StringLength(200)]
         public string RegionName { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsAddress.RegionCodeNavigation))]
         public virtual ICollection<PimsAddress> PimsAddresses { get; set; }
+        [InverseProperty(nameof(PimsDistrict.RegionCodeNavigation))]
         public virtual ICollection<PimsDistrict> PimsDistricts { get; set; }
+        [InverseProperty(nameof(PimsOrganization.RegionCodeNavigation))]
         public virtual ICollection<PimsOrganization> PimsOrganizations { get; set; }
+        [InverseProperty(nameof(PimsProperty.RegionCodeNavigation))]
         public virtual ICollection<PimsProperty> PimsProperties { get; set; }
     }
 }

--- a/backend/entities/ef/PimsRole.cs
+++ b/backend/entities/ef/PimsRole.cs
@@ -1,10 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ROLE")]
+    [Index(nameof(KeycloakGroupId), Name = "ROLE_KEYCLOAK_GROUP_ID_IDX")]
+    [Index(nameof(RoleUid), Name = "ROLE_ROLE_UID_IDX")]
     public partial class PimsRole
     {
         public PimsRole()
@@ -15,31 +21,74 @@ namespace Pims.Dal.Entities
             PimsUserRoles = new HashSet<PimsUserRole>();
         }
 
+        [Key]
+        [Column("ROLE_ID")]
         public long RoleId { get; set; }
+        [Column("ROLE_UID")]
         public Guid RoleUid { get; set; }
+        [Column("KEYCLOAK_GROUP_ID")]
         public Guid? KeycloakGroupId { get; set; }
+        [Required]
+        [Column("NAME")]
+        [StringLength(100)]
         public string Name { get; set; }
+        [Column("DESCRIPTION")]
+        [StringLength(500)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_PUBLIC")]
         public bool? IsPublic { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("SORT_ORDER")]
         public int SortOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsAccessRequest.Role))]
         public virtual ICollection<PimsAccessRequest> PimsAccessRequests { get; set; }
+        [InverseProperty(nameof(PimsRoleClaim.Role))]
         public virtual ICollection<PimsRoleClaim> PimsRoleClaims { get; set; }
+        [InverseProperty(nameof(PimsUserOrganization.Role))]
         public virtual ICollection<PimsUserOrganization> PimsUserOrganizations { get; set; }
+        [InverseProperty(nameof(PimsUserRole.Role))]
         public virtual ICollection<PimsUserRole> PimsUserRoles { get; set; }
     }
 }

--- a/backend/entities/ef/PimsRoleClaim.cs
+++ b/backend/entities/ef/PimsRoleClaim.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsRoleClaim.cs
+++ b/backend/entities/ef/PimsRoleClaim.cs
@@ -1,30 +1,72 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ROLE_CLAIM")]
+    [Index(nameof(ClaimId), Name = "ROLCLM_CLAIM_ID_IDX")]
+    [Index(nameof(RoleId), nameof(ClaimId), Name = "ROLCLM_ROLE_CLAIM_TUC", IsUnique = true)]
+    [Index(nameof(RoleId), Name = "ROLCLM_ROLE_ID_IDX")]
     public partial class PimsRoleClaim
     {
+        [Key]
+        [Column("ROLE_CLAIM_ID")]
         public long RoleClaimId { get; set; }
+        [Column("ROLE_ID")]
         public long RoleId { get; set; }
+        [Column("CLAIM_ID")]
         public long ClaimId { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(ClaimId))]
+        [InverseProperty(nameof(PimsClaim.PimsRoleClaims))]
         public virtual PimsClaim Claim { get; set; }
+        [ForeignKey(nameof(RoleId))]
+        [InverseProperty(nameof(PimsRole.PimsRoleClaims))]
         public virtual PimsRole Role { get; set; }
     }
 }

--- a/backend/entities/ef/PimsRoleClaimHist.cs
+++ b/backend/entities/ef/PimsRoleClaimHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsRoleClaimHist.cs
+++ b/backend/entities/ef/PimsRoleClaimHist.cs
@@ -1,30 +1,69 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ROLE_CLAIM_HIST")]
+    [Index(nameof(RoleClaimHistId), nameof(EndDateHist), Name = "PIMS_ROLCLM_H_UK", IsUnique = true)]
     public partial class PimsRoleClaimHist
     {
+        [Key]
+        [Column("_ROLE_CLAIM_HIST_ID")]
         public long RoleClaimHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("ROLE_CLAIM_ID")]
         public long RoleClaimId { get; set; }
+        [Column("ROLE_ID")]
         public long RoleId { get; set; }
+        [Column("CLAIM_ID")]
         public long ClaimId { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsRoleHist.cs
+++ b/backend/entities/ef/PimsRoleHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsRoleHist.cs
+++ b/backend/entities/ef/PimsRoleHist.cs
@@ -1,34 +1,80 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_ROLE_HIST")]
+    [Index(nameof(RoleHistId), nameof(EndDateHist), Name = "PIMS_ROLE_H_UK", IsUnique = true)]
     public partial class PimsRoleHist
     {
+        [Key]
+        [Column("_ROLE_HIST_ID")]
         public long RoleHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("ROLE_ID")]
         public long RoleId { get; set; }
+        [Column("ROLE_UID")]
         public Guid RoleUid { get; set; }
+        [Column("KEYCLOAK_GROUP_ID")]
         public Guid? KeycloakGroupId { get; set; }
+        [Required]
+        [Column("NAME")]
+        [StringLength(100)]
         public string Name { get; set; }
+        [Column("DESCRIPTION")]
+        [StringLength(500)]
         public string Description { get; set; }
+        [Column("IS_PUBLIC")]
         public bool IsPublic { get; set; }
+        [Column("IS_DISABLED")]
         public bool IsDisabled { get; set; }
+        [Column("SORT_ORDER")]
         public int SortOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsSecDepHolderType.cs
+++ b/backend/entities/ef/PimsSecDepHolderType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_SEC_DEP_HOLDER_TYPE")]
     public partial class PimsSecDepHolderType
     {
         public PimsSecDepHolderType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsSecurityDeposits = new HashSet<PimsSecurityDeposit>();
         }
 
+        [Key]
+        [Column("SEC_DEP_HOLDER_TYPE_CODE")]
+        [StringLength(20)]
         public string SecDepHolderTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsSecurityDeposit.SecDepHolderTypeCodeNavigation))]
         public virtual ICollection<PimsSecurityDeposit> PimsSecurityDeposits { get; set; }
     }
 }

--- a/backend/entities/ef/PimsSecurityDeposit.cs
+++ b/backend/entities/ef/PimsSecurityDeposit.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsSecurityDeposit.cs
+++ b/backend/entities/ef/PimsSecurityDeposit.cs
@@ -1,36 +1,92 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_SECURITY_DEPOSIT")]
+    [Index(nameof(LeaseId), Name = "SECDEP_LEASE_ID_IDX")]
+    [Index(nameof(SecurityDepositTypeCode), Name = "SECDEP_SECURITY_DEPOSIT_TYPE_CODE_IDX")]
+    [Index(nameof(SecDepHolderTypeCode), Name = "SECDEP_SEC_DEP_HOLDER_TYPE_CODE_IDX")]
     public partial class PimsSecurityDeposit
     {
+        [Key]
+        [Column("SECURITY_DEPOSIT_ID")]
         public long SecurityDepositId { get; set; }
+        [Column("LEASE_ID")]
         public long LeaseId { get; set; }
+        [Required]
+        [Column("SEC_DEP_HOLDER_TYPE_CODE")]
+        [StringLength(20)]
         public string SecDepHolderTypeCode { get; set; }
+        [Required]
+        [Column("SECURITY_DEPOSIT_TYPE_CODE")]
+        [StringLength(20)]
         public string SecurityDepositTypeCode { get; set; }
+        [Column("OTHER_DEP_HOLDER_TYPE_DESC")]
+        [StringLength(100)]
         public string OtherDepHolderTypeDesc { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(2000)]
         public string Description { get; set; }
+        [Column("AMOUNT_PAID", TypeName = "money")]
         public decimal AmountPaid { get; set; }
+        [Column("DEPOSIT_DATE", TypeName = "date")]
         public DateTime DepositDate { get; set; }
+        [Column("ANNUAL_INTEREST_RATE", TypeName = "numeric(5, 2)")]
         public decimal? AnnualInterestRate { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(LeaseId))]
+        [InverseProperty(nameof(PimsLease.PimsSecurityDeposits))]
         public virtual PimsLease Lease { get; set; }
+        [ForeignKey(nameof(SecDepHolderTypeCode))]
+        [InverseProperty(nameof(PimsSecDepHolderType.PimsSecurityDeposits))]
         public virtual PimsSecDepHolderType SecDepHolderTypeCodeNavigation { get; set; }
+        [ForeignKey(nameof(SecurityDepositTypeCode))]
+        [InverseProperty(nameof(PimsSecurityDepositType.PimsSecurityDeposits))]
         public virtual PimsSecurityDepositType SecurityDepositTypeCodeNavigation { get; set; }
     }
 }

--- a/backend/entities/ef/PimsSecurityDepositHist.cs
+++ b/backend/entities/ef/PimsSecurityDepositHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsSecurityDepositHist.cs
+++ b/backend/entities/ef/PimsSecurityDepositHist.cs
@@ -1,35 +1,86 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_SECURITY_DEPOSIT_HIST")]
+    [Index(nameof(SecurityDepositHistId), nameof(EndDateHist), Name = "PIMS_SECDEP_H_UK", IsUnique = true)]
     public partial class PimsSecurityDepositHist
     {
+        [Key]
+        [Column("_SECURITY_DEPOSIT_HIST_ID")]
         public long SecurityDepositHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("SECURITY_DEPOSIT_ID")]
         public long SecurityDepositId { get; set; }
+        [Column("LEASE_ID")]
         public long LeaseId { get; set; }
+        [Required]
+        [Column("SEC_DEP_HOLDER_TYPE_CODE")]
+        [StringLength(20)]
         public string SecDepHolderTypeCode { get; set; }
+        [Required]
+        [Column("SECURITY_DEPOSIT_TYPE_CODE")]
+        [StringLength(20)]
         public string SecurityDepositTypeCode { get; set; }
+        [Column("OTHER_DEP_HOLDER_TYPE_DESC")]
+        [StringLength(100)]
         public string OtherDepHolderTypeDesc { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(2000)]
         public string Description { get; set; }
+        [Column("AMOUNT_PAID", TypeName = "money")]
         public decimal AmountPaid { get; set; }
+        [Column("DEPOSIT_DATE", TypeName = "date")]
         public DateTime DepositDate { get; set; }
+        [Column("ANNUAL_INTEREST_RATE", TypeName = "numeric(18, 0)")]
         public decimal? AnnualInterestRate { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsSecurityDepositReturn.cs
+++ b/backend/entities/ef/PimsSecurityDepositReturn.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsSecurityDepositReturn.cs
+++ b/backend/entities/ef/PimsSecurityDepositReturn.cs
@@ -1,37 +1,92 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_SECURITY_DEPOSIT_RETURN")]
+    [Index(nameof(LeaseId), Name = "SDRTRN_LEASE_ID_IDX")]
+    [Index(nameof(SecurityDepositTypeCode), Name = "SDRTRN_SECURITY_DEPOSIT_TYPE_CODE_IDX")]
     public partial class PimsSecurityDepositReturn
     {
+        [Key]
+        [Column("SECURITY_DEPOSIT_RETURN_ID")]
         public long SecurityDepositReturnId { get; set; }
+        [Column("LEASE_ID")]
         public long LeaseId { get; set; }
+        [Required]
+        [Column("SECURITY_DEPOSIT_TYPE_CODE")]
+        [StringLength(20)]
         public string SecurityDepositTypeCode { get; set; }
+        [Column("TERMINATION_DATE", TypeName = "datetime")]
         public DateTime TerminationDate { get; set; }
+        [Column("DEPOSIT_TOTAL", TypeName = "money")]
         public decimal DepositTotal { get; set; }
+        [Column("CLAIMS_AGAINST", TypeName = "money")]
         public decimal? ClaimsAgainst { get; set; }
+        [Column("RETURN_AMOUNT", TypeName = "money")]
         public decimal ReturnAmount { get; set; }
+        [Column("RETURN_DATE", TypeName = "datetime")]
         public DateTime ReturnDate { get; set; }
+        [Required]
+        [Column("CHEQUE_NUMBER")]
+        [StringLength(50)]
         public string ChequeNumber { get; set; }
+        [Required]
+        [Column("PAYEE_NAME")]
+        [StringLength(100)]
         public string PayeeName { get; set; }
+        [Column("PAYEE_ADDRESS")]
+        [StringLength(500)]
         public string PayeeAddress { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(LeaseId))]
+        [InverseProperty(nameof(PimsLease.PimsSecurityDepositReturns))]
         public virtual PimsLease Lease { get; set; }
+        [ForeignKey(nameof(SecurityDepositTypeCode))]
+        [InverseProperty(nameof(PimsSecurityDepositType.PimsSecurityDepositReturns))]
         public virtual PimsSecurityDepositType SecurityDepositTypeCodeNavigation { get; set; }
     }
 }

--- a/backend/entities/ef/PimsSecurityDepositReturnHist.cs
+++ b/backend/entities/ef/PimsSecurityDepositReturnHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsSecurityDepositReturnHist.cs
+++ b/backend/entities/ef/PimsSecurityDepositReturnHist.cs
@@ -1,37 +1,90 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_SECURITY_DEPOSIT_RETURN_HIST")]
+    [Index(nameof(SecurityDepositReturnHistId), nameof(EndDateHist), Name = "PIMS_SDRTRN_H_UK", IsUnique = true)]
     public partial class PimsSecurityDepositReturnHist
     {
+        [Key]
+        [Column("_SECURITY_DEPOSIT_RETURN_HIST_ID")]
         public long SecurityDepositReturnHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("SECURITY_DEPOSIT_RETURN_ID")]
         public long SecurityDepositReturnId { get; set; }
+        [Column("LEASE_ID")]
         public long LeaseId { get; set; }
+        [Required]
+        [Column("SECURITY_DEPOSIT_TYPE_CODE")]
+        [StringLength(20)]
         public string SecurityDepositTypeCode { get; set; }
+        [Column("TERMINATION_DATE", TypeName = "datetime")]
         public DateTime TerminationDate { get; set; }
+        [Column("DEPOSIT_TOTAL", TypeName = "money")]
         public decimal DepositTotal { get; set; }
+        [Column("CLAIMS_AGAINST", TypeName = "money")]
         public decimal? ClaimsAgainst { get; set; }
+        [Column("RETURN_AMOUNT", TypeName = "money")]
         public decimal ReturnAmount { get; set; }
+        [Column("RETURN_DATE", TypeName = "datetime")]
         public DateTime ReturnDate { get; set; }
+        [Required]
+        [Column("CHEQUE_NUMBER")]
+        [StringLength(50)]
         public string ChequeNumber { get; set; }
+        [Required]
+        [Column("PAYEE_NAME")]
+        [StringLength(100)]
         public string PayeeName { get; set; }
+        [Column("PAYEE_ADDRESS")]
+        [StringLength(500)]
         public string PayeeAddress { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsSecurityDepositType.cs
+++ b/backend/entities/ef/PimsSecurityDepositType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_SECURITY_DEPOSIT_TYPE")]
     public partial class PimsSecurityDepositType
     {
         public PimsSecurityDepositType()
@@ -13,17 +17,37 @@ namespace Pims.Dal.Entities
             PimsSecurityDeposits = new HashSet<PimsSecurityDeposit>();
         }
 
+        [Key]
+        [Column("SECURITY_DEPOSIT_TYPE_CODE")]
+        [StringLength(20)]
         public string SecurityDepositTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsSecurityDepositReturn.SecurityDepositTypeCodeNavigation))]
         public virtual ICollection<PimsSecurityDepositReturn> PimsSecurityDepositReturns { get; set; }
+        [InverseProperty(nameof(PimsSecurityDeposit.SecurityDepositTypeCodeNavigation))]
         public virtual ICollection<PimsSecurityDeposit> PimsSecurityDeposits { get; set; }
     }
 }

--- a/backend/entities/ef/PimsStaticVariable.cs
+++ b/backend/entities/ef/PimsStaticVariable.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsStaticVariable.cs
+++ b/backend/entities/ef/PimsStaticVariable.cs
@@ -1,17 +1,37 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_STATIC_VARIABLE")]
     public partial class PimsStaticVariable
     {
+        [Key]
+        [Column("STATIC_VARIABLE_NAME")]
+        [StringLength(100)]
         public string StaticVariableName { get; set; }
+        [Required]
+        [Column("STATIC_VARIABLE_VALUE")]
+        [StringLength(100)]
         public string StaticVariableValue { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsSurplusDeclarationType.cs
+++ b/backend/entities/ef/PimsSurplusDeclarationType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_SURPLUS_DECLARATION_TYPE")]
     public partial class PimsSurplusDeclarationType
     {
         public PimsSurplusDeclarationType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsProperties = new HashSet<PimsProperty>();
         }
 
+        [Key]
+        [Column("SURPLUS_DECLARATION_TYPE_CODE")]
+        [StringLength(20)]
         public string SurplusDeclarationTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsProperty.SurplusDeclarationTypeCodeNavigation))]
         public virtual ICollection<PimsProperty> PimsProperties { get; set; }
     }
 }

--- a/backend/entities/ef/PimsTask.cs
+++ b/backend/entities/ef/PimsTask.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsTask.cs
+++ b/backend/entities/ef/PimsTask.cs
@@ -1,31 +1,76 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_TASK")]
+    [Index(nameof(ActivityId), Name = "TASK_ACTIVITY_ID_IDX")]
+    [Index(nameof(TaskTemplateId), Name = "TASK_TASK_TEMPLATE_ID_IDX")]
+    [Index(nameof(UserId), nameof(ActivityId), nameof(TaskTemplateId), Name = "TASK_TEMPLATE_ACTIVITY_USER_TUC", IsUnique = true)]
+    [Index(nameof(UserId), Name = "TASK_USER_ID_IDX")]
     public partial class PimsTask
     {
+        [Key]
+        [Column("TASK_ID")]
         public long TaskId { get; set; }
+        [Column("TASK_TEMPLATE_ID")]
         public long TaskTemplateId { get; set; }
+        [Column("ACTIVITY_ID")]
         public long? ActivityId { get; set; }
+        [Column("USER_ID")]
         public long UserId { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(ActivityId))]
+        [InverseProperty(nameof(PimsActivity.PimsTasks))]
         public virtual PimsActivity Activity { get; set; }
+        [ForeignKey(nameof(TaskTemplateId))]
+        [InverseProperty(nameof(PimsTaskTemplate.PimsTasks))]
         public virtual PimsTaskTemplate TaskTemplate { get; set; }
+        [ForeignKey(nameof(UserId))]
+        [InverseProperty(nameof(PimsUser.PimsTasks))]
         public virtual PimsUser User { get; set; }
     }
 }

--- a/backend/entities/ef/PimsTaskHist.cs
+++ b/backend/entities/ef/PimsTaskHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsTaskHist.cs
+++ b/backend/entities/ef/PimsTaskHist.cs
@@ -1,30 +1,69 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_TASK_HIST")]
+    [Index(nameof(TaskHistId), nameof(EndDateHist), Name = "PIMS_TASK_H_UK", IsUnique = true)]
     public partial class PimsTaskHist
     {
+        [Key]
+        [Column("_TASK_HIST_ID")]
         public long TaskHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("TASK_ID")]
         public long TaskId { get; set; }
+        [Column("TASK_TEMPLATE_ID")]
         public long TaskTemplateId { get; set; }
+        [Column("ACTIVITY_ID")]
         public long? ActivityId { get; set; }
+        [Column("USER_ID")]
         public long UserId { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsTaskTemplate.cs
+++ b/backend/entities/ef/PimsTaskTemplate.cs
@@ -1,10 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_TASK_TEMPLATE")]
+    [Index(nameof(TaskTemplateTypeCode), Name = "TSKTMP_TASK_TEMPLATE_TYPE_CODE_IDX")]
     public partial class PimsTaskTemplate
     {
         public PimsTaskTemplate()
@@ -13,25 +18,61 @@ namespace Pims.Dal.Entities
             PimsTasks = new HashSet<PimsTask>();
         }
 
+        [Key]
+        [Column("TASK_TEMPLATE_ID")]
         public long TaskTemplateId { get; set; }
+        [Required]
+        [Column("TASK_TEMPLATE_TYPE_CODE")]
+        [StringLength(20)]
         public string TaskTemplateTypeCode { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(TaskTemplateTypeCode))]
+        [InverseProperty(nameof(PimsTaskTemplateType.PimsTaskTemplates))]
         public virtual PimsTaskTemplateType TaskTemplateTypeCodeNavigation { get; set; }
+        [InverseProperty(nameof(PimsTaskTemplateActivityModel.TaskTemplate))]
         public virtual ICollection<PimsTaskTemplateActivityModel> PimsTaskTemplateActivityModels { get; set; }
+        [InverseProperty(nameof(PimsTask.TaskTemplate))]
         public virtual ICollection<PimsTask> PimsTasks { get; set; }
     }
 }

--- a/backend/entities/ef/PimsTaskTemplateActivityModel.cs
+++ b/backend/entities/ef/PimsTaskTemplateActivityModel.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsTaskTemplateActivityModel.cs
+++ b/backend/entities/ef/PimsTaskTemplateActivityModel.cs
@@ -1,32 +1,77 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_TASK_TEMPLATE_ACTIVITY_MODEL")]
+    [Index(nameof(ActivityModelId), Name = "TSKTAM_ACTIVITY_MODEL_ID_IDX")]
+    [Index(nameof(TaskTemplateId), nameof(ActivityModelId), Name = "TSKTAM_TASK_TEMPLATE_ACTIVITY_MODEL_TUC", IsUnique = true)]
+    [Index(nameof(TaskTemplateId), Name = "TSKTAM_TASK_TEMPLATE_ID_IDX")]
     public partial class PimsTaskTemplateActivityModel
     {
+        [Key]
+        [Column("TASK_TEMPLATE_ACTIVITY_MODEL_ID")]
         public long TaskTemplateActivityModelId { get; set; }
+        [Column("TASK_TEMPLATE_ID")]
         public long TaskTemplateId { get; set; }
+        [Column("ACTIVITY_MODEL_ID")]
         public long ActivityModelId { get; set; }
+        [Required]
+        [Column("IS_MANDATORY")]
         public bool? IsMandatory { get; set; }
+        [Column("IMPLEMENTATION_ORDER")]
         public short ImplementationOrder { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(ActivityModelId))]
+        [InverseProperty(nameof(PimsActivityModel.PimsTaskTemplateActivityModels))]
         public virtual PimsActivityModel ActivityModel { get; set; }
+        [ForeignKey(nameof(TaskTemplateId))]
+        [InverseProperty(nameof(PimsTaskTemplate.PimsTaskTemplateActivityModels))]
         public virtual PimsTaskTemplate TaskTemplate { get; set; }
     }
 }

--- a/backend/entities/ef/PimsTaskTemplateActivityModelHist.cs
+++ b/backend/entities/ef/PimsTaskTemplateActivityModelHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsTaskTemplateActivityModelHist.cs
+++ b/backend/entities/ef/PimsTaskTemplateActivityModelHist.cs
@@ -1,32 +1,73 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_TASK_TEMPLATE_ACTIVITY_MODEL_HIST")]
+    [Index(nameof(TaskTemplateActivityModelHistId), nameof(EndDateHist), Name = "PIMS_TSKTAM_H_UK", IsUnique = true)]
     public partial class PimsTaskTemplateActivityModelHist
     {
+        [Key]
+        [Column("_TASK_TEMPLATE_ACTIVITY_MODEL_HIST_ID")]
         public long TaskTemplateActivityModelHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("TASK_TEMPLATE_ACTIVITY_MODEL_ID")]
         public long TaskTemplateActivityModelId { get; set; }
+        [Column("TASK_TEMPLATE_ID")]
         public long TaskTemplateId { get; set; }
+        [Column("ACTIVITY_MODEL_ID")]
         public long ActivityModelId { get; set; }
+        [Column("IS_MANDATORY")]
         public bool IsMandatory { get; set; }
+        [Column("IMPLEMENTATION_ORDER")]
         public short ImplementationOrder { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsTaskTemplateHist.cs
+++ b/backend/entities/ef/PimsTaskTemplateHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsTaskTemplateHist.cs
+++ b/backend/entities/ef/PimsTaskTemplateHist.cs
@@ -1,29 +1,69 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_TASK_TEMPLATE_HIST")]
+    [Index(nameof(TaskTemplateHistId), nameof(EndDateHist), Name = "PIMS_TSKTMP_H_UK", IsUnique = true)]
     public partial class PimsTaskTemplateHist
     {
+        [Key]
+        [Column("_TASK_TEMPLATE_HIST_ID")]
         public long TaskTemplateHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("TASK_TEMPLATE_ID")]
         public long TaskTemplateId { get; set; }
+        [Required]
+        [Column("TASK_TEMPLATE_TYPE_CODE")]
+        [StringLength(20)]
         public string TaskTemplateTypeCode { get; set; }
+        [Column("IS_DISABLED")]
         public bool IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsTaskTemplateType.cs
+++ b/backend/entities/ef/PimsTaskTemplateType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_TASK_TEMPLATE_TYPE")]
     public partial class PimsTaskTemplateType
     {
         public PimsTaskTemplateType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsTaskTemplates = new HashSet<PimsTaskTemplate>();
         }
 
+        [Key]
+        [Column("TASK_TEMPLATE_TYPE_CODE")]
+        [StringLength(20)]
         public string TaskTemplateTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsTaskTemplate.TaskTemplateTypeCodeNavigation))]
         public virtual ICollection<PimsTaskTemplate> PimsTaskTemplates { get; set; }
     }
 }

--- a/backend/entities/ef/PimsTenant.cs
+++ b/backend/entities/ef/PimsTenant.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsTenant.cs
+++ b/backend/entities/ef/PimsTenant.cs
@@ -1,20 +1,47 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_TENANT")]
     public partial class PimsTenant
     {
+        [Key]
+        [Column("TENANT_ID")]
         public long TenantId { get; set; }
+        [Required]
+        [Column("CODE")]
+        [StringLength(6)]
         public string Code { get; set; }
+        [Required]
+        [Column("NAME")]
+        [StringLength(150)]
         public string Name { get; set; }
+        [Column("DESCRIPTION")]
+        [StringLength(500)]
         public string Description { get; set; }
+        [Required]
+        [Column("SETTINGS")]
+        [StringLength(2000)]
         public string Settings { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsUser.cs
+++ b/backend/entities/ef/PimsUser.cs
@@ -1,10 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_USER")]
+    [Index(nameof(BusinessIdentifierValue), Name = "USER_BUSINESS_IDENTIFIER_VALUE_IDX")]
+    [Index(nameof(GuidIdentifierValue), Name = "USER_GUID_IDENTIFIER_VALUE_IDX")]
+    [Index(nameof(PersonId), Name = "USER_PERSON_ID_IDX")]
     public partial class PimsUser
     {
         public PimsUser()
@@ -15,35 +22,83 @@ namespace Pims.Dal.Entities
             PimsUserRoles = new HashSet<PimsUserRole>();
         }
 
+        [Key]
+        [Column("USER_ID")]
         public long UserId { get; set; }
+        [Column("PERSON_ID")]
         public long PersonId { get; set; }
+        [Required]
+        [Column("BUSINESS_IDENTIFIER_VALUE")]
+        [StringLength(30)]
         public string BusinessIdentifierValue { get; set; }
+        [Column("GUID_IDENTIFIER_VALUE")]
         public Guid? GuidIdentifierValue { get; set; }
+        [Column("POSITION")]
+        [StringLength(100)]
         public string Position { get; set; }
+        [Column("NOTE")]
+        [StringLength(1000)]
         public string Note { get; set; }
+        [Column("LAST_LOGIN", TypeName = "datetime")]
         public DateTime? LastLogin { get; set; }
+        [Column("APPROVED_BY_ID")]
+        [StringLength(30)]
         public string ApprovedById { get; set; }
+        [Column("ISSUE_DATE", TypeName = "datetime")]
         public DateTime IssueDate { get; set; }
+        [Column("EXPIRY_DATE", TypeName = "datetime")]
         public DateTime? ExpiryDate { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(PersonId))]
+        [InverseProperty(nameof(PimsPerson.PimsUsers))]
         public virtual PimsPerson Person { get; set; }
+        [InverseProperty(nameof(PimsAccessRequest.User))]
         public virtual ICollection<PimsAccessRequest> PimsAccessRequests { get; set; }
+        [InverseProperty(nameof(PimsTask.User))]
         public virtual ICollection<PimsTask> PimsTasks { get; set; }
+        [InverseProperty(nameof(PimsUserOrganization.User))]
         public virtual ICollection<PimsUserOrganization> PimsUserOrganizations { get; set; }
+        [InverseProperty(nameof(PimsUserRole.User))]
         public virtual ICollection<PimsUserRole> PimsUserRoles { get; set; }
     }
 }

--- a/backend/entities/ef/PimsUserHist.cs
+++ b/backend/entities/ef/PimsUserHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsUserHist.cs
+++ b/backend/entities/ef/PimsUserHist.cs
@@ -1,37 +1,88 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_USER_HIST")]
+    [Index(nameof(UserHistId), nameof(EndDateHist), Name = "PIMS_USER_H_UK", IsUnique = true)]
     public partial class PimsUserHist
     {
+        [Key]
+        [Column("_USER_HIST_ID")]
         public long UserHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("USER_ID")]
         public long UserId { get; set; }
+        [Column("PERSON_ID")]
         public long PersonId { get; set; }
+        [Required]
+        [Column("BUSINESS_IDENTIFIER_VALUE")]
+        [StringLength(30)]
         public string BusinessIdentifierValue { get; set; }
+        [Column("GUID_IDENTIFIER_VALUE")]
         public Guid? GuidIdentifierValue { get; set; }
+        [Column("POSITION")]
+        [StringLength(100)]
         public string Position { get; set; }
+        [Column("NOTE")]
+        [StringLength(1000)]
         public string Note { get; set; }
+        [Column("LAST_LOGIN", TypeName = "datetime")]
         public DateTime? LastLogin { get; set; }
+        [Column("APPROVED_BY_ID")]
+        [StringLength(30)]
         public string ApprovedById { get; set; }
+        [Column("ISSUE_DATE", TypeName = "datetime")]
         public DateTime IssueDate { get; set; }
+        [Column("EXPIRY_DATE", TypeName = "datetime")]
         public DateTime? ExpiryDate { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsUserOrganization.cs
+++ b/backend/entities/ef/PimsUserOrganization.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsUserOrganization.cs
+++ b/backend/entities/ef/PimsUserOrganization.cs
@@ -1,32 +1,78 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_USER_ORGANIZATION")]
+    [Index(nameof(OrganizationId), Name = "USRORG_ORGANIZATION_ID_IDX")]
+    [Index(nameof(RoleId), Name = "USRORG_ROLE_ID_IDX")]
+    [Index(nameof(UserId), Name = "USRORG_USER_ID_IDX")]
+    [Index(nameof(OrganizationId), nameof(UserId), nameof(RoleId), Name = "USRORG_USER_ROLE_ORGANIZATION_TUC", IsUnique = true)]
     public partial class PimsUserOrganization
     {
+        [Key]
+        [Column("USER_ORGANIZATION_ID")]
         public long UserOrganizationId { get; set; }
+        [Column("ORGANIZATION_ID")]
         public long OrganizationId { get; set; }
+        [Column("USER_ID")]
         public long UserId { get; set; }
+        [Column("ROLE_ID")]
         public long RoleId { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(OrganizationId))]
+        [InverseProperty(nameof(PimsOrganization.PimsUserOrganizations))]
         public virtual PimsOrganization Organization { get; set; }
+        [ForeignKey(nameof(RoleId))]
+        [InverseProperty(nameof(PimsRole.PimsUserOrganizations))]
         public virtual PimsRole Role { get; set; }
+        [ForeignKey(nameof(UserId))]
+        [InverseProperty(nameof(PimsUser.PimsUserOrganizations))]
         public virtual PimsUser User { get; set; }
     }
 }

--- a/backend/entities/ef/PimsUserOrganizationHist.cs
+++ b/backend/entities/ef/PimsUserOrganizationHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsUserOrganizationHist.cs
+++ b/backend/entities/ef/PimsUserOrganizationHist.cs
@@ -1,31 +1,71 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_USER_ORGANIZATION_HIST")]
+    [Index(nameof(UserOrganizationHistId), nameof(EndDateHist), Name = "PIMS_USRORG_H_UK", IsUnique = true)]
     public partial class PimsUserOrganizationHist
     {
+        [Key]
+        [Column("_USER_ORGANIZATION_HIST_ID")]
         public long UserOrganizationHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("USER_ORGANIZATION_ID")]
         public long UserOrganizationId { get; set; }
+        [Column("ORGANIZATION_ID")]
         public long OrganizationId { get; set; }
+        [Column("USER_ID")]
         public long UserId { get; set; }
+        [Column("ROLE_ID")]
         public long RoleId { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsUserRole.cs
+++ b/backend/entities/ef/PimsUserRole.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsUserRole.cs
+++ b/backend/entities/ef/PimsUserRole.cs
@@ -1,30 +1,72 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_USER_ROLE")]
+    [Index(nameof(RoleId), Name = "USERRL_ROLE_ID_IDX")]
+    [Index(nameof(UserId), Name = "USERRL_USER_ID_IDX")]
+    [Index(nameof(UserId), nameof(RoleId), Name = "USERRL_USER_ROLE_TUC", IsUnique = true)]
     public partial class PimsUserRole
     {
+        [Key]
+        [Column("USER_ROLE_ID")]
         public long UserRoleId { get; set; }
+        [Column("USER_ID")]
         public long UserId { get; set; }
+        [Column("ROLE_ID")]
         public long RoleId { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(RoleId))]
+        [InverseProperty(nameof(PimsRole.PimsUserRoles))]
         public virtual PimsRole Role { get; set; }
+        [ForeignKey(nameof(UserId))]
+        [InverseProperty(nameof(PimsUser.PimsUserRoles))]
         public virtual PimsUser User { get; set; }
     }
 }

--- a/backend/entities/ef/PimsUserRoleHist.cs
+++ b/backend/entities/ef/PimsUserRoleHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsUserRoleHist.cs
+++ b/backend/entities/ef/PimsUserRoleHist.cs
@@ -1,30 +1,69 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_USER_ROLE_HIST")]
+    [Index(nameof(UserRoleHistId), nameof(EndDateHist), Name = "PIMS_USERRL_H_UK", IsUnique = true)]
     public partial class PimsUserRoleHist
     {
+        [Key]
+        [Column("_USER_ROLE_HIST_ID")]
         public long UserRoleHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("USER_ROLE_ID")]
         public long UserRoleId { get; set; }
+        [Column("USER_ID")]
         public long UserId { get; set; }
+        [Column("ROLE_ID")]
         public long RoleId { get; set; }
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsWorkflowModel.cs
+++ b/backend/entities/ef/PimsWorkflowModel.cs
@@ -1,10 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_WORKFLOW_MODEL")]
+    [Index(nameof(WorkflowModelTypeCode), Name = "WFLMDL_WORKFLOW_MODEL_TYPE_CODE_IDX")]
     public partial class PimsWorkflowModel
     {
         public PimsWorkflowModel()
@@ -12,24 +17,59 @@ namespace Pims.Dal.Entities
             PimsProjectWorkflowModels = new HashSet<PimsProjectWorkflowModel>();
         }
 
+        [Key]
+        [Column("WORKFLOW_MODEL_ID")]
         public long WorkflowModelId { get; set; }
+        [Required]
+        [Column("WORKFLOW_MODEL_TYPE_CODE")]
+        [StringLength(20)]
         public string WorkflowModelTypeCode { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [ForeignKey(nameof(WorkflowModelTypeCode))]
+        [InverseProperty(nameof(PimsWorkflowModelType.PimsWorkflowModels))]
         public virtual PimsWorkflowModelType WorkflowModelTypeCodeNavigation { get; set; }
+        [InverseProperty(nameof(PimsProjectWorkflowModel.WorkflowModel))]
         public virtual ICollection<PimsProjectWorkflowModel> PimsProjectWorkflowModels { get; set; }
     }
 }

--- a/backend/entities/ef/PimsWorkflowModelHist.cs
+++ b/backend/entities/ef/PimsWorkflowModelHist.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 #nullable disable
 

--- a/backend/entities/ef/PimsWorkflowModelHist.cs
+++ b/backend/entities/ef/PimsWorkflowModelHist.cs
@@ -1,29 +1,69 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_WORKFLOW_MODEL_HIST")]
+    [Index(nameof(WorkflowModelHistId), nameof(EndDateHist), Name = "PIMS_WFLMDL_H_UK", IsUnique = true)]
     public partial class PimsWorkflowModelHist
     {
+        [Key]
+        [Column("_WORKFLOW_MODEL_HIST_ID")]
         public long WorkflowModelHistId { get; set; }
+        [Column("EFFECTIVE_DATE_HIST", TypeName = "datetime")]
         public DateTime EffectiveDateHist { get; set; }
+        [Column("END_DATE_HIST", TypeName = "datetime")]
         public DateTime? EndDateHist { get; set; }
+        [Column("WORKFLOW_MODEL_ID")]
         public long WorkflowModelId { get; set; }
+        [Required]
+        [Column("WORKFLOW_MODEL_TYPE_CODE")]
+        [StringLength(20)]
         public string WorkflowModelTypeCode { get; set; }
+        [Column("IS_DISABLED")]
         public bool IsDisabled { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("APP_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppCreateTimestamp { get; set; }
+        [Required]
+        [Column("APP_CREATE_USERID")]
+        [StringLength(30)]
         public string AppCreateUserid { get; set; }
+        [Column("APP_CREATE_USER_GUID")]
         public Guid? AppCreateUserGuid { get; set; }
+        [Required]
+        [Column("APP_CREATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppCreateUserDirectory { get; set; }
+        [Column("APP_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime AppLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string AppLastUpdateUserid { get; set; }
+        [Column("APP_LAST_UPDATE_USER_GUID")]
         public Guid? AppLastUpdateUserGuid { get; set; }
+        [Required]
+        [Column("APP_LAST_UPDATE_USER_DIRECTORY")]
+        [StringLength(30)]
         public string AppLastUpdateUserDirectory { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
     }
 }

--- a/backend/entities/ef/PimsWorkflowModelType.cs
+++ b/backend/entities/ef/PimsWorkflowModelType.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Table("PIMS_WORKFLOW_MODEL_TYPE")]
     public partial class PimsWorkflowModelType
     {
         public PimsWorkflowModelType()
@@ -12,16 +16,35 @@ namespace Pims.Dal.Entities
             PimsWorkflowModels = new HashSet<PimsWorkflowModel>();
         }
 
+        [Key]
+        [Column("WORKFLOW_MODEL_TYPE_CODE")]
+        [StringLength(20)]
         public string WorkflowModelTypeCode { get; set; }
+        [Required]
+        [Column("DESCRIPTION")]
+        [StringLength(200)]
         public string Description { get; set; }
+        [Required]
+        [Column("IS_DISABLED")]
         public bool? IsDisabled { get; set; }
+        [Column("DISPLAY_ORDER")]
         public int? DisplayOrder { get; set; }
+        [Column("CONCURRENCY_CONTROL_NUMBER")]
         public long ConcurrencyControlNumber { get; set; }
+        [Column("DB_CREATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbCreateTimestamp { get; set; }
+        [Required]
+        [Column("DB_CREATE_USERID")]
+        [StringLength(30)]
         public string DbCreateUserid { get; set; }
+        [Column("DB_LAST_UPDATE_TIMESTAMP", TypeName = "datetime")]
         public DateTime DbLastUpdateTimestamp { get; set; }
+        [Required]
+        [Column("DB_LAST_UPDATE_USERID")]
+        [StringLength(30)]
         public string DbLastUpdateUserid { get; set; }
 
+        [InverseProperty(nameof(PimsWorkflowModel.WorkflowModelTypeCodeNavigation))]
         public virtual ICollection<PimsWorkflowModel> PimsWorkflowModels { get; set; }
     }
 }

--- a/backend/entities/ef/PimsxTableDefinition.cs
+++ b/backend/entities/ef/PimsxTableDefinition.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
+﻿
 #nullable disable
 
 namespace Pims.Dal.Entities

--- a/backend/entities/ef/PimsxTableDefinition.cs
+++ b/backend/entities/ef/PimsxTableDefinition.cs
@@ -1,13 +1,27 @@
-﻿
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
 #nullable disable
 
 namespace Pims.Dal.Entities
 {
+    [Keyless]
+    [Table("PIMSX_TableDefinitions")]
     public partial class PimsxTableDefinition
     {
+        [Column("TABLE_NAME")]
+        [StringLength(255)]
         public string TableName { get; set; }
+        [Column("TABLE_ALIAS")]
+        [StringLength(255)]
         public string TableAlias { get; set; }
+        [Column("HIST_REQUIRED")]
+        [StringLength(1)]
         public string HistRequired { get; set; }
+        [Column("DESCRIPTION")]
         public string Description { get; set; }
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "frontend",
-  "version": "1.0.0-16.12",
+  "version": "1.0.0-16.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.0-16.12",
+      "version": "1.0.0-16.19",
       "hasInstallScript": true,
       "dependencies": {
         "@bcgov/bc-sans": "1.0.1",


### PR DESCRIPTION
Cleaned leftover usings that were causing a spike in issues on SonarQube
https://sonarqube-3cd915-tools.apps.silver.devops.gov.bc.ca/dashboard?id=483bc59d-f9ef-428c-866e-581d9ea69eab

Scaffold now uses data annotations
Data Annotations allow EF to use annotations on the entities for the table definitions instead of having to be defined in the context.
 https://docs.microsoft.com/en-us/ef/ef6/modeling/code-first/data-annotations