### PR TITLE
PSP-2928: Increase specificity of green button

### DIFF
--- a/frontend/src/features/leases/detail/LeasePages/payment/styles.tsx
+++ b/frontend/src/features/leases/detail/LeasePages/payment/styles.tsx
@@ -173,7 +173,7 @@ export const WarningTextBox = styled(InlineFlexDiv)`
 `;
 
 export const AddActualButton = styled(Button)`
-  && {
+  &&& {
     background-color: ${props => props.theme.css.completedColor};
     color: white;
     &:hover {


### PR DESCRIPTION
Button was originally showing up as blue on initial load due to a race condition.

Thanks @devinleighsmith for the help.