### PR TITLE
Psp 5626 create geoserver map proxy within the PIMS api

### DIFF
--- a/source/backend/api/Configuration/GeoserverProxyOptions.cs
+++ b/source/backend/api/Configuration/GeoserverProxyOptions.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.DataAnnotations;
+using Pims.Core.Exceptions;
+
+namespace Pims.Core.Http.Configuration
+{
+    /// <summary>
+    /// GeoserverProxyOptions class, provides a way to configure the proxy controller for geoserver.
+    /// </summary>
+    public class GeoserverProxyOptions
+    {
+        #region Properties
+
+        /// <summary>
+        /// get/set - the internal url of the geocoder server.
+        /// </summary>
+        [Required(ErrorMessage = "Configuration 'ProxyUrl' is required.")]
+        public string ProxyUrl { get; set; }
+
+        /// <summary>
+        /// get/set - the username of the geoserver service account for the inventory layer.
+        /// </summary>
+        [Required(ErrorMessage = "Configuration 'ServiceUser' is required.")]
+        public string ServiceUser { get; set; }
+
+        /// <summary>
+        /// get/set - the password of the geoserver service account for the inventory layer.
+        /// </summary>
+        [Required(ErrorMessage = "Configuration 'ServicePassword' is required.")]
+        public string ServicePassword { get; set; }
+        #endregion
+    }
+}

--- a/source/backend/api/Controllers/PimsGeoserverController.cs
+++ b/source/backend/api/Controllers/PimsGeoserverController.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using AspNetCore.Proxy;
+using AspNetCore.Proxy.Options;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Pims.Api.Policies;
+using Pims.Core.Http.Configuration;
+using Pims.Dal.Security;
+
+namespace Pims.Api.Controllers
+{
+    /// <summary>
+    /// PimsGeoserverController class, provides an authenticated proxy to the pims inventory layer.
+    /// </summary>
+    [Authorize]
+    [ApiController]
+    [ApiVersion("1.0")]
+    [Route("v{version:apiVersion}/geoserver")]
+    [Route("/geoserver")]
+    public class PimsGeoserverController : ControllerBase
+    {
+        #region Variables
+
+        private readonly IOptionsMonitor<GeoserverProxyOptions> _proxyOptions;
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of a PimsGeoserverController class.
+        /// </summary>
+        public PimsGeoserverController(IOptionsMonitor<GeoserverProxyOptions> options)
+        {
+            _proxyOptions = options;
+        }
+        #endregion
+
+        #region Endpoints
+
+        [Route("{**rest}")]
+        [HasPermission(Permissions.PropertyView)]
+        public Task ProxyCatchAll(string rest)
+        {
+            // If you don't need the query string, then you can remove this.
+            var queryString = this.Request.QueryString.Value;
+            HttpProxyOptions httpOptions = AspNetCore.Proxy.Options.HttpProxyOptionsBuilder.Instance.WithBeforeSend((c, hrm) =>
+            {
+                // Set something that is needed for the downstream endpoint.
+                var basicAuth = Convert.ToBase64String(Encoding.GetEncoding("ISO-8859-1").GetBytes($"{_proxyOptions.CurrentValue.ServiceUser}:{_proxyOptions.CurrentValue.ServicePassword}"));
+                hrm.Headers.Authorization = new AuthenticationHeaderValue("Basic", basicAuth);
+
+                return Task.CompletedTask;
+            }).Build();
+
+            return this.HttpProxyAsync($"{_proxyOptions.CurrentValue.ProxyUrl}/{rest}{queryString}", httpOptions); ;
+        }
+
+        #endregion
+    }
+}

--- a/source/backend/api/Controllers/PimsGeoserverController.cs
+++ b/source/backend/api/Controllers/PimsGeoserverController.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using AspNetCore.Proxy;
 using AspNetCore.Proxy.Options;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Pims.Api.Policies;
@@ -16,6 +15,10 @@ namespace Pims.Api.Controllers
 {
     /// <summary>
     /// PimsGeoserverController class, provides an authenticated proxy to the pims inventory layer.
+    /// Not possible to authenticate geoserver with keycloak gold standard.
+    /// Authentication with SITEMINDER/WebAde flawed as keycloak does not refresh SITEMINDER token and they expire independently of each other.
+    /// Basic auth (via internal gov network and service account) provides a workable method for authentication to Geoserver.
+    /// Authorization of the user is provided at this level and not at the Geoserver level.
     /// </summary>
     [Authorize]
     [ApiController]

--- a/source/backend/api/Controllers/PimsGeoserverController.cs
+++ b/source/backend/api/Controllers/PimsGeoserverController.cs
@@ -49,7 +49,6 @@ namespace Pims.Api.Controllers
         [HasPermission(Permissions.PropertyView)]
         public Task ProxyCatchAll(string rest)
         {
-            // If you don't need the query string, then you can remove this.
             var queryString = this.Request.QueryString.Value;
             HttpProxyOptions httpOptions = AspNetCore.Proxy.Options.HttpProxyOptionsBuilder.Instance.WithBeforeSend((c, hrm) =>
             {

--- a/source/backend/api/Pims.Api.csproj
+++ b/source/backend/api/Pims.Api.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="5.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="5.0.3" />
     <PackageReference Include="AspNetCore.HealthChecks.UI" Version="5.0.1" />
+    <PackageReference Include="AspNetCore.Proxy" Version="4.4.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="DotNetEnv" Version="2.1.1" />
     <PackageReference Include="Mapster" Version="7.2.0" />

--- a/source/backend/api/Startup.cs
+++ b/source/backend/api/Startup.cs
@@ -44,6 +44,7 @@ using Pims.Api.Services;
 using Pims.Av;
 using Pims.Core.Converters;
 using Pims.Core.Http;
+using Pims.Core.Http.Configuration;
 using Pims.Dal;
 using Pims.Dal.Keycloak;
 using Pims.Geocoder;
@@ -121,6 +122,7 @@ namespace Pims.Api
             services.Configure<Core.Http.Configuration.OpenIdConnectOptions>(this.Configuration.GetSection("OpenIdConnect"));
             services.Configure<Keycloak.Configuration.KeycloakOptions>(this.Configuration.GetSection("Keycloak"));
             services.Configure<Pims.Dal.PimsOptions>(this.Configuration.GetSection("Pims"));
+            services.Configure<GeoserverProxyOptions>(this.Configuration.GetSection("Geoserver"));
             services.AddOptions();
 
             services.AddControllers()

--- a/source/backend/api/appsettings.Local.json
+++ b/source/backend/api/appsettings.Local.json
@@ -49,5 +49,10 @@
     "BaseUri": "",
     "ConnectionUser": "admin",
     "ConnectionPassword": ""
+  },
+  "Geoserver": {
+    "ProxyUrl": "http://localhost:8600/geoserver",
+    "ServiceUser": "admin",
+    "ServicePassword": "admin"
   }
 }

--- a/source/backend/api/appsettings.json
+++ b/source/backend/api/appsettings.json
@@ -107,8 +107,8 @@
     "ServiceClientSecret": "[CLIENT_SECRET]"
   },
   "Geoserver": {
-    "ProxyUrl":  "[GEOSERVER_PROXY_URL]",
-    "ServiceUser":  "[SERVICE_ACCOUNT_USER]",
-    "ServicePassword":  "[SERVICE_ACCOUNT_PASSWORD]"
+    "ProxyUrl": "[GEOSERVER_PROXY_URL]",
+    "ServiceUser": "[SERVICE_ACCOUNT_USER]",
+    "ServicePassword": "[SERVICE_ACCOUNT_PASSWORD]"
   }
 }

--- a/source/backend/api/appsettings.json
+++ b/source/backend/api/appsettings.json
@@ -105,5 +105,10 @@
     "CDogsHost": "[CDOGS_HOST]",
     "ServiceClientId": "[CLIENT_ID]",
     "ServiceClientSecret": "[CLIENT_SECRET]"
+  },
+  "Geoserver": {
+    "ProxyUrl":  "[GEOSERVER_PROXY_URL]",
+    "ServiceUser":  "[SERVICE_ACCOUNT_USER]",
+    "ServicePassword":  "[SERVICE_ACCOUNT_PASSWORD]"
   }
 }

--- a/source/frontend/src/features/mapSideBar/tabs/bcAssessment/BcAssessmentTabView.test.tsx
+++ b/source/frontend/src/features/mapSideBar/tabs/bcAssessment/BcAssessmentTabView.test.tsx
@@ -6,6 +6,7 @@ import { render, RenderOptions } from 'utils/test-utils';
 import BcAssessmentTabView, { IBcAssessmentTabViewProps } from './BcAssessmentTabView';
 
 const history = createMemoryHistory();
+jest.mock('@react-keycloak/web');
 
 describe('BcAssessmentTabView component', () => {
   const setup = (
@@ -24,6 +25,7 @@ describe('BcAssessmentTabView component', () => {
       {
         ...renderOptions,
         history,
+        claims: [],
       },
     );
 

--- a/source/frontend/src/features/mapSideBar/tabs/bcAssessment/BcAssessmentTabView.tsx
+++ b/source/frontend/src/features/mapSideBar/tabs/bcAssessment/BcAssessmentTabView.tsx
@@ -1,6 +1,8 @@
+import { Button } from 'components/common/buttons';
 import { FormSection } from 'components/common/form/styles';
 import LoadingBackdrop from 'components/maps/leaflet/LoadingBackdrop/LoadingBackdrop';
 import { IBcAssessmentSummary } from 'hooks/useBcAssessmentLayer';
+import useKeycloakWrapper from 'hooks/useKeycloakWrapper';
 import moment from 'moment';
 import * as React from 'react';
 import styled from 'styled-components';
@@ -27,6 +29,8 @@ export const BcAssessmentTabView: React.FunctionComponent<IBcAssessmentTabViewPr
   pid,
 }) => {
   const address = summaryData?.ADDRESSES?.find(a => a.PRIMARY_IND === 'true');
+  const keycloak = useKeycloakWrapper();
+  const logout = keycloak.obj.logout;
 
   return (
     <>
@@ -46,9 +50,13 @@ export const BcAssessmentTabView: React.FunctionComponent<IBcAssessmentTabViewPr
           <b>
             Failed to load data from BC Assessment.
             <br />
-            <br /> Refresh this page to try again, or select a different property. If this error
-            persists, contact an administrator.
+            <br /> Refresh this page to try again, your SITEMINDER credentials may have expired. You
+            can refresh your credentials by logging out and logging back into the application. If
+            this error persists past the logout/login, contact a site administrator.
           </b>
+          <Button className="m-auto" onClick={() => logout()}>
+            Log Out
+          </Button>
         </FormSection>
       ) : (
         <StyledForm>

--- a/source/frontend/src/setupProxy.js
+++ b/source/frontend/src/setupProxy.js
@@ -23,7 +23,7 @@ module.exports = function (app) {
   app.use(
     '/ogs-internal',
     createProxyMiddleware({
-      target: 'http://localhost:8600/geoserver',
+      target: 'http://localhost:5000/api/geoserver',
       changeOrigin: true,
       secure: false,
       // timeout: 2000,

--- a/tools/geoserver/geoserver_data/psp/mssql/PIMS_PROPERTY_LOCATION_VW/layer.xml
+++ b/tools/geoserver/geoserver_data/psp/mssql/PIMS_PROPERTY_LOCATION_VW/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl--3da53034:17d0594c855:-7130</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl-dccd8c1:17c8054825a:-7ffc</id>
+    <id>StyleInfoImpl--81b1e4d:186ca83336c:-7ffc</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl--3da53034:17d0594c855:-7131</id>
@@ -13,4 +13,5 @@
     <logoHeight>0</logoHeight>
   </attribution>
   <dateCreated>2021-11-10 17:27:18.456 UTC</dateCreated>
+  <dateModified>2023-03-10 07:54:34.210 UTC</dateModified>
 </layer>


### PR DESCRIPTION
Based on pattern in the bcgov/crt project
use basic auth and internal route to the geoserver instead of webADE