### PR TITLE
PSP-2678: Correct draft color

### DIFF
--- a/frontend/src/colors.scss
+++ b/frontend/src/colors.scss
@@ -24,11 +24,10 @@ $primary-border-color: #aaaaaa;
 $disabled-color: #959da5;
 $discarded-color: #bcbec5;
 $filter-box-color: #d9eaf7;
-$draft-color: #a4bada;
+$draft-color: #1976d2;
 $link-color: #007bff;
 $link-hover-color: #0056b3;
 $subtle-color: #aaaaaa;
-
 // table ui
 $table-hover-color: #dee2e6;
 $table-header-text-color: #494949;


### PR DESCRIPTION
Correct draft status colour based off the UX-PIN mockup:
![image](https://user-images.githubusercontent.com/15724124/149395638-20849cfc-eda8-45c5-a008-a1c0853bc5ed.png)
