### PR TITLE
make sonarqube action on push only.

### DIFF
--- a/.github/workflows/api-dotnetcore.yml
+++ b/.github/workflows/api-dotnetcore.yml
@@ -101,7 +101,7 @@ jobs:
       - name: SonarScanner for .NET 6 with pull request decoration support
         id: scan
         uses: highbyte/sonarscan-dotnet@v2.1.2
-        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'bcgov/PSP' }}
+        if: ${{ github.event_name == 'push' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:


### PR DESCRIPTION
All of the errors are related to Pull Request permissions. Works around the issue for now.