### PR TITLE
Psp 3890

### DIFF
--- a/frontend/src/components/common/GenericModal.tsx
+++ b/frontend/src/components/common/GenericModal.tsx
@@ -94,6 +94,7 @@ export const GenericModal = (props: BsModalProps & ModalProps) => {
     cancelButtonVariant,
     cancelButtonText,
     closeButton,
+    ...rest
   } = props;
   const [show, setShow] = useState(true);
 
@@ -125,7 +126,7 @@ export const GenericModal = (props: BsModalProps & ModalProps) => {
   };
 
   return (
-    <ModalContainer {...props} show={showState}>
+    <ModalContainer {...rest} show={showState}>
       <Modal.Header closeButton={closeButton}>
         <Modal.Title>{title}</Modal.Title>
       </Modal.Header>

--- a/frontend/src/components/maps/hooks/useMapSearch.tsx
+++ b/frontend/src/components/maps/hooks/useMapSearch.tsx
@@ -1,0 +1,86 @@
+import { PointFeature } from 'components/maps/types';
+import { IGeoSearchParams } from 'constants/API';
+import { useMapProperties } from 'features/properties/map/hooks/useMapProperties';
+import { Feature, FeatureCollection, GeoJsonProperties, Geometry } from 'geojson';
+import { geoJSON } from 'leaflet';
+import { useContext, useEffect } from 'react';
+import { toast } from 'react-toastify';
+
+import { PropertyContext } from '../providers/PropertyContext';
+
+export const useMapSearch = () => {
+  const { properties, setProperties, setPropertiesLoading } = useContext(PropertyContext);
+  const {
+    loadProperties: { execute: loadProperties, loading, response },
+  } = useMapProperties();
+
+  useEffect(() => {
+    setPropertiesLoading(loading);
+  }, [loading, setPropertiesLoading]);
+
+  const search = async (
+    filters?: IGeoSearchParams[],
+  ): Promise<Feature<Geometry, GeoJsonProperties>[]> => {
+    //TODO: currently this loads all matching properties, this should be rewritten to use the bbox and make one request per tile.
+    try {
+      const tileData = await loadProperties(
+        filters?.length && filters.length > 1 ? filters[0] : undefined,
+      );
+      if (tileData) {
+        const validFeatures = tileData.features.filter(feature => !!feature?.geometry);
+        setProperties(propertiesResponseToPointFeature(tileData));
+
+        if (validFeatures.length === 0) {
+          toast.info('No search results found');
+        } else {
+          toast.info(`${validFeatures.length} properties found`);
+        }
+      }
+    } catch (error) {
+      toast.error((error as Error).message, { autoClose: 7000 });
+    } finally {
+    }
+    return [];
+  };
+
+  return {
+    search,
+    loading,
+    response,
+    properties,
+  };
+};
+
+/**
+ * TODO: convert polygon features into lat/lng coordinates, remove this when new Point Geoserver layer available.
+ * @param feature the feature to obtain lat/lng coordinates for.
+ * @returns [lat, lng]
+ */
+const getLatLng = (feature: any) => {
+  if (feature.geometry.type === 'Polygon' || feature.geometry.type === 'MultiPolygon') {
+    const latLng = geoJSON(feature.geometry)
+      .getBounds()
+      .getCenter();
+    return [latLng.lng, latLng.lat];
+  }
+  return feature.geometry.coordinates;
+};
+
+export const propertiesResponseToPointFeature = (
+  response: FeatureCollection<Geometry, GeoJsonProperties> | undefined,
+): PointFeature[] => {
+  const validFeatures = response?.features.filter(feature => !!feature?.geometry) ?? [];
+  const data: PointFeature[] = validFeatures.map((feature: Feature) => {
+    //TODO: this converts all polygons to points, this should be changed to a View that returns the POINT instead of the POLYGON (psp-1859)
+    return {
+      ...feature,
+      geometry: { type: 'Point', coordinates: getLatLng(feature) },
+      properties: {
+        ...feature.properties,
+        id: feature.properties?.id ?? 0,
+      },
+    };
+  });
+
+  return data;
+};

--- a/frontend/src/components/maps/leaflet/Map.tsx
+++ b/frontend/src/components/maps/leaflet/Map.tsx
@@ -4,7 +4,6 @@ import { IGeoSearchParams } from 'constants/API';
 import { MAP_MAX_NATIVE_ZOOM, MAP_MAX_ZOOM } from 'constants/strings';
 import { PropertyFilter } from 'features/properties/filter';
 import { IPropertyFilter } from 'features/properties/filter/IPropertyFilter';
-import useDeepCompareCallback from 'hooks/useDeepCompareCallback';
 import useKeycloakWrapper from 'hooks/useKeycloakWrapper';
 import { IProperty } from 'interfaces';
 import { LatLngBounds, Map as LeafletMap, TileLayer as LeafletTileLayer } from 'leaflet';

--- a/frontend/src/components/maps/providers/PropertyContext.tsx
+++ b/frontend/src/components/maps/providers/PropertyContext.tsx
@@ -1,0 +1,44 @@
+import { noop } from 'lodash';
+import React from 'react';
+
+import { PointFeature } from '../types';
+
+export interface IPropertyContext {
+  properties: PointFeature[];
+  setProperties: (properties: PointFeature[]) => void;
+  propertiesLoading: boolean;
+  setPropertiesLoading: (loading: boolean) => void;
+}
+
+export const PropertyContext = React.createContext<IPropertyContext>({
+  properties: [],
+  setProperties: noop,
+  propertiesLoading: false,
+  setPropertiesLoading: noop,
+});
+
+interface IPropertyContextComponent {
+  values?: Partial<IPropertyContext>;
+}
+
+export const PropertyContextProvider: React.FC<IPropertyContextComponent> = ({
+  children,
+  values,
+}) => {
+  const [properties, setProperties] = React.useState<PointFeature[]>(values?.properties ?? []);
+  const [propertiesLoading, setPropertiesLoading] = React.useState<boolean>(
+    values?.propertiesLoading ?? false,
+  );
+  return (
+    <PropertyContext.Provider
+      value={{
+        properties,
+        setProperties: values?.setProperties ?? setProperties,
+        propertiesLoading,
+        setPropertiesLoading,
+      }}
+    >
+      {children}
+    </PropertyContext.Provider>
+  );
+};

--- a/frontend/src/features/properties/map/MapView.test.tsx
+++ b/frontend/src/features/properties/map/MapView.test.tsx
@@ -28,12 +28,13 @@ import { lookupCodesSlice } from 'store/slices/lookupCodes';
 import { mockKeycloak } from 'utils/test-utils';
 import TestCommonWrapper from 'utils/TestCommonWrapper';
 
+import { useMapProperties } from './hooks/useMapProperties';
 import MapView from './MapView';
 
 const mockAxios = new MockAdapter(axios);
 jest.mock('@react-keycloak/web');
 const mockStore = configureMockStore([thunk]);
-jest.mock('hooks/useApi');
+jest.mock('./hooks/useMapProperties');
 jest.mock('components/maps/leaflet/LayerPopup');
 jest.mock('hooks/useProperties');
 jest.mock('hooks/usePropertyAssociations');
@@ -157,14 +158,14 @@ describe('MapView', () => {
         },
       },
     });
-    ((useApi as unknown) as jest.Mock<Partial<typeof useApi>>).mockReturnValue({
-      loadProperties: jest.fn(async () => {
-        return {
+    ((useMapProperties as unknown) as jest.Mock<Partial<typeof useMapProperties>>).mockReturnValue({
+      loadProperties: {
+        execute: jest.fn().mockResolvedValue({
           features: createPoints(mockParcels),
           type: 'FeatureCollection',
           bbox: undefined,
-        };
-      }),
+        }),
+      },
     });
     ((useApiProperties as unknown) as jest.Mock<Partial<typeof useApiProperties>>).mockReturnValue({
       getProperty: async () => {
@@ -244,14 +245,14 @@ describe('MapView', () => {
   });
 
   it('the map can zoom in until no clusters are visible', async () => {
-    ((useApi as unknown) as jest.Mock<Partial<typeof useApi>>).mockReturnValue({
-      loadProperties: jest.fn(async () => {
-        return {
+    ((useMapProperties as unknown) as jest.Mock<Partial<typeof useMapProperties>>).mockReturnValue({
+      loadProperties: {
+        execute: jest.fn().mockResolvedValue({
           features: createPoints(smallMockParcels),
           type: 'FeatureCollection',
           bbox: undefined,
-        };
-      }),
+        }),
+      },
     });
     ((useApiProperties as unknown) as jest.Mock<Partial<typeof useApiProperties>>).mockReturnValue({
       getParcel: async () => {
@@ -270,14 +271,14 @@ describe('MapView', () => {
   });
 
   it('the map can handle features with invalid geometry', async () => {
-    ((useApi as unknown) as jest.Mock<Partial<typeof useApi>>).mockReturnValue({
-      loadProperties: jest.fn(async () => {
-        return {
+    ((useMapProperties as unknown) as jest.Mock<Partial<typeof useMapProperties>>).mockReturnValue({
+      loadProperties: {
+        execute: jest.fn().mockResolvedValue({
           features: createPoints(smallMockParcels).map(feature => ({ ...feature, geometry: null })),
           type: 'FeatureCollection',
           bbox: undefined,
-        };
-      }),
+        }),
+      },
     });
     ((useApiProperties as unknown) as jest.Mock<Partial<typeof useApiProperties>>).mockReturnValue({
       getParcel: async () => {
@@ -371,14 +372,14 @@ describe('MapView', () => {
         return {} as IProperty;
       },
     });
-    ((useApi as unknown) as jest.Mock<Partial<typeof useApi>>).mockReturnValue({
-      loadProperties: jest.fn(async () => {
-        return {
+    ((useMapProperties as unknown) as jest.Mock<Partial<typeof useMapProperties>>).mockReturnValue({
+      loadProperties: {
+        execute: jest.fn().mockResolvedValue({
           features: createPoints(largeMockParcels),
           type: 'FeatureCollection',
           bbox: undefined,
-        };
-      }),
+        }),
+      },
     });
     const { container } = render(getMap());
     await waitFor(() => {
@@ -397,7 +398,7 @@ describe('MapView', () => {
     });
   });
 
-  it('Rendered markers can be clicked', async () => {
+  it('Rendered markers can be clicked normally', async () => {
     await waitFor(() => render(getMap()));
     const cluster = document.querySelector('.leaflet-marker-icon');
     fireEvent.click(cluster!);

--- a/frontend/src/features/properties/map/MapView.test.tsx
+++ b/frontend/src/features/properties/map/MapView.test.tsx
@@ -16,7 +16,6 @@ import {
 import { createMemoryHistory } from 'history';
 import { useProperties } from 'hooks';
 import { useApiProperties } from 'hooks/pims-api';
-import { useApi } from 'hooks/useApi';
 import { useLtsa } from 'hooks/useLtsa';
 import { usePropertyAssociations } from 'hooks/usePropertyAssociations';
 import { IProperty } from 'interfaces';

--- a/frontend/src/features/properties/map/MapView.tsx
+++ b/frontend/src/features/properties/map/MapView.tsx
@@ -1,10 +1,7 @@
 import DraftSvg from 'assets/images/pins/icon-draft.svg';
 import clsx from 'classnames';
 import { FilterProvider } from 'components/maps/providers/FIlterProvider';
-import {
-  PropertyContext,
-  PropertyContextProvider,
-} from 'components/maps/providers/PropertyContext';
+import { PropertyContextProvider } from 'components/maps/providers/PropertyContext';
 import {
   SelectedPropertyContext,
   SelectedPropertyContextProvider,

--- a/frontend/src/features/properties/map/MapView.tsx
+++ b/frontend/src/features/properties/map/MapView.tsx
@@ -2,6 +2,10 @@ import DraftSvg from 'assets/images/pins/icon-draft.svg';
 import clsx from 'classnames';
 import { FilterProvider } from 'components/maps/providers/FIlterProvider';
 import {
+  PropertyContext,
+  PropertyContextProvider,
+} from 'components/maps/providers/PropertyContext';
+import {
   SelectedPropertyContext,
   SelectedPropertyContextProvider,
 } from 'components/maps/providers/SelectedPropertyContext';
@@ -50,26 +54,28 @@ const MapView: React.FC<MapViewProps> = (props: MapViewProps) => {
     <SelectedPropertyContextProvider>
       <SelectedPropertyContext.Consumer>
         {({ cursor }) => (
-          <StyleMapView className={clsx(cursor)}>
-            <MapSideBar showSideBar={showSideBar}>{sidebarComponent}</MapSideBar>
-            <FilterProvider>
-              <Map
-                lat={defaultLatLng.lat}
-                lng={defaultLatLng.lng}
-                onViewportChanged={() => {
-                  if (!loadedProperties) {
-                    setLoadedProperties(true);
-                  }
-                }}
-                showParcelBoundaries={props.showParcelBoundaries ?? true}
-                zoom={6}
-                onPropertyMarkerClick={onMarkerClicked}
-                onViewPropertyClick={onPropertyViewClicked}
-                showSideBar={showSideBar}
-                whenCreated={setMapInstance}
-              />
-            </FilterProvider>
-          </StyleMapView>
+          <PropertyContextProvider>
+            <StyleMapView className={clsx(cursor)}>
+              <MapSideBar showSideBar={showSideBar}>{sidebarComponent}</MapSideBar>
+              <FilterProvider>
+                <Map
+                  lat={defaultLatLng.lat}
+                  lng={defaultLatLng.lng}
+                  onViewportChanged={() => {
+                    if (!loadedProperties) {
+                      setLoadedProperties(true);
+                    }
+                  }}
+                  showParcelBoundaries={props.showParcelBoundaries ?? true}
+                  zoom={6}
+                  onPropertyMarkerClick={onMarkerClicked}
+                  onViewPropertyClick={onPropertyViewClicked}
+                  showSideBar={showSideBar}
+                  whenCreated={setMapInstance}
+                />
+              </FilterProvider>
+            </StyleMapView>
+          </PropertyContextProvider>
         )}
       </SelectedPropertyContext.Consumer>
     </SelectedPropertyContextProvider>

--- a/frontend/src/features/properties/map/__snapshots__/MapView.test.tsx.snap
+++ b/frontend/src/features/properties/map/__snapshots__/MapView.test.tsx.snap
@@ -5,25 +5,25 @@ exports[`MapView Renders the map 1`] = `
   <div
     class="Toastify"
   />
-  .c5 {
+  .c4 {
   padding-right: 0;
 }
 
-.c5 .form-control {
+.c4 .form-control {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
 }
 
-.c6:not(:first-child) {
+.c5:not(:first-child) {
   padding-left: 0;
 }
 
-.c6:not(:first-child) .form-control {
+.c5:not(:first-child) .form-control {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
 }
 
-.c7.btn {
+.c6.btn {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -53,49 +53,49 @@ exports[`MapView Renders the map 1`] = `
   cursor: pointer;
 }
 
-.c7.btn:hover {
+.c6.btn:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   opacity: 0.8;
 }
 
-.c7.btn:focus {
+.c6.btn:focus {
   outline-width: 0.4rem;
   outline-style: solid;
   outline-offset: 1px;
   box-shadow: none;
 }
 
-.c7.btn.btn-primary {
+.c6.btn.btn-primary {
   border: none;
 }
 
-.c7.btn.btn-secondary {
+.c6.btn.btn-secondary {
   background: none;
 }
 
-.c7.btn.btn-info {
+.c6.btn.btn-info {
   border: none;
   background: none;
   padding-left: 0.6rem;
   padding-right: 0.6rem;
 }
 
-.c7.btn.btn-info:hover,
-.c7.btn.btn-info:active,
-.c7.btn.btn-info:focus {
+.c6.btn.btn-info:hover,
+.c6.btn.btn-info:active,
+.c6.btn.btn-info:focus {
   background: none;
 }
 
-.c7.btn.btn-light {
+.c6.btn.btn-light {
   border: none;
 }
 
-.c7.btn.btn-dark {
+.c6.btn.btn-dark {
   border: none;
 }
 
-.c7.btn.btn-link {
+.c6.btn.btn-link {
   font-size: 1.6rem;
   font-weight: 400;
   background: none;
@@ -115,9 +115,9 @@ exports[`MapView Renders the map 1`] = `
   padding: 0;
 }
 
-.c7.btn.btn-link:hover,
-.c7.btn.btn-link:active,
-.c7.btn.btn-link:focus {
+.c6.btn.btn-link:hover,
+.c6.btn.btn-link:active,
+.c6.btn.btn-link:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   border: none;
@@ -126,14 +126,14 @@ exports[`MapView Renders the map 1`] = `
   outline: none;
 }
 
-.c7.btn.btn-link:disabled,
-.c7.btn.btn-link.disabled {
+.c6.btn.btn-link:disabled,
+.c6.btn.btn-link.disabled {
   background: none;
   pointer-events: none;
 }
 
-.c7.btn:disabled,
-.c7.btn:disabled:hover {
+.c6.btn:disabled,
+.c6.btn:disabled:hover {
   box-shadow: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -144,75 +144,49 @@ exports[`MapView Renders the map 1`] = `
   opacity: 0.65;
 }
 
-.c7.Button .Button__icon {
+.c6.Button .Button__icon {
   margin-right: 1.6rem;
 }
 
-.c7.Button--icon-only:focus {
+.c6.Button--icon-only:focus {
   outline: none;
 }
 
-.c7.Button--icon-only .Button__icon {
+.c6.Button--icon-only .Button__icon {
   margin-right: 0;
 }
 
-.c3 {
-  width: 100%;
-  height: 100%;
-  position: fixed;
-  z-index: 999;
-  top: 0;
-  left: 0;
-  background-color: rgba(0,0,0,0.4);
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
-  align-content: center;
-  justify-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c8 div:nth-child(1) div:nth-child(1) {
+.c7 div:nth-child(1) div:nth-child(1) {
   cursor: auto;
 }
 
-.c8 div:nth-child(1) div:nth-child(1) svg {
+.c7 div:nth-child(1) div:nth-child(1) svg {
   fill: #909090;
 }
 
-.c8 div:nth-child(2) div:nth-child(1) {
+.c7 div:nth-child(2) div:nth-child(1) {
   cursor: pointer;
 }
 
-.c8 div:nth-child(2) div:nth-child(1) svg {
+.c7 div:nth-child(2) div:nth-child(1) svg {
   fill: #003366;
 }
 
-.c9 {
+.c8 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
   width: 100%;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -229,50 +203,50 @@ exports[`MapView Renders the map 1`] = `
   align-items: center;
 }
 
-.c10 svg {
+.c9 svg {
   min-width: -webkit-max-content;
   min-width: -moz-max-content;
   min-width: max-content;
 }
 
-.c11 {
+.c10 {
   grid-area: map;
 }
 
-.c11 .leaflet-div-icon {
+.c10 .leaflet-div-icon {
   background: none;
   border: none;
 }
 
-.c11 .leaflet-div-icon img {
+.c10 .leaflet-div-icon img {
   width: inherit;
   height: inherit;
   -webkit-filter: drop-shadow(3px 1px 10px rgb(0 0 0 / 0.6));
   filter: drop-shadow(3px 1px 10px rgb(0 0 0 / 0.6));
 }
 
-.c11 .leaflet-container {
+.c10 .leaflet-container {
   height: 100%;
   margin: auto;
 }
 
-.c11 .leaflet-container .leaflet-popup-content-wrapper {
+.c10 .leaflet-container .leaflet-popup-content-wrapper {
   border-radius: 0;
 }
 
-.c11 .leaflet-container .leaflet-popup-content {
+.c10 .leaflet-container .leaflet-popup-content {
   margin: 0rem;
 }
 
-.c11 .leaflet-container .leaflet-control-container .leaflet-top {
+.c10 .leaflet-container .leaflet-control-container .leaflet-top {
   z-index: 500;
 }
 
-.c11 .leaflet-control-layers.leaflet-control-layers-expanded {
+.c10 .leaflet-control-layers.leaflet-control-layers-expanded {
   border-radius: 0rem;
 }
 
-.c11 .leaflet-control-layers .leaflet-control-layers-overlays {
+.c10 .leaflet-control-layers .leaflet-control-layers-overlays {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -284,7 +258,7 @@ exports[`MapView Renders the map 1`] = `
   width: 15rem;
 }
 
-.c11 .leaflet-control-layers .leaflet-control-layers-overlays label {
+.c10 .leaflet-control-layers .leaflet-control-layers-overlays label {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -308,7 +282,7 @@ exports[`MapView Renders the map 1`] = `
   transition: 1s;
 }
 
-.c4 {
+.c3 {
   -webkit-transition: margin 1s;
   transition: margin 1s;
   grid-area: filter;
@@ -317,7 +291,7 @@ exports[`MapView Renders the map 1`] = `
   z-index: 500;
 }
 
-.c4 .map-filter-bar {
+.c3 .map-filter-bar {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -329,7 +303,7 @@ exports[`MapView Renders the map 1`] = `
   padding: 0.5rem 0;
 }
 
-.c4 .map-filter-bar .vl {
+.c3 .map-filter-bar .vl {
   border-left: 6px solid rgba(96,96,96,0.2);
   height: 4rem;
   margin-left: 1%;
@@ -337,7 +311,7 @@ exports[`MapView Renders the map 1`] = `
   border-width: 0.2rem;
 }
 
-.c4 .map-filter-bar .btn-primary {
+.c3 .map-filter-bar .btn-primary {
   color: white;
   font-weight: bold;
   height: 3.5rem;
@@ -346,11 +320,11 @@ exports[`MapView Renders the map 1`] = `
   padding: 0;
 }
 
-.c4 .map-filter-bar .form-control {
+.c3 .map-filter-bar .form-control {
   font-size: 1.4rem;
 }
 
-.c4 .form-group {
+.c3 .form-group {
   margin-bottom: 0;
 }
 
@@ -403,15 +377,7 @@ exports[`MapView Renders the map 1`] = `
       class="c2 px-0 map"
     >
       <div
-        class="c3"
-      >
-        <div
-          class="spinner-border text-warning"
-          data-testid="filter-backdrop-loading"
-        />
-      </div>
-      <div
-        class="c4 px-0 container-fluid"
+        class="c3 px-0 container-fluid"
       >
         <form
           class=""
@@ -434,7 +400,7 @@ exports[`MapView Renders the map 1`] = `
                 class="idir-input-group flex-nowrap row"
               >
                 <div
-                  class="c5 col-auto"
+                  class="c4 col-auto"
                 >
                   <div
                     class="input-group-prepend"
@@ -464,7 +430,7 @@ exports[`MapView Renders the map 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c6 col"
+                  class="c5 col"
                 >
                   <div
                     class="input form-group"
@@ -485,7 +451,7 @@ exports[`MapView Renders the map 1`] = `
               class="col-auto"
             >
               <button
-                class="c7 Button Button--icon-only primary btn btn-primary"
+                class="c6 Button Button--icon-only primary btn btn-primary"
                 data-testid="search"
                 id="search-button"
                 title="search"
@@ -514,7 +480,7 @@ exports[`MapView Renders the map 1`] = `
               class="col-auto"
             >
               <button
-                class="c7 Button Button--icon-only btn btn-info"
+                class="c6 Button Button--icon-only btn btn-info"
                 data-testid="reset-button"
                 id="reset-button"
                 title="reset-button"
@@ -543,13 +509,13 @@ exports[`MapView Renders the map 1`] = `
               class="bar-item col-auto"
             >
               <div
-                class="c8"
+                class="c7"
               >
                 <div
-                  class="c9"
+                  class="c8"
                 >
                   <div
-                    class="c10"
+                    class="c9"
                   >
                     <svg>
                       icon-map.svg
@@ -557,10 +523,10 @@ exports[`MapView Renders the map 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c9"
+                  class="c8"
                 >
                   <div
-                    class="c10"
+                    class="c9"
                   >
                     <svg>
                       icon-table.svg
@@ -573,7 +539,7 @@ exports[`MapView Renders the map 1`] = `
         </form>
       </div>
       <div
-        class="c11"
+        class="c10"
       >
         <div />
       </div>

--- a/frontend/src/features/properties/map/hooks/useMapProperties.tsx
+++ b/frontend/src/features/properties/map/hooks/useMapProperties.tsx
@@ -1,0 +1,32 @@
+import { toCqlFilter } from 'components/maps/leaflet/mapUtils';
+import { IGeoSearchParams } from 'constants/API';
+import CustomAxios from 'customAxios';
+import { FeatureCollection } from 'geojson';
+import { useApiRequestWrapper } from 'hooks/pims-api/useApiRequestWrapper';
+import { useCallback, useContext } from 'react';
+import { TenantContext } from 'tenants';
+
+export const useMapProperties = () => {
+  const {
+    tenant: { propertiesUrl },
+  } = useContext(TenantContext);
+
+  const loadPropertiesRequest = useCallback(
+    (params?: IGeoSearchParams) => {
+      const geoserver_params = {
+        STREET_ADDRESS_1: params?.STREET_ADDRESS_1,
+        PID_PADDED: params?.PID,
+        PIN: params?.PIN,
+      };
+      const url = `${propertiesUrl}${geoserver_params ? toCqlFilter(geoserver_params) : ''}`;
+      return CustomAxios().get<FeatureCollection>(url);
+    },
+    [propertiesUrl],
+  );
+
+  const loadProperties = useApiRequestWrapper({
+    requestFunction: loadPropertiesRequest,
+    requestName: 'LOAD_PROPERTIES',
+  });
+  return { loadProperties };
+};

--- a/frontend/src/features/properties/map/research/ResearchContainer.tsx
+++ b/frontend/src/features/properties/map/research/ResearchContainer.tsx
@@ -1,12 +1,13 @@
 import { Button } from 'components/common/buttons/Button';
 import GenericModal from 'components/common/GenericModal';
+import { useMapSearch } from 'components/maps/hooks/useMapSearch';
 import LoadingBackdrop from 'components/maps/leaflet/LoadingBackdrop/LoadingBackdrop';
 import MapSideBarLayout from 'features/mapSideBar/layout/MapSideBarLayout';
 import ResearchFileLayout from 'features/mapSideBar/layout/ResearchFileLayout';
 import { FormikProps } from 'formik';
 import { Api_ResearchFile, Api_ResearchFileProperty } from 'models/api/ResearchFile';
 import * as React from 'react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { MdLocationPin, MdTopic } from 'react-icons/md';
 import styled from 'styled-components';
 import { pidFormatter } from 'utils';
@@ -30,7 +31,6 @@ export const ResearchContainer: React.FunctionComponent<IResearchContainerProps>
 
   const [selectedMenuIndex, setSelectedMenuIndex] = useState<number>(0);
   const [isEditing, setIsEditing] = useState<boolean>(false);
-  const [isDirty, setIsDirty] = useState<boolean>(false);
 
   const [isShowingPropertySelector, setIsShowingPropertySelector] = useState<boolean>(false);
 
@@ -39,18 +39,19 @@ export const ResearchContainer: React.FunctionComponent<IResearchContainerProps>
   );
 
   const [showConfirmModal, setShowConfirmModal] = useState<boolean>(false);
+  const { search } = useMapSearch();
 
   const menuItems = researchFile?.researchProperties?.map(x => getPropertyName(x)) || [];
   menuItems.unshift('RFile Summary');
 
-  useEffect(() => {
-    async function fetchResearchFile() {
-      var retrieved = await retrieveResearchFile(props.researchFileId);
-      setResearchFile(retrieved);
-      setIsDirty(false);
-    }
+  const fetchResearchFile = React.useCallback(async () => {
+    var retrieved = await retrieveResearchFile(props.researchFileId);
+    setResearchFile(retrieved);
+  }, [retrieveResearchFile, setResearchFile, props.researchFileId]);
+
+  React.useEffect(() => {
     fetchResearchFile();
-  }, [props.researchFileId, retrieveResearchFile, isDirty]);
+  }, [fetchResearchFile]);
 
   if (researchFile === undefined) {
     return (
@@ -128,8 +129,9 @@ export const ResearchContainer: React.FunctionComponent<IResearchContainerProps>
   };
 
   const onSuccess = () => {
-    setIsDirty(true);
+    fetchResearchFile();
     setIsEditing(false);
+    search();
   };
 
   const showPropertiesSelector = () => {

--- a/frontend/src/features/properties/map/research/add/models.ts
+++ b/frontend/src/features/properties/map/research/add/models.ts
@@ -100,15 +100,4 @@ export class PropertyForm {
       district: toTypeCode(this.districtId),
     };
   }
-
-  public toMapModel(): IMapProperty {
-    return {
-      id: this.mapId,
-      pid: this.pid,
-      pin: this.pin,
-      latitude: this.latitude,
-      longitude: this.longitude,
-      planNumber: this.planNumber,
-    };
-  }
 }

--- a/frontend/src/features/properties/selector/MapSelectorContainer.test.tsx
+++ b/frontend/src/features/properties/selector/MapSelectorContainer.test.tsx
@@ -12,6 +12,7 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { fillInput, render, RenderOptions, userEvent } from 'utils/test-utils';
 
+import { PropertyForm } from '../map/research/add/models';
 import MapSelectorContainer, { IMapSelectorContainerProps } from './MapSelectorContainer';
 import { IMapProperty } from './models';
 import { featuresToIdentifiedMapProperty } from './search/PropertySelectorSearchContainer';
@@ -102,12 +103,16 @@ describe('MapSelectorContainer component', () => {
   });
 
   it('lists selected properties', () => {
-    const { getByText } = setup({ existingProperties: [testProperty] });
+    const { getByText } = setup({
+      existingProperties: [PropertyForm.fromMapProperty(testProperty)],
+    });
     expect(getByText('PID: 123-456-789')).toBeVisible();
   });
 
   it('selected properties can be removed', () => {
-    const { getByText } = setup({ existingProperties: [testProperty] });
+    const { getByText } = setup({
+      existingProperties: [PropertyForm.fromMapProperty(testProperty)],
+    });
     const removeButton = getByText('Remove');
     userEvent.click(removeButton);
     expect(onRemoveProperty).toHaveBeenCalled();
@@ -145,7 +150,9 @@ describe('MapSelectorContainer component', () => {
 
   it('selected properties display a warning if added multiple times', async () => {
     const { getByText, getByTitle, findByTestId, container } = setup({
-      existingProperties: featuresToIdentifiedMapProperty(mockPropertyLayerSearchResponse as any),
+      existingProperties: featuresToIdentifiedMapProperty(
+        mockPropertyLayerSearchResponse as any,
+      )?.map(p => PropertyForm.fromMapProperty(p)),
     });
 
     const searchTab = getByText('Search');

--- a/frontend/src/features/properties/selector/MapSelectorContainer.tsx
+++ b/frontend/src/features/properties/selector/MapSelectorContainer.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { useState } from 'react';
 import { toast } from 'react-toastify';
 
+import { PropertyForm } from '../map/research/add/models';
 import SelectedPropertyHeaderRow from '../map/research/add/SelectedPropertyHeaderRow';
 import SelectedPropertyRow from '../map/research/add/SelectedPropertyRow';
 import PropertyMapSelectorFormView from './map/PropertyMapSelectorFormView';
@@ -16,7 +17,7 @@ import { getPropertyIdentifier } from './utils';
 export interface IMapSelectorContainerProps {
   onSelectedProperty: (property: IMapProperty) => void;
   onRemoveProperty: (index: number) => void;
-  existingProperties: IMapProperty[];
+  existingProperties: PropertyForm[];
 }
 
 export const MapSelectorContainer: React.FunctionComponent<IMapSelectorContainerProps> = ({
@@ -42,7 +43,17 @@ export const MapSelectorContainer: React.FunctionComponent<IMapSelectorContainer
       <PropertySelectorTabsView
         activeTab={activeSelectorTab}
         setActiveTab={setActiveSelectorTab}
-        MapSelectorView={<PropertyMapSelectorFormView onSelectedProperty={onSelectedProperty} />}
+        MapSelectorView={
+          <PropertyMapSelectorFormView
+            onSelectedProperty={(property: IMapProperty) =>
+              addProperties(
+                [{ ...property, id: getPropertyIdentifier(property) }],
+                existingPropertiesWithIds,
+                onSelectedProperty,
+              )
+            }
+          />
+        }
         ListSelectorView={
           <PropertySelectorSearchContainer
             selectedProperties={selectedProperties}
@@ -65,7 +76,7 @@ export const MapSelectorContainer: React.FunctionComponent<IMapSelectorContainer
         <SelectedPropertyHeaderRow />
         {existingProperties.map((property, index) => (
           <SelectedPropertyRow
-            key={`property.${property.latitude}-${property.longitude}-${property.pid}`}
+            key={`property.${property.latitude}-${property.longitude}-${property.pid}-${property.apiId}`}
             onRemove={() => onRemoveProperty(index)}
             nameSpace={`properties.${index}`}
             index={index}

--- a/frontend/src/hooks/useApi.test.tsx
+++ b/frontend/src/hooks/useApi.test.tsx
@@ -31,7 +31,7 @@ describe('useApi hook', () => {
       mockAxios.onGet().reply(200, {});
 
       const api = getUseApiHook({ store });
-      await api.current.isPidAvailable(undefined, '123-456-789');
+      await api.current.searchAddress('1234 Fake st.');
       expect(mockAxios.history.get[0]).toMatchObject({
         headers: {
           Accept: 'application/json, text/plain, */*',
@@ -45,7 +45,7 @@ describe('useApi hook', () => {
       mockAxios.onGet().reply(200, {});
 
       const api = getUseApiHook({ store });
-      await api.current.isPidAvailable(undefined, '123-456-789');
+      await api.current.searchAddress('1234 Fake st.');
       expect(realStore.getState().loadingBar).toStrictEqual({});
     });
     it('dispatches hide loading bar action on error response', async () => {
@@ -54,7 +54,7 @@ describe('useApi hook', () => {
 
       const api = getUseApiHook({ store });
       try {
-        await api.current.isPidAvailable(undefined, '123-456-789');
+        await api.current.searchAddress('1234 Fake st.');
       } catch (e) {}
       expect(realStore.getState().loadingBar).toStrictEqual({});
     });
@@ -63,24 +63,6 @@ describe('useApi hook', () => {
     afterEach(() => {
       jest.clearAllMocks();
       mockAxios.resetHistory();
-    });
-
-    it('calls isPidAvailable with expected parameters', async () => {
-      mockAxios.onGet().reply(200, {});
-      const api = getUseApiHook();
-      await api.current.isPidAvailable(undefined, '123-456-789');
-      expect(mockAxios.history.get[0]).toMatchObject({
-        url: '/api/properties/parcels/check/pid-available?pid=123456789',
-      });
-    });
-
-    it('calls isPinAvailable with expected parameters', async () => {
-      mockAxios.onGet().reply(200, {});
-      const api = getUseApiHook();
-      await api.current.isPinAvailable(undefined, 123456789);
-      expect(mockAxios.history.get[0]).toMatchObject({
-        url: '/api/properties/parcels/check/pin-available?pin=123456789',
-      });
     });
 
     it('calls searchAddress with expected parameters', async () => {

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1,16 +1,11 @@
-import { IGeoSearchParams } from 'constants/API';
 import { ENVIRONMENT } from 'constants/environment';
 import CustomAxios from 'customAxios';
-import { FeatureCollection } from 'geojson';
 import { LatLngLiteral } from 'leaflet';
 import _ from 'lodash';
-import { useCallback, useContext } from 'react';
+import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { hideLoading, showLoading } from 'react-redux-loading-bar';
 import { store } from 'store/store';
-import { TenantContext } from 'tenants';
-
-import { toCqlFilter } from './../components/maps/leaflet/mapUtils';
 
 export interface IGeocoderResponse {
   siteId: string;
@@ -29,19 +24,10 @@ export interface IGeocoderPidsResponse {
 }
 
 export interface IPimsAPI {
-  isPidAvailable: (
-    parcelId: number | '' | undefined,
-    pid: string | undefined,
-  ) => Promise<{ available: boolean }>;
-  isPinAvailable: (
-    parcelId: number | '' | undefined,
-    pin: number | '' | undefined,
-  ) => Promise<{ available: boolean }>;
   searchAddress: (text: string) => Promise<IGeocoderResponse[]>;
   getSitePids: (siteId: string) => Promise<IGeocoderPidsResponse>;
   getNearAddresses: (latLng: LatLngLiteral) => Promise<IGeocoderResponse[]>;
   getNearestAddress: (latLng: LatLngLiteral) => Promise<IGeocoderResponse>;
-  loadProperties: (params: IGeoSearchParams) => Promise<FeatureCollection>;
 }
 
 /**
@@ -50,9 +36,6 @@ export interface IPimsAPI {
  */
 export const useApi = (): IPimsAPI => {
   const dispatch = useDispatch();
-  const {
-    tenant: { propertiesUrl },
-  } = useContext(TenantContext);
 
   const getAxios = useCallback(() => {
     const axios = CustomAxios();
@@ -83,44 +66,6 @@ export const useApi = (): IPimsAPI => {
     );
     return axios;
   }, [dispatch]);
-
-  const isPidAvailable = useCallback(
-    async (
-      parcelId: number | '' | undefined,
-      pid: string | undefined,
-    ): Promise<{ available: boolean }> => {
-      const pidParam = `pid=${Number(
-        pid
-          ?.split('-')
-          .join('')
-          .split(',')
-          .join(''),
-      )}`;
-      let params = parcelId ? `${pidParam}&parcelId=${parcelId}` : pidParam;
-      const { data } = await getAxios().get<{ available: boolean }>(
-        `${ENVIRONMENT.apiUrl}/properties/parcels/check/pid-available?${params}`,
-      );
-      return data;
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
-
-  const isPinAvailable = useCallback(
-    async (
-      parcelId: number | '' | undefined,
-      pin: number | '' | undefined,
-    ): Promise<{ available: boolean }> => {
-      const pinParam = `pin=${Number(pin)}`;
-      let params = parcelId ? `${pinParam}&parcelId=${parcelId}` : pinParam;
-      const { data } = await getAxios().get<{ available: boolean }>(
-        `${ENVIRONMENT.apiUrl}/properties/parcels/check/pin-available?${params}`,
-      );
-      return data;
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
 
   const searchAddress = useCallback(
     async (address: string): Promise<IGeocoderResponse[]> => {
@@ -172,29 +117,11 @@ export const useApi = (): IPimsAPI => {
     [],
   );
 
-  const loadProperties = useCallback(
-    async (params: IGeoSearchParams): Promise<FeatureCollection> => {
-      const { BBOX, ...rest } = params;
-      const geoserver_params = {
-        STREET_ADDRESS_1: rest?.STREET_ADDRESS_1,
-        PID_PADDED: rest?.PID,
-        PIN: rest?.PIN,
-      };
-      const { data } = await CustomAxios().get<FeatureCollection>(
-        `${propertiesUrl}${geoserver_params ? toCqlFilter(geoserver_params) : ''}`,
-      );
-      return data;
-    },
-    [propertiesUrl],
-  );
   // The below memo is only intended to run once, at startup. Or when the jwt is updated.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   return {
     getSitePids,
-    loadProperties,
     searchAddress,
-    isPinAvailable,
-    isPidAvailable,
     getNearestAddress,
     getNearAddresses,
   };


### PR DESCRIPTION
Update research properties on map after modification.
Fix warnings on generic modal.
remove code from deprecated useApi hook.
prevent map properties from being added with duplicate identifiers
remove dead code in model
prevent duplicate fetch research file requests
add context/hook to manage map properites.
remove dead map prop code.