### PR TITLE
Psp 4237 ensure the help desk arrow is on the same line as the dependent element.

### DIFF
--- a/frontend/src/features/help/components/HelpBox.scss
+++ b/frontend/src/features/help/components/HelpBox.scss
@@ -13,6 +13,7 @@
   .active:after {
     content: '';
     transform: translateX(100%);
+    align-self: center;
     width: 0;
     height: 0;
     display: inline-block;

--- a/frontend/src/features/help/components/HelpBox.tsx
+++ b/frontend/src/features/help/components/HelpBox.tsx
@@ -25,6 +25,7 @@ const Box = styled.div`
 const TopicButton = styled(Button)`
   max-height: 4rem;
   background-color: white;
+  display: flex;
 `;
 
 const TopicSelector = styled(ButtonGroup)``;

--- a/frontend/src/features/help/components/__snapshots__/HelpBox.test.tsx.snap
+++ b/frontend/src/features/help/components/__snapshots__/HelpBox.test.tsx.snap
@@ -148,6 +148,10 @@ exports[`Help box tests... renders correctly.. 1`] = `
 .c2 {
   max-height: 4rem;
   background-color: white;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 <div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41091511/189207542-8954e1ca-8ac7-4893-8af6-0b811762f419.png)
