### PR TITLE
psp-4829 The FA parcel map layer does not require the Siteminder cookie anymor…

### DIFF
--- a/source/frontend/src/components/maps/leaflet/LayerPopup/constants/index.tsx
+++ b/source/frontend/src/components/maps/leaflet/LayerPopup/constants/index.tsx
@@ -18,7 +18,7 @@ export const ALR_LAYER_URL =
 export const INDIAN_RESERVES_LAYER_URL =
   'https://openmaps.gov.bc.ca/geo/pub/WHSE_ADMIN_BOUNDARIES.ADM_INDIAN_RESERVES_BANDS_SP/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=1.3.0&outputFormat=application/json&typeNames=pub:WHSE_ADMIN_BOUNDARIES.ADM_INDIAN_RESERVES_BANDS_SP';
 export const PIMS_BOUNDARY_LAYER_URL =
-  '/ogs-internal/ows?service=wfs&request=GetFeature&typeName=PIMS_PROPERTY_BOUNDARY_VW&outputformat=json&srsName=EPSG:4326&version=2.0.0&';
+  '/ogs-internal/ows?service=wfs&request=GetFeature&typeName=PIMS_PROPERTY_BOUNDARY_VW&outputformat=json&version=2.0.0';
 
 export const parcelLayerPopupConfig = {
   PID: { label: 'Parcel PID:', display: (data: any) => pidFormatter(data?.PID) },

--- a/source/frontend/src/hooks/pims-api/useFullyAttributedParcelMapLayer.ts
+++ b/source/frontend/src/hooks/pims-api/useFullyAttributedParcelMapLayer.ts
@@ -10,7 +10,6 @@ import { useWfsLayer } from './useWfsLayer';
 export const useFullyAttributedParcelMapLayer = (url: string, name: string) => {
   const getAllFeaturesWrapper = useWfsLayer(url, {
     name,
-    withCredentials: true,
   });
   const { execute: getAllFeatures, loading: getAllFeaturesLoading } = getAllFeaturesWrapper;
 


### PR DESCRIPTION
…e, as we are using the public layer. This should fix the "header too large" error being returned by the PIMS geoserver in DEV.