### PR TITLE
psp-3800 Add additional error handling/logging to JSON parsing.

### DIFF
--- a/backend/ltsa/LtsaService.cs
+++ b/backend/ltsa/LtsaService.cs
@@ -166,7 +166,7 @@ namespace Pims.Ltsa
             {
                 try
                 {
-                    var refreshToken = _token.RefreshToken;
+                    var refreshToken = _token?.RefreshToken;
                     _token = null; // remove any existing token details so that the authpolicy will fetch a new token if this auth request fails.
                     var response = await _authPolicy.ExecuteAsync(async () => await this.Client.PostJsonAsync(this.Options.AuthUrl.AppendToURL(this.Options.RefreshEndpoint), new { refreshToken }));
                     var tokens = JsonSerializer.Deserialize<AuthResponseTokens>(await response.Content.ReadAsStringAsync(), _jsonSerializerOptions);


### PR DESCRIPTION
Note that I wasn't able to reproduce this in dev or tst even with 10 minutes of continuous usage of the ltsa api. However, I was able to get a rough idea of where the error was being thrown from the error message in the ticket.