### PR TITLE
PSP-2721: Handle keycloak undefined middle name

### DIFF
--- a/frontend/src/features/leases/leaseUtils.ts
+++ b/frontend/src/features/leases/leaseUtils.ts
@@ -37,7 +37,9 @@ export const apiLeaseToFormLease = (lease?: ILease) => {
         ...lease,
         tenants: lease.tenants.map(tenant => ({
           summary: !!tenant.person
-            ? `${tenant.person?.firstName} ${tenant.person?.middleNames} ${tenant.person?.surname}`
+            ? `${tenant.person?.firstName} ${
+                !!tenant.person?.middleNames ? tenant.person?.middleNames : ''
+              } ${tenant.person?.surname}`
             : tenant.organization?.name,
           firstName: tenant.person?.firstName,
           surname: tenant.person?.surname,


### PR DESCRIPTION
When adding a tenant to the lease, after saving a middle name of `undefined` would appear. It seems that this only happened from contacts coming from Keycloak as one's entered through the system have a default value of '' and not `undefined`.

![image](https://user-images.githubusercontent.com/15724124/150243872-306066cf-a6b6-47b2-9c2c-2a7a537bf7c6.png)
