### PR TITLE
ensure research file list view searches for active files by default.

### DIFF
--- a/frontend/src/features/research/list/ResearchFilter/ResearchFilter.test.tsx
+++ b/frontend/src/features/research/list/ResearchFilter/ResearchFilter.test.tsx
@@ -37,6 +37,13 @@ describe('Research Filter', () => {
     expect(fragment).toMatchSnapshot();
   });
 
+  it('searches for active research files by default', async () => {
+    const { resetButton } = setup();
+    await act(async () => userEvent.click(resetButton));
+
+    expect(setFilter).toHaveBeenCalledWith(defaultResearchFilter);
+  });
+
   it('searches by region', async () => {
     const { container, searchButton } = setup();
 

--- a/frontend/src/features/research/list/ResearchFilter/ResearchFilter.tsx
+++ b/frontend/src/features/research/list/ResearchFilter/ResearchFilter.tsx
@@ -21,7 +21,7 @@ export interface IResearchFilterProps {
 
 export const defaultResearchFilter: IResearchFilter = {
   regionCode: '',
-  researchFileStatusTypeCode: '',
+  researchFileStatusTypeCode: 'ACTIVE',
   name: '',
   roadOrAlias: '',
   appCreateUserid: '',
@@ -101,7 +101,11 @@ export const ResearchFilter: React.FunctionComponent<IResearchFilterProps> = ({
                 <Col xl="12">
                   <Row>
                     <Col xl="4">
-                      <Select options={researchStatusOptions} field="researchFileStatusTypeCode" />
+                      <Select
+                        placeholder="Select a status"
+                        options={researchStatusOptions}
+                        field="researchFileStatusTypeCode"
+                      />
                     </Col>
                     <Col xl="8">
                       <Input field="roadOrAlias" placeholder="Road name or alias" />

--- a/frontend/src/features/research/list/ResearchFilter/__snapshots__/ResearchFilter.test.tsx.snap
+++ b/frontend/src/features/research/list/ResearchFilter/__snapshots__/ResearchFilter.test.tsx.snap
@@ -334,6 +334,11 @@ exports[`Research Filter matches snapshot 1`] = `
                     name="researchFileStatusTypeCode"
                   >
                     <option
+                      value=""
+                    >
+                      Select a status
+                    </option>
+                    <option
                       class="option"
                       value="ACTIVE"
                     >

--- a/frontend/src/features/research/list/__snapshots__/ResearchListView.test.tsx.snap
+++ b/frontend/src/features/research/list/__snapshots__/ResearchListView.test.tsx.snap
@@ -427,6 +427,11 @@ exports[`Research List View matches snapshot 1`] = `
                               name="researchFileStatusTypeCode"
                             >
                               <option
+                                value=""
+                              >
+                                Select a status
+                              </option>
+                              <option
                                 class="option"
                                 value="ACTIVE"
                               >


### PR DESCRIPTION
Also added a placeholder such that the user is able to clear the status field entirely.