### PR TITLE
update properties screens to use id instead of pid where appropriate.

### DIFF
--- a/backend/api/Areas/Property/Controllers/PropertyController.cs
+++ b/backend/api/Areas/Property/Controllers/PropertyController.cs
@@ -86,7 +86,7 @@ namespace Pims.Api.Areas.Property.Controllers
         [Produces("application/json")]
         [ProducesResponseType(typeof(PropertyAssociationModel), 200)]
         [SwaggerOperation(Tags = new[] { "property" })]
-        public IActionResult GetPropertyAssociationsWithPid(long id)
+        public IActionResult GetPropertyAssociationsWithId(long id)
         {
             var property = _pimsRepository.Property.GetAssociations(id);
 

--- a/backend/api/Areas/Property/Controllers/PropertyController.cs
+++ b/backend/api/Areas/Property/Controllers/PropertyController.cs
@@ -78,17 +78,17 @@ namespace Pims.Api.Areas.Property.Controllers
         }
 
         /// <summary>
-        /// Get the property associations for the specified unique 'pid'.
+        /// Get the property associations for the specified unique 'id'.
         /// </summary>
         /// <returns></returns>
-        [HttpGet("{pid}/associations")]
+        [HttpGet("{id}/associations")]
         [HasPermission(Permissions.PropertyView)]
         [Produces("application/json")]
         [ProducesResponseType(typeof(PropertyAssociationModel), 200)]
         [SwaggerOperation(Tags = new[] { "property" })]
-        public IActionResult GetPropertyAssociationsWithPid(string pid)
+        public IActionResult GetPropertyAssociationsWithPid(long id)
         {
-            var property = _pimsRepository.Property.GetAssociations(pid);
+            var property = _pimsRepository.Property.GetAssociations(id);
 
             return new JsonResult(_mapper.Map<PropertyAssociationModel>(property));
         }
@@ -96,17 +96,17 @@ namespace Pims.Api.Areas.Property.Controllers
 
         #region Concept Endpoints
         /// <summary>
-        /// Get the property for the specified unique 'pid'.
+        /// Get the property for the specified unique 'id'.
         /// </summary>
         /// <returns></returns>
-        [HttpGet("concept/{pid}")]
+        [HttpGet("concept/{id}")]
         [HasPermission(Permissions.PropertyView)]
         [Produces("application/json")]
         [ProducesResponseType(typeof(IEnumerable<Pims.Api.Models.Concepts.PropertyModel>), 200)]
         [SwaggerOperation(Tags = new[] { "property" })]
-        public IActionResult GetConceptPropertyWithPid(string pid)
+        public IActionResult GetConceptPropertyWithId(long id)
         {
-            var property = _pimsService.PropertyService.GetByPid(pid);
+            var property = _pimsService.PropertyService.GetById(id);
             return new JsonResult(_mapper.Map<Pims.Api.Models.Concepts.PropertyModel>(property));
         }
 
@@ -114,7 +114,7 @@ namespace Pims.Api.Areas.Property.Controllers
         /// Update the specified property, and attached properties.
         /// </summary>
         /// <returns></returns>
-        [HttpPut("concept/{pid}")]
+        [HttpPut("concept/{id}")]
         [HasPermission(Permissions.PropertyEdit)]
         [Produces("application/json")]
         [ProducesResponseType(typeof(Pims.Api.Models.Concepts.PropertyModel), 200)]

--- a/backend/dal/Repositories/Interfaces/IPropertyRepository.cs
+++ b/backend/dal/Repositories/Interfaces/IPropertyRepository.cs
@@ -15,7 +15,7 @@ namespace Pims.Dal.Repositories
         PimsProperty Get(long id);
         PimsProperty GetByPid(string pid);
         PimsProperty GetByPid(int pid);
-        PimsProperty GetAssociations(string pid);
+        PimsProperty GetAssociations(long id);
         PimsProperty Update(PimsProperty property);
         void Delete(PimsProperty property);
     }

--- a/backend/dal/Repositories/PropertyRepository.cs
+++ b/backend/dal/Repositories/PropertyRepository.cs
@@ -193,14 +193,12 @@ namespace Pims.Dal.Repositories
         }
 
         /// <summary>
-        /// Get the property for the specified PID value.
+        /// Get the property for the specified id value.
         /// </summary>
-        /// <param name="pid"></param>
+        /// <param name="id"></param>
         /// <returns></returns>
-        public PimsProperty GetAssociations(string pid)
+        public PimsProperty GetAssociations(long id)
         {
-            int parsedPid = pid.ConvertPID();
-
             PimsProperty property = this.Context.PimsProperties
                 .Include(p => p.PimsPropertyLeases)
                     .ThenInclude(pl => pl.Lease)
@@ -208,7 +206,7 @@ namespace Pims.Dal.Repositories
                 .Include(p => p.PimsPropertyResearchFiles)
                     .ThenInclude(pr => pr.ResearchFile)
                     .ThenInclude(r => r.ResearchFileStatusTypeCodeNavigation)
-                .FirstOrDefault(p => p.Pid == parsedPid);
+                .FirstOrDefault(p => p.PropertyId == id);
 
             return property;
         }

--- a/backend/geocoder/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/geocoder/Extensions/ServiceCollectionExtensions.cs
@@ -19,7 +19,7 @@ namespace Pims.Geocoder
         {
             return services
                 .Configure<Configuration.GeocoderOptions>(section)
-                .AddScoped<IGeocoderService, GeocoderService>()
+                .AddSingleton<IGeocoderService, GeocoderService>()
                 .AddScoped<IHttpRequestClient, HttpRequestClient>();
         }
     }

--- a/backend/tests/unit/api/Controllers/Property/PropertyControllerTest.cs
+++ b/backend/tests/unit/api/Controllers/Property/PropertyControllerTest.cs
@@ -22,7 +22,7 @@ namespace Pims.Api.Test.Controllers.Property
         /// Make a successful request to fetch property by PID.
         /// </summary>
         [Fact]
-        public void GetConceptPropertyByPid_Success()
+        public void GetConceptPropertyById_Success()
         {
             // Arrange
             var pid = 12345;
@@ -33,17 +33,17 @@ namespace Pims.Api.Test.Controllers.Property
             var service = helper.GetService<Mock<IPimsService>>();
             var mapper = helper.GetService<IMapper>();
 
-            service.Setup(m => m.PropertyService.GetByPid(It.IsAny<string>())).Returns(property);
+            service.Setup(m => m.PropertyService.GetById(It.IsAny<long>())).Returns(property);
 
             // Act
-            var result = controller.GetConceptPropertyWithPid(pid.ToString());
+            var result = controller.GetConceptPropertyWithId(property.Id);
 
             // Assert
             var actionResult = Assert.IsType<JsonResult>(result);
             var actualResult = Assert.IsType<Models.Concepts.PropertyModel>(actionResult.Value);
             var expectedResult = mapper.Map<Models.Concepts.PropertyModel>(property);
             expectedResult.Should().BeEquivalentTo(actualResult);
-            service.Verify(m => m.PropertyService.GetByPid(It.IsAny<string>()), Times.Once());
+            service.Verify(m => m.PropertyService.GetById(It.IsAny<long>()), Times.Once());
         }
         #endregion
         #region Update

--- a/backend/tests/unit/api/Routes/Property/PropertyControllerTest.cs
+++ b/backend/tests/unit/api/Routes/Property/PropertyControllerTest.cs
@@ -40,15 +40,15 @@ namespace Pims.Api.Test.Routes
         }
 
         [Fact]
-        public void GetConceptPropertyWithPid_Route()
+        public void GetConceptPropertyWithId_Route()
         {
             // Arrange
-            var endpoint = typeof(PropertyController).FindMethod(nameof(PropertyController.GetConceptPropertyWithPid), typeof(string));
+            var endpoint = typeof(PropertyController).FindMethod(nameof(PropertyController.GetConceptPropertyWithId), typeof(long));
 
             // Act
             // Assert
             Assert.NotNull(endpoint);
-            endpoint.HasGet("concept/{pid}");
+            endpoint.HasGet("concept/{id}");
             endpoint.HasPermissions(Permissions.PropertyView);
         }
 
@@ -61,7 +61,7 @@ namespace Pims.Api.Test.Routes
             // Act
             // Assert
             Assert.NotNull(endpoint);
-            endpoint.HasPut("concept/{pid}");
+            endpoint.HasPut("concept/{id}");
             endpoint.HasPermissions(Permissions.PropertyEdit);
         }
         #endregion

--- a/frontend/src/components/maps/leaflet/PointClusterer.tsx
+++ b/frontend/src/components/maps/leaflet/PointClusterer.tsx
@@ -338,7 +338,7 @@ export const PointClusterer: React.FC<PointClustererProps> = ({
               position={[latitude, longitude]}
               icon={getMarkerIcon(cluster)}
               eventHandlers={{
-                click: () => {
+                click: e => {
                   const convertedProperty = convertToProperty(
                     cluster.properties,
                     latitude,

--- a/frontend/src/features/mapSideBar/MotiInventoryContainer.test.tsx
+++ b/frontend/src/features/mapSideBar/MotiInventoryContainer.test.tsx
@@ -38,6 +38,7 @@ describe('MotiInventoryContainer component', () => {
         onClose={renderOptions.onClose}
         pid={renderOptions.pid}
         onZoom={renderOptions.onZoom}
+        id={renderOptions.id}
       />,
       {
         ...renderOptions,
@@ -79,14 +80,14 @@ describe('MotiInventoryContainer component', () => {
     mockAxios.onGet(new RegExp('/ogs-internal/*')).reply(200, {});
 
     const { findByText, queryByTestId } = setup({
-      pid: '9212434',
+      id: 9212434,
       onClose,
       onZoom,
     });
 
     await waitFor(() => {
       expect(mockAxios.history.get.length).toBeGreaterThanOrEqual(1);
-      expect(mockAxios.history.get[0].url).toBe(`/properties/009-212-434`);
+      expect(mockAxios.history.get[0].url).toBe(`/properties/9212434`);
     });
     await waitFor(() => {
       expect(queryByTestId('filter-backdrop-loading')).toBeNull();
@@ -96,7 +97,7 @@ describe('MotiInventoryContainer component', () => {
 
   it('hides the property information tab for non-inventory properties', async () => {
     mockAxios.onPost().reply(200, {});
-    // non-inventory properties return a "not-found" error from API
+    // non-inventory properties will not attempt to contact the backend.
     const error = {
       isAxiosError: true,
       response: { status: 404 },
@@ -104,18 +105,16 @@ describe('MotiInventoryContainer component', () => {
     mockAxios.onGet(new RegExp('/properties/*')).reply(404, error);
     mockAxios.onGet(new RegExp('ogs-internal/*')).reply(200, {});
 
-    const { queryByText, getByText, queryByTestId } = setup({
+    const { queryByText, getByText, queryAllByTestId } = setup({
       pid: '9212434',
       onClose,
       onZoom,
     });
 
-    await waitFor(() => {
-      expect(mockAxios.history.get.length).toBeGreaterThanOrEqual(1);
-      expect(mockAxios.history.get[0].url).toBe(`/properties/009-212-434`);
-    });
     expect(queryByText(/property attributes/i)).toBeNull();
     expect(getByText('Title')).toHaveClass('active');
-    expect(queryByTestId('filter-backdrop-loading')).toBeNull();
+    await waitFor(() => {
+      expect(queryAllByTestId('filter-backdrop-loading')).toHaveLength(0);
+    });
   });
 });

--- a/frontend/src/features/mapSideBar/MotiInventoryContainer.test.tsx
+++ b/frontend/src/features/mapSideBar/MotiInventoryContainer.test.tsx
@@ -76,7 +76,7 @@ describe('MotiInventoryContainer component', () => {
 
   it('shows the property information tab for inventory properties', async () => {
     mockAxios.onPost().reply(200, {});
-    mockAxios.onGet(new RegExp('/properties/*')).reply(200, { pid: '009-212-434' });
+    mockAxios.onGet(new RegExp('/properties/*')).reply(200, { id: 9212434 });
     mockAxios.onGet(new RegExp('/ogs-internal/*')).reply(200, {});
 
     const { findByText, queryByTestId } = setup({

--- a/frontend/src/features/mapSideBar/hooks/useMapSideBarQueryParams.tsx
+++ b/frontend/src/features/mapSideBar/hooks/useMapSideBarQueryParams.tsx
@@ -71,7 +71,7 @@ export const useMapSideBarQueryParams = (map?: L.Map): IMapSideBar => {
         }
       } else if (parts.length > 3 && parts[2] === 'property') {
         pid = queryString.parse(location.search).pid?.toString() ?? '';
-        propertyId = !!parts[3] ? +propertyId : undefined;
+        propertyId = !!parts[3] ? +parts[3] : undefined;
         currentState = MapViewState.PROPERTY_INFORMATION;
       } else if (parts.length > 3 && parts[2] === 'non-inventory-property') {
         pid = parts[3];

--- a/frontend/src/features/mapSideBar/hooks/useMapSideBarQueryParams.tsx
+++ b/frontend/src/features/mapSideBar/hooks/useMapSideBarQueryParams.tsx
@@ -4,6 +4,7 @@ import AddResearchContainer from 'features/properties/map/research/add/AddResear
 import ResearchContainer from 'features/properties/map/research/ResearchContainer';
 import { IPropertyApiModel } from 'interfaces/IPropertyApiModel';
 import { isNumber } from 'lodash';
+import queryString from 'query-string';
 import React, { useCallback, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
@@ -55,6 +56,7 @@ export const useMapSideBarQueryParams = (map?: L.Map): IMapSideBar => {
     var currentState: MapViewState = MapViewState.MAP_ONLY;
     var researchId = 0;
     var propertyId = '';
+    var pid = '';
     if (parts.length === 2) {
       currentState = MapViewState.MAP_ONLY;
     } else if (parts.length > 2) {
@@ -68,7 +70,11 @@ export const useMapSideBarQueryParams = (map?: L.Map): IMapSideBar => {
           currentState = MapViewState.MAP_ONLY;
         }
       } else if (parts.length > 3 && parts[2] === 'property') {
+        pid = queryString.parse(location.search).pid?.toString() ?? '';
         propertyId = parts[3];
+        currentState = MapViewState.PROPERTY_INFORMATION;
+      } else if (parts.length > 3 && parts[2] === 'non-inventory-property') {
+        pid = parts[3];
         currentState = MapViewState.PROPERTY_INFORMATION;
       } else if (parts[2] === 'acquisition') {
         if (parts.length === 4 && parts[3] === 'new') {
@@ -98,7 +104,12 @@ export const useMapSideBarQueryParams = (map?: L.Map): IMapSideBar => {
         break;
       case MapViewState.PROPERTY_INFORMATION:
         setSidebarComponent(
-          <MotiInventoryContainer onClose={handleClose} pid={propertyId} onZoom={onZoom} />,
+          <MotiInventoryContainer
+            onClose={handleClose}
+            id={!!propertyId ? +propertyId : undefined}
+            pid={pid}
+            onZoom={onZoom}
+          />,
         );
         setShowSideBar(true);
         break;

--- a/frontend/src/features/mapSideBar/hooks/useMapSideBarQueryParams.tsx
+++ b/frontend/src/features/mapSideBar/hooks/useMapSideBarQueryParams.tsx
@@ -54,8 +54,8 @@ export const useMapSideBarQueryParams = (map?: L.Map): IMapSideBar => {
 
     var parts = location.pathname.split('/');
     var currentState: MapViewState = MapViewState.MAP_ONLY;
-    var researchId = 0;
-    var propertyId = '';
+    var researchId: number = 0;
+    var propertyId: number | undefined = 0;
     var pid = '';
     if (parts.length === 2) {
       currentState = MapViewState.MAP_ONLY;
@@ -71,7 +71,7 @@ export const useMapSideBarQueryParams = (map?: L.Map): IMapSideBar => {
         }
       } else if (parts.length > 3 && parts[2] === 'property') {
         pid = queryString.parse(location.search).pid?.toString() ?? '';
-        propertyId = parts[3];
+        propertyId = !!parts[3] ? +propertyId : undefined;
         currentState = MapViewState.PROPERTY_INFORMATION;
       } else if (parts.length > 3 && parts[2] === 'non-inventory-property') {
         pid = parts[3];
@@ -106,7 +106,7 @@ export const useMapSideBarQueryParams = (map?: L.Map): IMapSideBar => {
         setSidebarComponent(
           <MotiInventoryContainer
             onClose={handleClose}
-            id={!!propertyId ? +propertyId : undefined}
+            id={propertyId}
             pid={pid}
             onZoom={onZoom}
           />,

--- a/frontend/src/features/mapSideBar/tabs/propertyDetails/hooks/useGetProperty.ts
+++ b/frontend/src/features/mapSideBar/tabs/propertyDetails/hooks/useGetProperty.ts
@@ -9,11 +9,11 @@ import { toast } from 'react-toastify';
  * hook that retrieves a property from the inventory.
  */
 export const useGetProperty = () => {
-  const { getPropertyConceptWithPid } = useApiProperties();
+  const { getPropertyConceptWithId } = useApiProperties();
 
   const { execute, loading } = useApiRequestWrapper({
-    requestFunction: useCallback(async (pid: string) => await getPropertyConceptWithPid(pid), [
-      getPropertyConceptWithPid,
+    requestFunction: useCallback(async (id: number) => await getPropertyConceptWithId(id), [
+      getPropertyConceptWithId,
     ]),
     requestName: 'retrievePropertyConcept',
     onSuccess: useCallback(() => toast.success('Property information retrieved'), []),

--- a/frontend/src/features/mapSideBar/tabs/propertyDetails/update/UpdatePropertyDetailsContainer.tsx
+++ b/frontend/src/features/mapSideBar/tabs/propertyDetails/update/UpdatePropertyDetailsContainer.tsx
@@ -13,13 +13,14 @@ import { UpdatePropertyDetailsForm } from './UpdatePropertyDetailsForm';
 import { UpdatePropertyDetailsYupSchema } from './validation';
 
 export interface IUpdatePropertyDetailsContainerProps {
-  pid: string;
+  id?: number;
   setFormikRef: (ref: React.RefObject<FormikProps<any>> | undefined) => void;
   onSuccess: () => void;
 }
 
 export const UpdatePropertyDetailsContainer: React.FC<IUpdatePropertyDetailsContainerProps> = props => {
   const isMounted = useIsMounted();
+  const history = useHistory();
   const { retrieveProperty, retrievePropertyLoading } = useGetProperty();
   const { updateProperty } = useUpdateProperty();
   const { queryAll } = useQueryMapLayersByLocation();
@@ -32,8 +33,8 @@ export const UpdatePropertyDetailsContainer: React.FC<IUpdatePropertyDetailsCont
 
   useEffect(() => {
     async function fetchProperty() {
-      if (!!props.pid) {
-        const retrieved = await retrieveProperty(props.pid);
+      if (!!props.id) {
+        const retrieved = await retrieveProperty(props.id);
         if (retrieved !== undefined && isMounted()) {
           const formValues = UpdatePropertyDetailsFormModel.fromApi(retrieved);
 
@@ -52,7 +53,7 @@ export const UpdatePropertyDetailsContainer: React.FC<IUpdatePropertyDetailsCont
       }
     }
     fetchProperty();
-  }, [isMounted, props.pid, queryAll, retrieveProperty]);
+  }, [isMounted, props.id, queryAll, retrieveProperty]);
 
   // save handler - sends updated property information to backend
   const savePropertyInformation = async (
@@ -64,7 +65,7 @@ export const UpdatePropertyDetailsContainer: React.FC<IUpdatePropertyDetailsCont
 
     formikHelpers.setSubmitting(false);
 
-    if (!!response?.pid) {
+    if (!!response?.id) {
       formikHelpers.resetForm();
       props.onSuccess();
     }

--- a/frontend/src/features/mapSideBar/tabs/propertyDetails/update/UpdatePropertyDetailsContainer.tsx
+++ b/frontend/src/features/mapSideBar/tabs/propertyDetails/update/UpdatePropertyDetailsContainer.tsx
@@ -20,7 +20,6 @@ export interface IUpdatePropertyDetailsContainerProps {
 
 export const UpdatePropertyDetailsContainer: React.FC<IUpdatePropertyDetailsContainerProps> = props => {
   const isMounted = useIsMounted();
-  const history = useHistory();
   const { retrieveProperty, retrievePropertyLoading } = useGetProperty();
   const { updateProperty } = useUpdateProperty();
   const { queryAll } = useQueryMapLayersByLocation();
@@ -71,10 +70,6 @@ export const UpdatePropertyDetailsContainer: React.FC<IUpdatePropertyDetailsCont
     }
   };
 
-  if (retrievePropertyLoading) {
-    return <LoadingBackdrop show={true} parentScreen={true}></LoadingBackdrop>;
-  }
-
   return (
     <Formik<UpdatePropertyDetailsFormModel>
       enableReinitialize
@@ -85,6 +80,10 @@ export const UpdatePropertyDetailsContainer: React.FC<IUpdatePropertyDetailsCont
     >
       {formikProps => (
         <StyledFormWrapper>
+          <LoadingBackdrop
+            show={retrievePropertyLoading || !initialForm}
+            parentScreen={true}
+          ></LoadingBackdrop>
           <UpdatePropertyDetailsForm formikProps={formikProps} />
         </StyledFormWrapper>
       )}

--- a/frontend/src/features/mapSideBar/tabs/propertyDetails/update/UpdatePropertyDetailsContainer.tsx
+++ b/frontend/src/features/mapSideBar/tabs/propertyDetails/update/UpdatePropertyDetailsContainer.tsx
@@ -13,7 +13,7 @@ import { UpdatePropertyDetailsForm } from './UpdatePropertyDetailsForm';
 import { UpdatePropertyDetailsYupSchema } from './validation';
 
 export interface IUpdatePropertyDetailsContainerProps {
-  id?: number;
+  id: number;
   setFormikRef: (ref: React.RefObject<FormikProps<any>> | undefined) => void;
   onSuccess: () => void;
 }

--- a/frontend/src/features/mapSideBar/tabs/propertyDetails/update/UpdatePropertyDetailsForm.tsx
+++ b/frontend/src/features/mapSideBar/tabs/propertyDetails/update/UpdatePropertyDetailsForm.tsx
@@ -74,24 +74,25 @@ export const UpdatePropertyDetailsForm: React.FunctionComponent<IUpdatePropertyD
   const volumetricMeasurement = getIn(values, 'volumetricMeasurement') as number;
   const volumetricUnit = getIn(values, 'volumetricUnitTypeCode') as string;
 
+  const setFieldValue = formikProps.setFieldValue;
   // clear related fields when volumetric parcel radio changes
   useEffect(() => {
     if (!isVolumetricParcel) {
-      formikProps.setFieldValue('volumetricMeasurement', 0);
-      formikProps.setFieldValue('volumetricUnitTypeCode', undefined);
-      formikProps.setFieldValue('volumetricParcelTypeCode', undefined);
+      setFieldValue('volumetricMeasurement', 0);
+      setFieldValue('volumetricUnitTypeCode', undefined);
+      setFieldValue('volumetricParcelTypeCode', undefined);
     }
-  }, [isVolumetricParcel, formikProps, formikProps.setFieldValue]);
+  }, [isVolumetricParcel, setFieldValue]);
 
   // clear related fields when tenure status changes
   useEffect(() => {
     if (!isHighwayRoad) {
-      formikProps.setFieldValue('roadTypes', []);
+      setFieldValue('roadTypes', []);
     }
     if (!isAdjacentLand) {
-      formikProps.setFieldValue('adjacentLands', []);
+      setFieldValue('adjacentLands', []);
     }
-  }, [isAdjacentLand, isHighwayRoad, formikProps, formikProps.setFieldValue]);
+  }, [isAdjacentLand, isHighwayRoad, setFieldValue]);
 
   const cannotDetermineInfoText =
     'This means the property is out of bounds or there was an error at the time of determining this value. If needed, edit property details and pick the appropriate  value to update it.';

--- a/frontend/src/features/properties/map/MapView.tsx
+++ b/frontend/src/features/properties/map/MapView.tsx
@@ -10,6 +10,7 @@ import useMapSideBarQueryParams from 'features/mapSideBar/hooks/useMapSideBarQue
 import { IProperty } from 'interfaces';
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { toast } from 'react-toastify';
 import styled from 'styled-components';
 import { pidParser } from 'utils';
 
@@ -34,16 +35,16 @@ const MapView: React.FC<MapViewProps> = (props: MapViewProps) => {
   const { sidebarComponent, showSideBar } = useMapSideBarQueryParams(mapInstance);
 
   const onMarkerClicked = (property: IProperty) => {
-    const parsedPid = pidParser(property.pid);
-    history.push(`/mapview/property/${parsedPid}`);
+    history.push(`/mapview/property/${property.id}?pid=${property.pid}`);
   };
 
   const onPropertyViewClicked = (pid?: string | null) => {
     if (pid !== undefined && pid !== null) {
       const parsedPid = pidParser(pid);
-      history.push(`/mapview/property/${parsedPid}`);
+      history.push(`/mapview/non-inventory-property/${parsedPid}`);
     } else {
-      console.warn('Invalid pin when trying to see property information');
+      console.warn('Invalid marker when trying to see property information');
+      toast.warn('A map parcel must have a PID in order to view detailed information');
     }
   };
 

--- a/frontend/src/features/properties/map/propertyInformation/PropertyViewSelector.tsx
+++ b/frontend/src/features/properties/map/propertyInformation/PropertyViewSelector.tsx
@@ -10,7 +10,6 @@ export interface IPropertyViewSelectorProps {
   setEditMode: (isEditing: boolean) => void;
   setFormikRef: (ref: React.RefObject<FormikProps<any>> | undefined) => void;
   onSuccess: () => void;
-
   composedProperty: ComposedProperty;
 }
 
@@ -18,7 +17,7 @@ const PropertyViewSelector: React.FunctionComponent<IPropertyViewSelectorProps> 
   if (props.isEditMode) {
     return (
       <UpdatePropertyDetailsContainer
-        pid={props.composedProperty.pid || ''}
+        id={props.composedProperty?.apiProperty?.id}
         onSuccess={props.onSuccess}
         setFormikRef={props.setFormikRef}
       />

--- a/frontend/src/features/properties/map/propertyInformation/PropertyViewSelector.tsx
+++ b/frontend/src/features/properties/map/propertyInformation/PropertyViewSelector.tsx
@@ -14,10 +14,10 @@ export interface IPropertyViewSelectorProps {
 }
 
 const PropertyViewSelector: React.FunctionComponent<IPropertyViewSelectorProps> = props => {
-  if (props.isEditMode) {
+  if (props.isEditMode && !!props?.composedProperty?.apiProperty?.id) {
     return (
       <UpdatePropertyDetailsContainer
-        id={props.composedProperty?.apiProperty?.id}
+        id={props.composedProperty.apiProperty.id}
         onSuccess={props.onSuccess}
         setFormikRef={props.setFormikRef}
       />

--- a/frontend/src/features/properties/map/research/detail/PropertyResearchContainer.tsx
+++ b/frontend/src/features/properties/map/research/detail/PropertyResearchContainer.tsx
@@ -38,15 +38,16 @@ const PropertyResearchContainer: React.FunctionComponent<IPropertyResearchContai
   const [showPropertyInfoTab, setShowPropertyInfoTab] = useState(true);
 
   const pid = props.researchFileProperty?.property?.pid?.toString();
+  const id = props.researchFileProperty?.property?.id;
 
   // First, fetch property information from PSP API
-  const { getPropertyWithPid, getPropertyWithPidLoading: propertyLoading } = useProperties();
+  const { getProperty, getPropertyLoading: propertyLoading } = useProperties();
   useEffect(() => {
     const func = async () => {
       try {
-        if (!!pid) {
-          const propInfo = await getPropertyWithPid(pid);
-          if (isMounted() && propInfo.pid === pidFormatter(pid)) {
+        if (!!id) {
+          const propInfo = await getProperty(id);
+          if (isMounted() && propInfo?.id === id) {
             setApiProperty(propInfo);
             setShowPropertyInfoTab(true);
           }
@@ -64,7 +65,7 @@ const PropertyResearchContainer: React.FunctionComponent<IPropertyResearchContai
     };
 
     func();
-  }, [getPropertyWithPid, isMounted, pid]);
+  }, [getProperty, id, isMounted]);
 
   // After API property object has been received, we query relevant map layers to find
   // additional information which we store in a different model (IPropertyDetailsForm)
@@ -95,8 +96,8 @@ const PropertyResearchContainer: React.FunctionComponent<IPropertyResearchContai
 
   useEffect(() => {
     const func = async () => {
-      if (pid !== undefined) {
-        const response = await getPropertyAssociations(pid);
+      if (id !== undefined) {
+        const response = await getPropertyAssociations(id);
         if (response?.id !== undefined) {
           setPropertyAssociations(response);
         }
@@ -104,7 +105,7 @@ const PropertyResearchContainer: React.FunctionComponent<IPropertyResearchContai
     };
 
     func();
-  }, [getPropertyAssociations, pid]);
+  }, [getPropertyAssociations, id]);
 
   const tabViews: TabInventoryView[] = [];
 

--- a/frontend/src/hooks/pims-api/useApiProperties.ts
+++ b/frontend/src/hooks/pims-api/useApiProperties.ts
@@ -22,8 +22,8 @@ export const useApiProperties = () => {
         ),
       getPropertyWithPid: (pid: string) => api.get<IPropertyApiModel>(`/properties/${pid}`),
       getProperty: (id: number) => api.get<IPropertyApiModel>(`/properties/${id}`),
-      getPropertyAssociations: (pid: string) =>
-        api.get<Api_PropertyAssociations>(`/properties/${pid}/associations`),
+      getPropertyAssociations: (id: number) =>
+        api.get<Api_PropertyAssociations>(`/properties/${id}/associations`),
       exportProperties: (filter: IPaginateProperties, outputFormat: 'csv' | 'excel' = 'excel') =>
         api.get(
           `/reports/properties?${filter ? queryString.stringify({ ...filter, all: true }) : ''}`,
@@ -34,10 +34,9 @@ export const useApiProperties = () => {
             },
           },
         ),
-      getPropertyConceptWithPid: (pid: string) =>
-        api.get<Api_Property>(`/properties/concept/${pid}`),
+      getPropertyConceptWithId: (id: number) => api.get<Api_Property>(`/properties/concept/${id}`),
       putPropertyConcept: (property: Api_Property) =>
-        api.put<Api_Property>(`/properties/concept/${property.pid}`, property),
+        api.put<Api_Property>(`/properties/concept/${property.id}`, property),
     }),
     [api],
   );

--- a/frontend/src/hooks/pims-api/useGeoServer.ts
+++ b/frontend/src/hooks/pims-api/useGeoServer.ts
@@ -40,5 +40,17 @@ export const useGeoServer = () => {
     [baseUrl],
   );
 
-  return { getPropertyWfs, getPropertyWithPidWfs };
+  const getPropertyWithIdWfs = useCallback(
+    async function(id: number): Promise<Feature<Point> | null> {
+      if (!id) {
+        return null;
+      }
+      const wfsUrl = buildUrl(baseUrl, { ID: id });
+      const { data } = await CustomAxios().get<FeatureCollection>(wfsUrl);
+      return data.features?.length ? (data.features[0] as Feature<Point>) : null;
+    },
+    [baseUrl],
+  );
+
+  return { getPropertyWfs, getPropertyWithPidWfs, getPropertyWithIdWfs };
 };

--- a/frontend/src/hooks/pims-api/useGeoServer.ts
+++ b/frontend/src/hooks/pims-api/useGeoServer.ts
@@ -40,17 +40,5 @@ export const useGeoServer = () => {
     [baseUrl],
   );
 
-  const getPropertyWithIdWfs = useCallback(
-    async function(id: number): Promise<Feature<Point> | null> {
-      if (!id) {
-        return null;
-      }
-      const wfsUrl = buildUrl(baseUrl, { ID: id });
-      const { data } = await CustomAxios().get<FeatureCollection>(wfsUrl);
-      return data.features?.length ? (data.features[0] as Feature<Point>) : null;
-    },
-    [baseUrl],
-  );
-
-  return { getPropertyWfs, getPropertyWithPidWfs, getPropertyWithIdWfs };
+  return { getPropertyWfs, getPropertyWithPidWfs };
 };

--- a/frontend/src/hooks/useProperties.ts
+++ b/frontend/src/hooks/useProperties.ts
@@ -24,7 +24,7 @@ export const useProperties = () => {
     exportProperties: rawApiExportProperties,
   } = useApiProperties();
 
-  const { getPropertyWithIdWfs } = useGeoServer();
+  const { getPropertyWfs } = useGeoServer();
 
   const fetchProperties = useApiRequestWrapper<
     (
@@ -59,7 +59,7 @@ export const useProperties = () => {
       // Due to spatial information being stored in BC Albers in the database, we need to make TWO requests here:
       //   1. to the REST API to fetch property field attributes (e.g. address, etc)
       //   2. to GeoServer to fetch latitude/longitude in expected web mercator projection (EPSG:4326)
-      return Promise.all([getPropertyWrapped(id), getPropertyWithIdWfs(id)]).then(
+      return Promise.all([getPropertyWrapped(id), getPropertyWfs(id)]).then(
         ([propertyResponse, wfsResponse]) => {
           const [longitude, latitude] = wfsResponse?.geometry?.coordinates || [];
           const property: IPropertyApiModel = {
@@ -71,7 +71,7 @@ export const useProperties = () => {
         },
       );
     },
-    [getPropertyWrapped, getPropertyWithIdWfs],
+    [getPropertyWrapped, getPropertyWfs],
   );
 
   /**

--- a/frontend/src/hooks/usePropertyAssociations.ts
+++ b/frontend/src/hooks/usePropertyAssociations.ts
@@ -3,7 +3,6 @@ import { useApiProperties } from 'hooks/pims-api';
 import { Api_PropertyAssociations } from 'models/api/Property';
 import { useCallback } from 'react';
 import { toast } from 'react-toastify';
-import { pidFormatter } from 'utils';
 
 import { useApiRequestWrapper } from './pims-api/useApiRequestWrapper';
 
@@ -11,12 +10,11 @@ export const usePropertyAssociations = () => {
   const { getPropertyAssociations } = useApiProperties();
 
   const { execute, loading } = useApiRequestWrapper<
-    (pid: string) => Promise<AxiosResponse<Api_PropertyAssociations>>
+    (id: number) => Promise<AxiosResponse<Api_PropertyAssociations>>
   >({
-    requestFunction: useCallback(
-      async (pid: string) => await getPropertyAssociations(pidFormatter(pid)),
-      [getPropertyAssociations],
-    ),
+    requestFunction: useCallback(async (id: number) => await getPropertyAssociations(id), [
+      getPropertyAssociations,
+    ]),
     requestName: 'getPropertyAssociations',
     onError: useCallback(axiosError => {
       toast.error(


### PR DESCRIPTION
not all properties in inventory have pids, therefore when we are retrieving properties from our inventory we should use the id if possible.