### PR TITLE
PSP-2919 Property Details - NON-INVENTORY 

### DIFF
--- a/backend/api/Helpers/Middleware/ErrorHandlingMiddleware.cs
+++ b/backend/api/Helpers/Middleware/ErrorHandlingMiddleware.cs
@@ -113,7 +113,7 @@ namespace Pims.Api.Helpers.Middleware
             }
             else if (ex is KeyNotFoundException)
             {
-                code = HttpStatusCode.BadRequest;
+                code = HttpStatusCode.NotFound;
                 message = "Item does not exist.";
 
                 _logger.LogDebug(ex, "Middleware caught unhandled exception.");

--- a/frontend/src/components/maps/leaflet/LayerPopup/LayerPopup.tsx
+++ b/frontend/src/components/maps/leaflet/LayerPopup/LayerPopup.tsx
@@ -1,6 +1,5 @@
 import useMapSideBarQueryParams from 'features/mapSideBar/hooks/useMapSideBarQueryParams';
 import { Feature, GeoJsonProperties } from 'geojson';
-import { IProperty } from 'interfaces';
 import { LatLng, LatLngBounds } from 'leaflet';
 import noop from 'lodash/noop';
 import React, { useCallback, useState } from 'react';
@@ -46,10 +45,15 @@ export interface ILayerPopupProps {
 }
 
 export const LayerPopup: React.FC<ILayerPopupProps> = ({ layerPopup, onClose, onAddToParcel }) => {
+  // We are interested in the PID field that comes back from parcel map layer attributes
+  const pid = layerPopup?.data?.PID;
+  // open/close map popup fly-out menu
   const [showFlyout, setShowFlyout] = useState(false);
   const openFlyout = useCallback(() => setShowFlyout(true), []);
   const closeFlyout = useCallback(() => setShowFlyout(false), []);
+  // open map side-bar for non-inventory properties - based on their PID
   const { setShowSideBar } = useMapSideBarQueryParams();
+  const onViewPropertyInfo = useCallback(() => setShowSideBar(true, pid), [pid, setShowSideBar]);
 
   const handlePopupClose = useCallback(() => {
     closeFlyout();
@@ -57,11 +61,6 @@ export const LayerPopup: React.FC<ILayerPopupProps> = ({ layerPopup, onClose, on
       onClose();
     }
   }, [onClose, closeFlyout]);
-
-  const onViewPropertyInfo = useCallback(() => {
-    const property = { pid: layerPopup?.data?.PID } as IProperty;
-    setShowSideBar(true, property);
-  }, [layerPopup, setShowSideBar]);
 
   return (
     <Popup

--- a/frontend/src/components/maps/leaflet/LayerPopup/LayerPopup.tsx
+++ b/frontend/src/components/maps/leaflet/LayerPopup/LayerPopup.tsx
@@ -1,4 +1,6 @@
+import useMapSideBarQueryParams from 'features/mapSideBar/hooks/useMapSideBarQueryParams';
 import { Feature, GeoJsonProperties } from 'geojson';
+import { IProperty } from 'interfaces';
 import { LatLng, LatLngBounds } from 'leaflet';
 import noop from 'lodash/noop';
 import React, { useCallback, useState } from 'react';
@@ -47,6 +49,7 @@ export const LayerPopup: React.FC<ILayerPopupProps> = ({ layerPopup, onClose, on
   const [showFlyout, setShowFlyout] = useState(false);
   const openFlyout = useCallback(() => setShowFlyout(true), []);
   const closeFlyout = useCallback(() => setShowFlyout(false), []);
+  const { setShowSideBar } = useMapSideBarQueryParams();
 
   const handlePopupClose = useCallback(() => {
     closeFlyout();
@@ -54,6 +57,11 @@ export const LayerPopup: React.FC<ILayerPopupProps> = ({ layerPopup, onClose, on
       onClose();
     }
   }, [onClose, closeFlyout]);
+
+  const onViewPropertyInfo = useCallback(() => {
+    const property = { pid: layerPopup?.data?.PID } as IProperty;
+    setShowSideBar(true, property);
+  }, [layerPopup, setShowSideBar]);
 
   return (
     <Popup
@@ -73,7 +81,7 @@ export const LayerPopup: React.FC<ILayerPopupProps> = ({ layerPopup, onClose, on
 
         {showFlyout && (
           <StyledFlyoutContainer>
-            <LayerPopupFlyout onViewPropertyInfo={noop} onCreateResearchFile={noop} />
+            <LayerPopupFlyout onViewPropertyInfo={onViewPropertyInfo} onCreateResearchFile={noop} />
           </StyledFlyoutContainer>
         )}
       </StyledContainer>

--- a/frontend/src/components/maps/leaflet/Map.tsx
+++ b/frontend/src/components/maps/leaflet/Map.tsx
@@ -263,7 +263,7 @@ const Map: React.FC<MapProps> = ({
             bounds={bounds}
             onMarkerClick={(property: IProperty) => {
               setLayersOpen(false);
-              setShowSideBar(true, property);
+              setShowSideBar(true, property?.pid);
             }}
             filter={geoFilter}
             onRequestData={setShowLoadingBackdrop}

--- a/frontend/src/features/mapSideBar/MapSideBarContainer.test.tsx
+++ b/frontend/src/features/mapSideBar/MapSideBarContainer.test.tsx
@@ -4,20 +4,33 @@ import { createMemoryHistory } from 'history';
 import { cleanup, render, RenderOptions, waitFor } from 'utils/test-utils';
 
 import MapSideBarContainer from './MapSideBarContainer';
+
+// Need to mock this library for unit tests
+jest.mock('react-visibility-sensor', () => {
+  return jest.fn().mockImplementation(({ children }) => {
+    if (children instanceof Function) {
+      return children({ isVisible: true });
+    }
+    return children;
+  });
+});
+
 describe('MapSideBarContainer component', () => {
   const mockAxios = new MockAdapter(axios);
   const history = createMemoryHistory();
-  const setup = (renderOptions: RenderOptions = {}) => {
-    // render component under test
-    const component = render(<MapSideBarContainer />, {
-      ...renderOptions,
-      history,
-    });
 
-    return {
-      component,
-    };
+  // render component under test
+  const setup = (renderOptions: RenderOptions = {}) => {
+    const renderResult = render(<MapSideBarContainer />, { ...renderOptions, history });
+    return { ...renderResult };
   };
+
+  afterEach(() => {
+    mockAxios.reset();
+    jest.restoreAllMocks();
+    cleanup();
+    history.push('');
+  });
 
   it('requests ltsa data by pid', async () => {
     history.push('mapview?pid=9212434&searchBy=pinOrPid&sidebar=true');
@@ -29,10 +42,35 @@ describe('MapSideBarContainer component', () => {
       expect(mockAxios.history.post[0].url).toBe(`/tools/ltsa/all?pid=009-212-434`);
     });
   });
-  afterEach(() => {
-    mockAxios.reset();
-    jest.restoreAllMocks();
-    cleanup();
-    history.push('');
+
+  it('shows the property information tab for inventory properties', async () => {
+    history.push('mapview?pid=9212434&searchBy=pinOrPid&sidebar=true');
+    mockAxios.onPost().reply(200, {});
+    mockAxios.onGet(new RegExp('/properties/*')).reply(200, {});
+    const { getByText } = setup({});
+    await waitFor(() => {
+      expect(mockAxios.history.get.length).toBeGreaterThanOrEqual(1);
+      expect(mockAxios.history.get[0].url).toBe(`/properties/009-212-434`);
+    });
+    expect(getByText('Property attributes')).toBeVisible();
+  });
+
+  it('hides the property information tab for non-inventory properties', async () => {
+    history.push('mapview?pid=9212434&searchBy=pinOrPid&sidebar=true');
+    mockAxios.onPost().reply(200, {});
+    // non-inventory properties return a "not-found" error from API
+    const error = {
+      isAxiosError: true,
+      response: { status: 400 },
+    };
+    mockAxios.onGet(new RegExp('/properties/*')).reply(400, error);
+    const { queryByText } = setup({});
+    await waitFor(() => {
+      expect(mockAxios.history.post).toHaveLength(1);
+      expect(mockAxios.history.post[0].url).toBe(`/tools/ltsa/all?pid=009-212-434`);
+      expect(mockAxios.history.get.length).toBeGreaterThanOrEqual(1);
+      expect(mockAxios.history.get[0].url).toBe(`/properties/009-212-434`);
+    });
+    expect(queryByText('Property attributes')).toBeNull();
   });
 });

--- a/frontend/src/features/mapSideBar/MapSideBarContainer.test.tsx
+++ b/frontend/src/features/mapSideBar/MapSideBarContainer.test.tsx
@@ -25,15 +25,15 @@ describe('MapSideBarContainer component', () => {
     return { ...renderResult };
   };
 
-  afterEach(() => {
+  beforeEach(() => {
     mockAxios.reset();
     jest.restoreAllMocks();
     cleanup();
-    history.push('');
+    history.replace('');
   });
 
   it('requests ltsa data by pid', async () => {
-    history.push('mapview?pid=9212434&searchBy=pinOrPid&sidebar=true');
+    history.replace('mapview?pid=9212434&searchBy=pinOrPid&sidebar=true');
     mockAxios.onPost().reply(200, {});
     mockAxios.onGet().reply(200, {});
     setup({});
@@ -44,30 +44,30 @@ describe('MapSideBarContainer component', () => {
   });
 
   it('shows the property information tab for inventory properties', async () => {
-    history.push('mapview?pid=9212434&searchBy=pinOrPid&sidebar=true');
+    history.replace('mapview?pid=9212434&searchBy=pinOrPid&sidebar=true');
     mockAxios.onPost().reply(200, {});
-    mockAxios.onGet(new RegExp('/properties/*')).reply(200, {});
-    const { getByText } = setup({});
+    mockAxios.onGet(new RegExp('properties/*')).reply(200, {});
+    mockAxios.onGet(new RegExp('ogs-internal/*')).reply(200, {});
+    const { findByText } = setup({});
     await waitFor(() => {
       expect(mockAxios.history.get.length).toBeGreaterThanOrEqual(1);
       expect(mockAxios.history.get[0].url).toBe(`/properties/009-212-434`);
     });
-    expect(getByText('Property attributes')).toBeVisible();
+    expect(await findByText('Property attributes')).toBeInTheDocument();
   });
 
   it('hides the property information tab for non-inventory properties', async () => {
-    history.push('mapview?pid=9212434&searchBy=pinOrPid&sidebar=true');
+    history.replace('mapview?pid=9212434&searchBy=pinOrPid&sidebar=true');
     mockAxios.onPost().reply(200, {});
     // non-inventory properties return a "not-found" error from API
     const error = {
       isAxiosError: true,
-      response: { status: 400 },
+      response: { status: 404 },
     };
-    mockAxios.onGet(new RegExp('/properties/*')).reply(400, error);
+    mockAxios.onGet(new RegExp('/properties/*')).reply(404, error);
+    mockAxios.onGet(new RegExp('ogs-internal/*')).reply(200, {});
     const { queryByText } = setup({});
     await waitFor(() => {
-      expect(mockAxios.history.post).toHaveLength(1);
-      expect(mockAxios.history.post[0].url).toBe(`/tools/ltsa/all?pid=009-212-434`);
       expect(mockAxios.history.get.length).toBeGreaterThanOrEqual(1);
       expect(mockAxios.history.get[0].url).toBe(`/properties/009-212-434`);
     });

--- a/frontend/src/features/mapSideBar/MapSideBarContainer.tsx
+++ b/frontend/src/features/mapSideBar/MapSideBarContainer.tsx
@@ -46,7 +46,7 @@ export const MotiInventoryContainer: React.FunctionComponent = () => {
         // We get an error because PID is not on our database
         if (axios.isAxiosError(e)) {
           const axiosError = e as AxiosError<IApiError>;
-          if (axiosError?.response?.status === 400) {
+          if (axiosError?.response?.status === 404) {
             setShowPropertyInfoTab(false);
           }
         }

--- a/frontend/src/features/mapSideBar/MapSideBarContainer.tsx
+++ b/frontend/src/features/mapSideBar/MapSideBarContainer.tsx
@@ -1,7 +1,9 @@
+import axios, { AxiosError } from 'axios';
 import { FormikProps, FormikValues } from 'formik';
 import useIsMounted from 'hooks/useIsMounted';
 import { useLtsa } from 'hooks/useLtsa';
 import { useProperties } from 'hooks/useProperties';
+import { IApiError } from 'interfaces/IApiError';
 import { IPropertyApiModel } from 'interfaces/IPropertyApiModel';
 import { LtsaOrders } from 'interfaces/ltsaModels';
 import React, { useEffect, useState } from 'react';
@@ -25,15 +27,28 @@ export const MotiInventoryContainer: React.FunctionComponent = () => {
   const [ltsaData, setLtsaData] = useState<LtsaOrders | undefined>(undefined);
   const [apiProperty, setApiProperty] = useState<IPropertyApiModel | undefined>(undefined);
   const [ltsaDataRequestedOn, setLtsaDataRequestedOn] = useState<Date | undefined>(undefined);
+  const [showPropertyInfoTab, setShowPropertyInfoTab] = useState(true);
 
   // First, fetch property information from PSP API
   const { getPropertyWithPid } = useProperties();
   useEffect(() => {
     const func = async () => {
-      if (!!pid) {
-        const propInfo = await getPropertyWithPid(pid);
-        if (isMounted() && propInfo.pid === pidFormatter(pid)) {
-          setApiProperty(propInfo);
+      try {
+        if (!!pid) {
+          const propInfo = await getPropertyWithPid(pid);
+          if (isMounted() && propInfo.pid === pidFormatter(pid)) {
+            setApiProperty(propInfo);
+            setShowPropertyInfoTab(true);
+          }
+        }
+      } catch (e) {
+        // PSP-2919 Hide the property info tab for non-inventory properties
+        // We get an error because PID is not on our database
+        if (axios.isAxiosError(e)) {
+          const axiosError = e as AxiosError<IApiError>;
+          if (axiosError?.response?.status === 400) {
+            setShowPropertyInfoTab(false);
+          }
         }
       }
     };
@@ -72,7 +87,9 @@ export const MotiInventoryContainer: React.FunctionComponent = () => {
       header={<MapSlideBarHeader ltsaData={ltsaData} property={apiProperty} />}
     >
       <InventoryTabs
-        PropertyView={<PropertyDetailsTabView property={propertyViewForm} />}
+        PropertyView={
+          showPropertyInfoTab ? <PropertyDetailsTabView property={propertyViewForm} /> : null
+        }
         LtsaView={<LtsaTabView ltsaData={ltsaData} ltsaRequestedOn={ltsaDataRequestedOn} />}
       />
     </MapSideBarLayout>

--- a/frontend/src/features/mapSideBar/hooks/useMapSideBarQueryParams.ts
+++ b/frontend/src/features/mapSideBar/hooks/useMapSideBarQueryParams.ts
@@ -1,5 +1,4 @@
 import useDeepCompareEffect from 'hooks/useDeepCompareEffect';
-import { IProperty } from 'interfaces';
 import queryString from 'query-string';
 import { useCallback, useMemo, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
@@ -8,7 +7,7 @@ import { pidParser } from './../../../utils/propertyUtils';
 
 interface IMapSideBar {
   showSideBar: boolean;
-  setShowSideBar: (show: boolean, property?: IProperty) => void;
+  setShowSideBar: (show: boolean, pid?: string) => void;
   setDisabled: (disabled: boolean) => void;
   disabled?: boolean;
   pid?: string;
@@ -36,11 +35,11 @@ export const useMapSideBarQueryParams = (formikRef?: any): IMapSideBar => {
   }, [searchParams]);
 
   const setShow = useCallback(
-    (show: boolean, propertyInfo?: IProperty) => {
+    (show: boolean, pid?: string) => {
       const search = {
         ...(searchParams as any),
         sidebar: show,
-        pid: pidParser(propertyInfo?.pid),
+        pid: pidParser(pid),
       };
       history.push({ search: queryString.stringify(search) });
     },

--- a/frontend/src/features/mapSideBar/tabs/InventoryTabs.tsx
+++ b/frontend/src/features/mapSideBar/tabs/InventoryTabs.tsx
@@ -21,15 +21,19 @@ export const InventoryTabs: React.FunctionComponent<IInventoryTabsProps> = ({
   PropertyView,
   LtsaView,
 }) => {
+  const showPropertyInfo = PropertyView !== null;
+
   return (
-    <TabView defaultActiveKey={InventoryTabNames.property}>
+    <TabView activeKey={showPropertyInfo ? InventoryTabNames.property : InventoryTabNames.title}>
       <Tab eventKey={InventoryTabNames.title} title="Title">
         {LtsaView}
       </Tab>
       <Tab eventKey={InventoryTabNames.value} title="Value"></Tab>
-      <Tab eventKey={InventoryTabNames.property} title="Property Details">
-        {PropertyView}
-      </Tab>
+      {showPropertyInfo && (
+        <Tab eventKey={InventoryTabNames.property} title="Property Details">
+          {PropertyView}
+        </Tab>
+      )}
     </TabView>
   );
 };


### PR DESCRIPTION
This PR will hide the property information tab in the map slide-out for non-inventory properties. Basically when the API returns an error for a property from the map it means it's not on our inventory. In that case, hide the tab and make LTSA the default selected tab.

Also refactored the way we launch the sidebar to only require a PID instead of a full property object. For non-inventory we have no property object so wouldn't make sense there.