### PR TITLE
HOTFIX: Fix keycloak sync

### DIFF
--- a/backend/api/Pims.Api.csproj
+++ b/backend/api/Pims.Api.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <UserSecretsId>0ef6255f-9ea0-49ec-8c65-c172304b4926</UserSecretsId>
-    <Version>2.1.2-32.27</Version>
-    <AssemblyVersion>2.1.2.32</AssemblyVersion>
+    <Version>2.1.3-32.28</Version>
+    <AssemblyVersion>2.1.3.32</AssemblyVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ProjectGuid>16BC0468-78F6-4C91-87DA-7403C919E646</ProjectGuid>
   </PropertyGroup>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.1.2-32.27",
+  "version": "2.1.3-32.28",
   "private": true,
   "dependencies": {
     "@bcgov/bc-sans": "1.0.1",

--- a/tools/keycloak/sync/Program.cs
+++ b/tools/keycloak/sync/Program.cs
@@ -98,7 +98,7 @@ namespace Pims.Tools.Keycloak.Sync
         /// <returns></returns>
         private static IConfigurationBuilder Configure(string[] args)
         {
-            DotNetEnv.Env.Load();
+            DotNetEnv.Env.TraversePath().Load();
             string environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT").ToLower();
 
             return new ConfigurationBuilder()

--- a/tools/keycloak/sync/Properties/launchSettings.json
+++ b/tools/keycloak/sync/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "Pims.Tools.Keycloak.Sync": {
-      "commandName": "Project",
-      "workingDirectory": "C:\\git\\PSP\\tools\\keycloak\\sync"
+      "commandName": "Project"
     }
   }
 }

--- a/tools/keycloak/sync/Properties/launchSettings.json
+++ b/tools/keycloak/sync/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "Pims.Tools.Keycloak.Sync": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "workingDirectory": "C:\\git\\PSP\\tools\\keycloak\\sync"
     }
   }
 }

--- a/tools/keycloak/sync/RealmFactory.cs
+++ b/tools/keycloak/sync/RealmFactory.cs
@@ -91,7 +91,7 @@ namespace Pims.Tools.Keycloak.Sync
         private async Task<SKModel.RoleModel> AddUpdateRealmRoleAsync(RoleOptions config)
         {
             _logger.LogInformation($"Fetch realm role '{config.Name}'");
-            var role = await _client.HandleGetAsync<SKModel.RoleModel>(_client.AdminRoute($"roles/{config.Name}"), r => true);
+            var role = await _client.HandleGetAsync<SKModel.RoleModel>(_client.AdminRoute($"roles/{config.Name}"));
 
             if (role == null)
             {
@@ -163,7 +163,7 @@ namespace Pims.Tools.Keycloak.Sync
         private async Task<SKModel.GroupModel> AddUpdateGroupAsync(GroupOptions config)
         {
             _logger.LogInformation($"Fetch group '{config.Name}'");
-            var groups = await _client.HandleGetAsync<SKModel.GroupModel[]>(_client.AdminRoute($"groups?search={config.Name}"), r => true);
+            var groups = await _client.HandleGetAsync<SKModel.GroupModel[]>(_client.AdminRoute($"groups?search={config.Name}"));
             var group = groups.FirstOrDefault();
 
             if (group == null)
@@ -176,7 +176,7 @@ namespace Pims.Tools.Keycloak.Sync
                 if (!rRes.IsSuccessStatusCode) throw new HttpClientRequestException(rRes);
 
                 // Have to look for it now that we've added it.
-                groups = await _client.HandleGetAsync<SKModel.GroupModel[]>(_client.AdminRoute($"groups?search={config.Name}"), r => true);
+                groups = await _client.HandleGetAsync<SKModel.GroupModel[]>(_client.AdminRoute($"groups?search={config.Name}"));
                 group = groups.FirstOrDefault();
             }
             else

--- a/tools/keycloak/sync/SyncFactory.cs
+++ b/tools/keycloak/sync/SyncFactory.cs
@@ -423,10 +423,10 @@ namespace Pims.Tools.Keycloak.Sync
                     // Fetch the group from PIMS.
                     foreach (var kgroup in kgroups)
                     {
-                        var role = await _client.HandleGetAsync<PModel.RoleModel>($"{_options.Api.Uri}/admin/roles/name/{kgroup.Name}", r => true);
+                        var role = await _client.HandleGetAsync<PModel.RoleModel>($"{_options.Api.Uri}/admin/roles/{kgroup.Id}");
                         if (role != null)
                         {
-                            uRoles.Append(new PModel.UserRoleModel() { User = user, Role = role });
+                            uRoles = uRoles.Append(new PModel.UserRoleModel() { User = user, Role = role });
                         }
                     }
 


### PR DESCRIPTION
keycloak sync was not successfully adding roles to newly created users. This was due to a route change a model change.