### PR TITLE
psp-4242

### DIFF
--- a/backend/api/Services/AcquisitionFileService.cs
+++ b/backend/api/Services/AcquisitionFileService.cs
@@ -111,6 +111,21 @@ namespace Pims.Api.Services
                         PopulateNewProperty(acquisitionProperty.Property);
                     }
                 }
+                else if (acquisitionProperty.Property.Pin.HasValue)
+                {
+                    var pin = acquisitionProperty.Property.Pin.Value;
+                    try
+                    {
+                        var foundProperty = _propertyRepository.GetByPin(pin);
+                        acquisitionProperty.PropertyId = foundProperty.Id;
+                        acquisitionProperty.Property = foundProperty;
+                    }
+                    catch (KeyNotFoundException e)
+                    {
+                        _logger.LogDebug("Adding new property with pin:{pin}", pin);
+                        PopulateNewProperty(acquisitionProperty.Property);
+                    }
+                }
                 else
                 {
                     _logger.LogDebug("Adding new property without a pid");

--- a/backend/api/Services/ResearchFileService.cs
+++ b/backend/api/Services/ResearchFileService.cs
@@ -163,6 +163,21 @@ namespace Pims.Api.Services
                         PopulateNewProperty(researchProperty.Property);
                     }
                 }
+                else if (researchProperty.Property.Pin.HasValue)
+                {
+                    var pin = researchProperty.Property.Pin.Value;
+                    try
+                    {
+                        var foundProperty = _propertyRepository.GetByPin(pin);
+                        researchProperty.PropertyId = foundProperty.Id;
+                        researchProperty.Property = foundProperty;
+                    }
+                    catch (KeyNotFoundException e)
+                    {
+                        _logger.LogDebug("Adding new property with pin:{pin}", pin);
+                        PopulateNewProperty(researchProperty.Property);
+                    }
+                }
                 else
                 {
                     _logger.LogDebug("Adding new property without a pid");

--- a/backend/dal/Repositories/Interfaces/IPropertyRepository.cs
+++ b/backend/dal/Repositories/Interfaces/IPropertyRepository.cs
@@ -21,6 +21,8 @@ namespace Pims.Dal.Repositories
 
         PimsProperty GetByPid(int pid);
 
+        PimsProperty GetByPin(int pin);
+
         PimsProperty GetAssociations(long id);
 
         PimsProperty Update(PimsProperty property);

--- a/backend/dal/Repositories/PropertyRepository.cs
+++ b/backend/dal/Repositories/PropertyRepository.cs
@@ -194,6 +194,45 @@ namespace Pims.Dal.Repositories
         }
 
         /// <summary>
+        /// Get the property for the specified PIN value.
+        /// </summary>
+        /// <param name="pin"></param>
+        /// <returns></returns>
+        public PimsProperty GetByPin(int pin)
+        {
+            this.User.ThrowIfNotAllAuthorized(Permissions.PropertyView);
+
+            var property = this.Context.PimsProperties.AsNoTracking()
+                .Include(p => p.DistrictCodeNavigation)
+                .Include(p => p.RegionCodeNavigation)
+                .Include(p => p.PropertyTypeCodeNavigation)
+                .Include(p => p.PropertyStatusTypeCodeNavigation)
+                .Include(p => p.PropertyDataSourceTypeCodeNavigation)
+                .Include(p => p.PropertyClassificationTypeCodeNavigation)
+                .Include(p => p.PimsPropPropAnomalyTypes)
+                    .ThenInclude(t => t.PropertyAnomalyTypeCodeNavigation)
+                .Include(p => p.PimsPropPropRoadTypes)
+                    .ThenInclude(t => t.PropertyRoadTypeCodeNavigation)
+                .Include(p => p.PimsPropPropAdjacentLandTypes)
+                    .ThenInclude(t => t.PropertyAdjacentLandTypeCodeNavigation)
+                .Include(p => p.PimsPropPropTenureTypes)
+                    .ThenInclude(t => t.PropertyTenureTypeCodeNavigation)
+                .Include(p => p.PropertyAreaUnitTypeCodeNavigation)
+                .Include(p => p.VolumetricTypeCodeNavigation)
+                .Include(p => p.VolumeUnitTypeCodeNavigation)
+                .Include(p => p.Address)
+                    .ThenInclude(a => a.RegionCodeNavigation)
+                .Include(p => p.Address)
+                    .ThenInclude(a => a.DistrictCodeNavigation)
+                .Include(p => p.Address)
+                    .ThenInclude(a => a.ProvinceState)
+                .Include(p => p.Address)
+                    .ThenInclude(a => a.Country)
+                .FirstOrDefault(p => p.Pin == pin) ?? throw new KeyNotFoundException();
+            return property;
+        }
+
+        /// <summary>
         /// Get the property for the specified id value.
         /// </summary>
         /// <param name="id"></param>

--- a/backend/tests/unit/api/Services/ResearchServiceTest.cs
+++ b/backend/tests/unit/api/Services/ResearchServiceTest.cs
@@ -1,0 +1,197 @@
+using FluentAssertions;
+using Moq;
+using NetTopologySuite.Geometries;
+using Pims.Api.Services;
+using Pims.Core.Test;
+using Pims.Dal.Entities;
+using Pims.Dal.Repositories;
+using Pims.Dal.Security;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Pims.Api.Test.Services
+{
+    [Trait("category", "unit")]
+    [Trait("category", "api")]
+    [Trait("group", "research")]
+    [ExcludeFromCodeCoverage]
+    public class ResearchServiceTest
+    {
+        #region UpdateProperties
+        [Fact]
+        public void UpdateProperties_MatchProperties_PID_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.ResearchFileEdit);
+            var service = helper.Create<ResearchFileService>(user);
+
+            var researchFile = EntityHelper.CreateResearchFile();
+            researchFile.ConcurrencyControlNumber = 1;
+
+            var property = EntityHelper.CreateProperty(12345);
+            researchFile.PimsPropertyResearchFiles = new List<PimsPropertyResearchFile>() { new PimsPropertyResearchFile() { Property = property } };
+
+            var repository = helper.GetService<Mock<IResearchFileRepository>>();
+            repository.Setup(x => x.GetRowVersion(It.IsAny<long>())).Returns(1);
+            repository.Setup(x => x.GetById(It.IsAny<long>())).Returns(researchFile);
+
+            var propertyRepository = helper.GetService<Mock<IPropertyRepository>>();
+            propertyRepository.Setup(x => x.GetByPid(It.IsAny<int>())).Returns(property);
+
+            var filePropertyRepository = helper.GetService<Mock<IResearchFilePropertyRepository>>();
+            filePropertyRepository.Setup(x => x.GetByResearchFileId(It.IsAny<long>())).Returns(researchFile.PimsPropertyResearchFiles.ToList());
+
+            // Act
+            service.UpdateProperties(researchFile);
+
+            // Assert
+            filePropertyRepository.Verify(x => x.GetByResearchFileId(It.IsAny<long>()), Times.Once);
+            repository.Verify(x => x.GetRowVersion(It.IsAny<long>()), Times.Once);
+            repository.Verify(x => x.GetById(It.IsAny<long>()), Times.Once);
+            propertyRepository.Verify(x => x.GetByPid(It.IsAny<int>()), Times.Once);
+        }
+
+        [Fact]
+        public void UpdateProperties_MatchProperties_PIN_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.ResearchFileEdit);
+            var service = helper.Create<ResearchFileService>(user);
+
+            var researchFile = EntityHelper.CreateResearchFile();
+            researchFile.ConcurrencyControlNumber = 1;
+
+            var property = EntityHelper.CreateProperty(12345, 54321);
+            property.Pid = null;
+            researchFile.PimsPropertyResearchFiles = new List<PimsPropertyResearchFile>() { new PimsPropertyResearchFile() { Property = property } };
+
+            var repository = helper.GetService<Mock<IResearchFileRepository>>();
+            repository.Setup(x => x.GetRowVersion(It.IsAny<long>())).Returns(1);
+            repository.Setup(x => x.GetById(It.IsAny<long>())).Returns(researchFile);
+
+            var propertyRepository = helper.GetService<Mock<IPropertyRepository>>();
+            propertyRepository.Setup(x => x.GetByPin(It.IsAny<int>())).Returns(property);
+
+            var filePropertyRepository = helper.GetService<Mock<IResearchFilePropertyRepository>>();
+            filePropertyRepository.Setup(x => x.GetByResearchFileId(It.IsAny<long>())).Returns(researchFile.PimsPropertyResearchFiles.ToList());
+
+            // Act
+            service.UpdateProperties(researchFile);
+
+            // Assert
+            filePropertyRepository.Verify(x => x.GetByResearchFileId(It.IsAny<long>()), Times.Once);
+            repository.Verify(x => x.GetRowVersion(It.IsAny<long>()), Times.Once);
+            repository.Verify(x => x.GetById(It.IsAny<long>()), Times.Once);
+            propertyRepository.Verify(x => x.GetByPin(It.IsAny<int>()), Times.Once);
+        }
+
+        [Fact]
+        public void UpdateProperties_MatchProperties_PID_NewProperty_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.ResearchFileEdit);
+            var service = helper.Create<ResearchFileService>(user);
+
+            var researchFile = EntityHelper.CreateResearchFile();
+            researchFile.ConcurrencyControlNumber = 1;
+
+            var property = EntityHelper.CreateProperty(12345);
+            researchFile.PimsPropertyResearchFiles = new List<PimsPropertyResearchFile>() { new PimsPropertyResearchFile() { Property = property } };
+
+            var repository = helper.GetService<Mock<IResearchFileRepository>>();
+            PimsPropertyResearchFile updatedResearchFileProperty = null;
+            repository.Setup(x => x.GetRowVersion(It.IsAny<long>())).Returns(1);
+            repository.Setup(x => x.GetById(It.IsAny<long>())).Returns(researchFile);
+
+            var filePropertyRepository = helper.GetService<Mock<IResearchFilePropertyRepository>>();
+            filePropertyRepository.Setup(x => x.GetByResearchFileId(It.IsAny<long>())).Returns(researchFile.PimsPropertyResearchFiles.ToList());
+            filePropertyRepository.Setup(x => x.Add(It.IsAny<PimsPropertyResearchFile>())).Callback<PimsPropertyResearchFile>(x => updatedResearchFileProperty = x).Returns(researchFile.PimsPropertyResearchFiles.FirstOrDefault());
+
+            var propertyRepository = helper.GetService<Mock<IPropertyRepository>>();
+            propertyRepository.Setup(x => x.GetByPid(It.IsAny<int>())).Throws<KeyNotFoundException>();
+
+            var coordinateService = helper.GetService<Mock<ICoordinateTransformService>>();
+            coordinateService.Setup(x => x.TransformCoordinates(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<Coordinate>())).Returns(new Coordinate(924046.3314288399, 1088892.9140135897));
+
+            // Act
+            service.UpdateProperties(researchFile);
+
+            // Assert
+            // since this is a new property, the following default fields should be set.
+            var updatedProperty = updatedResearchFileProperty.Property;
+            updatedProperty.PropertyClassificationTypeCode.Should().Be("UNKNOWN");
+            updatedProperty.PropertyTypeCode.Should().Be("UNKNOWN");
+            updatedProperty.PropertyStatusTypeCode.Should().Be("UNKNOWN");
+            updatedProperty.SurplusDeclarationTypeCode.Should().Be("UNKNOWN");
+            updatedProperty.PropertyDataSourceEffectiveDate.Should().BeCloseTo(System.DateTime.Now);
+            updatedProperty.PropertyDataSourceTypeCode.Should().Be("PMBC");
+            updatedProperty.IsPropertyOfInterest.Should().Be(true);
+
+            filePropertyRepository.Verify(x => x.GetByResearchFileId(It.IsAny<long>()), Times.Once);
+            repository.Verify(x => x.GetRowVersion(It.IsAny<long>()), Times.Once);
+            repository.Verify(x => x.GetById(It.IsAny<long>()), Times.Once);
+            propertyRepository.Verify(x => x.GetByPid(It.IsAny<int>()), Times.Once);
+            coordinateService.Verify(x => x.TransformCoordinates(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<Coordinate>()));
+        }
+
+        [Fact]
+        public void UpdateProperties_MatchProperties_PIN_NewProperty_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.ResearchFileEdit);
+            var service = helper.Create<ResearchFileService>(user);
+
+            var researchFile = EntityHelper.CreateResearchFile();
+            researchFile.ConcurrencyControlNumber = 1;
+
+            var property = EntityHelper.CreateProperty(12345, 54321);
+            property.Pid = null;
+            researchFile.PimsPropertyResearchFiles = new List<PimsPropertyResearchFile>() { new PimsPropertyResearchFile() { Property = property } };
+
+            var repository = helper.GetService<Mock<IResearchFileRepository>>();
+            PimsPropertyResearchFile updatedResearchFileProperty = null;
+            repository.Setup(x => x.GetRowVersion(It.IsAny<long>())).Returns(1);
+            repository.Setup(x => x.GetById(It.IsAny<long>())).Returns(researchFile);
+
+            var filePropertyRepository = helper.GetService<Mock<IResearchFilePropertyRepository>>();
+            filePropertyRepository.Setup(x => x.GetByResearchFileId(It.IsAny<long>())).Returns(researchFile.PimsPropertyResearchFiles.ToList());
+            filePropertyRepository.Setup(x => x.Add(It.IsAny<PimsPropertyResearchFile>())).Callback<PimsPropertyResearchFile>(x => updatedResearchFileProperty = x).Returns(researchFile.PimsPropertyResearchFiles.FirstOrDefault());
+
+            var propertyRepository = helper.GetService<Mock<IPropertyRepository>>();
+            propertyRepository.Setup(x => x.GetByPin(It.IsAny<int>())).Throws<KeyNotFoundException>();
+
+            var coordinateService = helper.GetService<Mock<ICoordinateTransformService>>();
+            coordinateService.Setup(x => x.TransformCoordinates(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<Coordinate>())).Returns(new Coordinate(924046.3314288399, 1088892.9140135897));
+
+            // Act
+            service.UpdateProperties(researchFile);
+
+            // Assert
+            // since this is a new property, the following default fields should be set.
+            var updatedProperty = updatedResearchFileProperty.Property;
+            updatedProperty.PropertyClassificationTypeCode.Should().Be("UNKNOWN");
+            updatedProperty.PropertyTypeCode.Should().Be("UNKNOWN");
+            updatedProperty.PropertyStatusTypeCode.Should().Be("UNKNOWN");
+            updatedProperty.SurplusDeclarationTypeCode.Should().Be("UNKNOWN");
+            updatedProperty.PropertyDataSourceEffectiveDate.Should().BeCloseTo(System.DateTime.Now);
+            updatedProperty.PropertyDataSourceTypeCode.Should().Be("PMBC");
+            updatedProperty.IsPropertyOfInterest.Should().Be(true);
+
+            filePropertyRepository.Verify(x => x.GetByResearchFileId(It.IsAny<long>()), Times.Once);
+            repository.Verify(x => x.GetRowVersion(It.IsAny<long>()), Times.Once);
+            repository.Verify(x => x.GetById(It.IsAny<long>()), Times.Once);
+            propertyRepository.Verify(x => x.GetByPin(It.IsAny<int>()), Times.Once);
+            coordinateService.Verify(x => x.TransformCoordinates(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<Coordinate>()));
+        }
+        #endregion
+    }
+}

--- a/backend/tests/unit/dal/Repositories/PropertyRepositoryTest.cs
+++ b/backend/tests/unit/dal/Repositories/PropertyRepositoryTest.cs
@@ -147,6 +147,28 @@ namespace Pims.Dal.Test.Repositories
         }
         #endregion
 
+        #region GetByPin
+        [Fact]
+        public void GetByPin_Success()
+        {
+            // Arrange
+            var helper = new TestHelper();
+            var user = PrincipalHelper.CreateForPermission(Permissions.PropertyView);
+            var pin = 1111;
+            var property = EntityHelper.CreateProperty(1, pin);
+            helper.CreatePimsContext(user, true).AddAndSaveChanges(property);
+
+            var repository = helper.CreateRepository<PropertyRepository>(user);
+
+            // Act
+            var result = repository.GetByPin(pin);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Pin.Should().Be(pin);
+        }
+        #endregion
+
         #region Update
         [Fact]
         public void Update_Property_Success()


### PR DESCRIPTION
File association counts were "wrong". Actual underlying problem is that property matching currently only occurs when a property has a pid. Updated to also include PINS for property matching.

Note that either a pid or pin is required for property matching. We may need a mechanism for matching non-pid, non-pin properties that are already in the system.