### PR TITLE
HOTFIX: Psp 4198

### DIFF
--- a/backend/api/Pims.Api.csproj
+++ b/backend/api/Pims.Api.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <UserSecretsId>0ef6255f-9ea0-49ec-8c65-c172304b4926</UserSecretsId>
-    <Version>2.2.0-33.25</Version>
-    <AssemblyVersion>2.2.0.33</AssemblyVersion>
+    <Version>2.2.1-33.25</Version>
+    <AssemblyVersion>2.2.1.33</AssemblyVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ProjectGuid>16BC0468-78F6-4C91-87DA-7403C919E646</ProjectGuid>
   </PropertyGroup>

--- a/backend/api/Pims.Api.csproj
+++ b/backend/api/Pims.Api.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <UserSecretsId>0ef6255f-9ea0-49ec-8c65-c172304b4926</UserSecretsId>
-    <Version>2.2.0-33.24</Version>
+    <Version>2.2.0-33.25</Version>
     <AssemblyVersion>2.2.0.33</AssemblyVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ProjectGuid>16BC0468-78F6-4C91-87DA-7403C919E646</ProjectGuid>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.2.0-33.24",
+  "version": "2.2.0-33.25",
   "private": true,
   "dependencies": {
     "@bcgov/bc-sans": "1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.2.0-33.25",
+  "version": "2.2.1-33.25",
   "private": true,
   "dependencies": {
     "@bcgov/bc-sans": "1.0.1",


### PR DESCRIPTION
When attempting to sync keycloak users, ignore roles failures for roles the exist in KC but not keycloak.