### PR TITLE
PSP-4800: Property Details Tab and Research Property Tab - Updates cannot be saved

### DIFF
--- a/source/frontend/src/features/properties/map/research/ViewSelector.tsx
+++ b/source/frontend/src/features/properties/map/research/ViewSelector.tsx
@@ -62,6 +62,7 @@ const ViewSelector = React.forwardRef<FormikProps<any>, IViewSelectorProps>((pro
           <UpdatePropertyDetailsContainer
             id={researchFileProperty.property?.id as number}
             onSuccess={props.onSuccess}
+            ref={formikRef}
           />
         );
       } else {
@@ -69,6 +70,7 @@ const ViewSelector = React.forwardRef<FormikProps<any>, IViewSelectorProps>((pro
           <UpdatePropertyView
             researchFileProperty={researchFileProperty}
             onSuccess={props.onSuccess}
+            ref={formikRef}
           />
         );
       }


### PR DESCRIPTION
Pass formikRef to sub-forms to enable saving and cancelling