### PR TITLE
PSP-2582: Contact names on new line

### DIFF
--- a/frontend/src/features/contacts/contact/detail/Organization.tsx
+++ b/frontend/src/features/contacts/contact/detail/Organization.tsx
@@ -178,13 +178,16 @@ const OrganizationView: React.FunctionComponent<OrganizationViewProps> = ({ orga
           <Col>
             {organization.persons &&
               organization.persons.map((person: IContactPerson, index: number) => (
-                <Link
-                  to={'/contact/P' + person.id}
-                  data-testid="contact-organization-person"
-                  key={'org-person-' + index}
-                >
-                  {person.fullName}
-                </Link>
+                <>
+                  <Link
+                    to={'/contact/P' + person.id}
+                    data-testid="contact-organization-person"
+                    key={'org-person-' + index}
+                  >
+                    {person.fullName}
+                  </Link>
+                  <br />
+                </>
               ))}
           </Col>
         </Styled.RowAligned>

--- a/frontend/src/features/contacts/contact/detail/Person.tsx
+++ b/frontend/src/features/contacts/contact/detail/Person.tsx
@@ -109,13 +109,16 @@ const PersonView: React.FunctionComponent<PersonViewProps> = ({ person }) => {
           <Col md="auto">
             {person.organizations &&
               person.organizations.map((organization: IContactOrganization, index: number) => (
-                <Link
-                  to={'/contact/O' + organization.id}
-                  data-testid="contact-person-organization"
-                  key={'person-org-' + index}
-                >
-                  {organization.name}
-                </Link>
+                <>
+                  <Link
+                    to={'/contact/O' + organization.id}
+                    data-testid="contact-person-organization"
+                    key={'person-org-' + index}
+                  >
+                    {organization.name}
+                  </Link>
+                  <br />
+                </>
               ))}
           </Col>
         </Styled.RowAligned>


### PR DESCRIPTION
Small "bug" (https://jira.th.gov.bc.ca/browse/PSP-2582).

Just to match the mockup. Previously name appearing like:
 `Example OneExample Two`.

Same issue for organizations on an individual.