### PR TITLE
HOTFIX: Psp-5235 unable to view map after timing out/logging out of application

### DIFF
--- a/openshift/s2i/nginx-runtime/nginx.conf.template
+++ b/openshift/s2i/nginx-runtime/nginx.conf.template
@@ -59,6 +59,8 @@ http {
         location /ogs-internal {
             proxy_ssl_server_name on;
             proxy_ssl_session_reuse on;
+            proxy_hide_header Set-Cookie;
+            proxy_ignore_headers Set-Cookie;
             proxy_pass          %GEOSERVER_URL%;
         }
 


### PR DESCRIPTION
completed additional investigation:
vanity url proxy not source of additional cookie, was able to trace this back to iis server hosting pims layer.
As this layer is proxyied via nginx able to remove cookie at that level.