### PR TITLE
Do not attempt to return the person name if tenant is not a person.

### DIFF
--- a/backend/api/Areas/Leases/Mapping/Search/LeaseMap.cs
+++ b/backend/api/Areas/Leases/Mapping/Search/LeaseMap.cs
@@ -16,7 +16,7 @@ namespace Pims.Api.Areas.Lease.Mapping.Search
                 .Map(dest => dest.LFileNo, src => src.LFileNo)
                 .Map(dest => dest.Properties, src => src.GetProperties())
                 .Map(dest => dest.ProgramName, src => src.GetProgramName())
-                .Map(dest => dest.TenantNames, src => src.PimsLeaseTenants.Select(t => t.Person.GetFullName()));
+                .Map(dest => dest.TenantNames, src => src.PimsLeaseTenants.Where(t => t != null && t.Person != null).Select(t => t.Person.GetFullName()));
         }
     }
 }

--- a/backend/entities/Helpers/PersonExtensions.cs
+++ b/backend/entities/Helpers/PersonExtensions.cs
@@ -60,6 +60,10 @@ namespace Pims.Dal.Entities
         /// <returns></returns>
         public static string GetFullName(this PimsPerson person)
         {
+            if(person == null)
+            {
+                return null;
+            }
             string[] names = { person.FirstName, person.MiddleNames, person.Surname };
             return String.Join(" ", names.Where(n => n != null && n.Trim() != String.Empty));
         }

--- a/frontend/src/features/leases/detail/LeasePages/deposits/Deposits.test.tsx
+++ b/frontend/src/features/leases/detail/LeasePages/deposits/Deposits.test.tsx
@@ -69,6 +69,12 @@ const setup = (renderOptions: RenderOptions & { lease?: IFormLease } = {}): Rend
 };
 
 describe('Lease Deposits', () => {
+  beforeEach(() => {
+    Date.now = jest.fn().mockReturnValue(new Date('2020-10-15T18:33:37.000Z'));
+  });
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
   it('renders as expected', () => {
     const result = setup({
       lease: {

--- a/frontend/src/features/leases/detail/LeasePages/deposits/__snapshots__/Deposits.test.tsx.snap
+++ b/frontend/src/features/leases/detail/LeasePages/deposits/__snapshots__/Deposits.test.tsx.snap
@@ -223,7 +223,7 @@ exports[`Lease Deposits renders as expected 1`] = `
                 style="box-sizing: border-box; flex: 40 0 auto; min-width: 30px; width: 40px; justify-content: flex-end; text-align: right; flex-wrap: wrap; align-items: center; display: flex;"
                 title=""
               >
-                $1.75
+                -$8.75
               </div>
               <div
                 class="td"
@@ -231,7 +231,7 @@ exports[`Lease Deposits renders as expected 1`] = `
                 style="box-sizing: border-box; flex: 40 0 auto; min-width: 30px; width: 40px; justify-content: flex-end; text-align: right; flex-wrap: wrap; align-items: center; display: flex;"
                 title=""
               >
-                $501.75
+                $491.25
               </div>
             </div>
           </div>
@@ -299,7 +299,7 @@ Integer nec odio.
                 style="box-sizing: border-box; flex: 40 0 auto; min-width: 30px; width: 40px; justify-content: flex-end; text-align: right; flex-wrap: wrap; align-items: center; display: flex;"
                 title=""
               >
-                $115.5
+                $66.5
               </div>
               <div
                 class="td"
@@ -307,7 +307,7 @@ Integer nec odio.
                 style="box-sizing: border-box; flex: 40 0 auto; min-width: 30px; width: 40px; justify-content: flex-end; text-align: right; flex-wrap: wrap; align-items: center; display: flex;"
                 title=""
               >
-                $2,115.5
+                $2,066.5
               </div>
             </div>
           </div>

--- a/frontend/src/features/leases/detail/LeasePages/deposits/components/DepositsReceivedTable/DepositsReceivedTable.test.tsx
+++ b/frontend/src/features/leases/detail/LeasePages/deposits/components/DepositsReceivedTable/DepositsReceivedTable.test.tsx
@@ -51,6 +51,12 @@ const setup = (renderOptions: RenderOptions & IDepositsReceivedTableProps = {}) 
 };
 
 describe('DepositsReceivedTable component', () => {
+  beforeEach(() => {
+    Date.now = jest.fn().mockReturnValue(new Date('2020-11-30T18:33:37.000Z'));
+  });
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
   it('renders as expected', () => {
     const { asFragment } = setup({ dataSource: [...mockDeposits] });
     expect(asFragment()).toMatchSnapshot();

--- a/frontend/src/features/leases/detail/LeasePages/deposits/components/DepositsReceivedTable/__snapshots__/DepositsReceivedTable.test.tsx.snap
+++ b/frontend/src/features/leases/detail/LeasePages/deposits/components/DepositsReceivedTable/__snapshots__/DepositsReceivedTable.test.tsx.snap
@@ -184,7 +184,7 @@ exports[`DepositsReceivedTable component renders as expected 1`] = `
             style="box-sizing: border-box; flex: 40 0 auto; min-width: 30px; width: 40px; justify-content: flex-end; text-align: right; flex-wrap: wrap; align-items: center; display: flex;"
             title=""
           >
-            $1.75
+            -$7.88
           </div>
           <div
             class="td"
@@ -192,7 +192,7 @@ exports[`DepositsReceivedTable component renders as expected 1`] = `
             style="box-sizing: border-box; flex: 40 0 auto; min-width: 30px; width: 40px; justify-content: flex-end; text-align: right; flex-wrap: wrap; align-items: center; display: flex;"
             title=""
           >
-            $501.75
+            $492.13
           </div>
         </div>
       </div>
@@ -260,7 +260,7 @@ Integer nec odio.
             style="box-sizing: border-box; flex: 40 0 auto; min-width: 30px; width: 40px; justify-content: flex-end; text-align: right; flex-wrap: wrap; align-items: center; display: flex;"
             title=""
           >
-            $115.5
+            $70
           </div>
           <div
             class="td"
@@ -268,7 +268,7 @@ Integer nec odio.
             style="box-sizing: border-box; flex: 40 0 auto; min-width: 30px; width: 40px; justify-content: flex-end; text-align: right; flex-wrap: wrap; align-items: center; display: flex;"
             title=""
           >
-            $2,115.5
+            $2,070
           </div>
         </div>
       </div>


### PR DESCRIPTION
corresponds to psp-2580. Corrects NPE generated by trying to dereference organization based tenants as if they were persons.