### PR TITLE
PSP-4855 Property Research - Research Summary section has a different subtitle when in Edit mode

### DIFF
--- a/source/frontend/src/features/properties/map/research/update/property/UpdatePropertyForm.tsx
+++ b/source/frontend/src/features/properties/map/research/update/property/UpdatePropertyForm.tsx
@@ -106,7 +106,7 @@ const UpdatePropertyForm: React.FunctionComponent<IUpdatePropertyFormProps> = pr
         </SectionField>
       </Section>
 
-      <Section header="Research Request">
+      <Section header="Research Summary">
         <SectionField label="Summary notes" />
         <TextArea field="researchSummary" />
       </Section>

--- a/source/frontend/src/features/properties/map/research/update/property/__snapshots__/UpdatePropertyForm.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/research/update/property/__snapshots__/UpdatePropertyForm.test.tsx.snap
@@ -414,7 +414,7 @@ exports[`UpdatePropertyForm component renders as expected when provided no resea
           <div
             class="col"
           >
-            Research Request
+            Research Summary
           </div>
           <div
             class="col-1"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24322224/202579094-d5141bff-d1c2-4624-bf0c-28354a1f7fd8.png)
