### PR TITLE
use the guid instead of the business identifier to id users.

### DIFF
--- a/tools/keycloak/sync/SyncFactory.cs
+++ b/tools/keycloak/sync/SyncFactory.cs
@@ -382,7 +382,7 @@ namespace Pims.Tools.Keycloak.Sync
 
             // Add keycloak users to PIMS.
             // Only add users who don't exist.
-            foreach (var kuser in kusers.Where(u => !users.Any(pu => pu.BusinessIdentifier == u.Username)))
+            foreach (var kuser in kusers.Where(u => !users.Any(pu => pu.KeycloakUserId == u.Id)))
             {
                 try
                 {


### PR DESCRIPTION
This will prevent duplicate users from being created.

Also logged the following to cleanup the duplicates:
https://jira.th.gov.bc.ca/browse/PSP-3411