### PR TITLE
PSP-2497: Fix IDIR not displaying

### DIFF
--- a/frontend/src/features/admin/edit-user/EditUserPage.test.tsx
+++ b/frontend/src/features/admin/edit-user/EditUserPage.test.tsx
@@ -48,7 +48,7 @@ const selectedUser = {
   surname: 'User',
   position: '',
   rowVersion: 1,
-  businessIdentifierValue: 'admin',
+  businessIdentifier: 'admin',
   lastLogin: '2020-10-14T17:45:39.7381599',
 };
 

--- a/frontend/src/features/admin/edit-user/EditUserPage.tsx
+++ b/frontend/src/features/admin/edit-user/EditUserPage.tsx
@@ -96,7 +96,7 @@ const EditUserPage = (props: IEditUserPageProps) => {
   };
 
   const initialValues = {
-    businessIdentifierValue: user.businessIdentifierValue ?? '',
+    businessIdentifierValue: user.businessIdentifier ?? '',
     firstName: user.firstName ?? '',
     surname: user.surname ?? '',
     email: user.email ?? '',
@@ -140,7 +140,7 @@ const EditUserPage = (props: IEditUserPageProps) => {
               await updateUser({
                 id: user.id,
                 keycloakUserId: user.keycloakUserId,
-                businessIdentifierValue: user.businessIdentifierValue,
+                businessIdentifier: user.businessIdentifier,
                 displayName: values.displayName,
                 firstName: values.firstName,
                 surname: values.surname,

--- a/frontend/src/features/admin/users/ManageUsers.test.tsx
+++ b/frontend/src/features/admin/users/ManageUsers.test.tsx
@@ -72,7 +72,7 @@ const getStore = (includeDate?: boolean) =>
         items: [
           {
             id: 1,
-            businessIdentifierValue: 'testername1',
+            businessIdentifier: 'testername1',
             firstName: 'testUserFirst1',
             surname: 'testUserLast1',
             isDisabled: false,
@@ -83,7 +83,7 @@ const getStore = (includeDate?: boolean) =>
           },
           {
             id: 2,
-            businessIdentifierValue: 'testername2',
+            businessIdentifier: 'testername2',
             firstName: 'testUser',
             surname: 'testUser',
             isDisabled: true,

--- a/frontend/src/features/admin/users/ManageUsers.tsx
+++ b/frontend/src/features/admin/users/ManageUsers.tsx
@@ -95,7 +95,7 @@ export const ManageUsers = () => {
       id: u.id,
       keycloakUserId: u.keycloakUserId,
       email: u.email,
-      businessIdentifierValue: u.businessIdentifierValue,
+      businessIdentifierValue: u.businessIdentifier,
       firstName: u.firstName,
       surname: u.surname,
       isDisabled: u.isDisabled,

--- a/frontend/src/interfaces/IUser.ts
+++ b/frontend/src/interfaces/IUser.ts
@@ -6,6 +6,7 @@ import { IRole } from './IRole';
 export interface IUser {
   id?: number;
   businessIdentifierValue?: string;
+  businessIdentifier?: string;
   keycloakUserId?: string;
   email?: string;
   displayName?: string;


### PR DESCRIPTION
After some of the database first changes the business identifier field name underwent some changes. `businessIdentifier` is still being returned and the paged users was trying to map from a non existent (in this case) `businessIdentifierValue`.

I simply added the old value name to the` IUser` interface, but let me know if we should make a separate type and or rename more on the backend.

![image](https://user-images.githubusercontent.com/15724124/146296865-a844d9cb-b41c-4cb8-962f-b7682c553f0c.png)

![manageusersbug](https://user-images.githubusercontent.com/15724124/146298694-09ac575d-b354-4c18-8016-164a54c30a3b.gif)

 