### PR TITLE
hide listview download icon until file detail performance is fixed.

### DIFF
--- a/source/frontend/src/features/documents/list/DocumentListContainer.tsx
+++ b/source/frontend/src/features/documents/list/DocumentListContainer.tsx
@@ -1,15 +1,11 @@
 import { DocumentRelationshipType } from 'constants/documentRelationshipType';
 import { SideBarContext } from 'features/properties/map/context/sidebarContext';
-import useDeepCompareEffect from 'hooks/useDeepCompareEffect';
 import useIsMounted from 'hooks/useIsMounted';
 import { Api_DocumentRelationship } from 'models/api/Document';
-import { ExternalResultStatus } from 'models/api/ExternalResult';
 import { useCallback, useContext, useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
-import { getPage } from 'utils';
 
 import { DocumentRow } from '../ComposedDocument';
-import { useDocumentProvider } from '../hooks/useDocumentProvider';
 import { useDocumentRelationshipProvider } from '../hooks/useDocumentRelationshipProvider';
 import DocumentListView from './DocumentListView';
 
@@ -41,8 +37,6 @@ const DocumentListContainer: React.FunctionComponent<
     deleteDocumentRelationship,
   } = useDocumentRelationshipProvider();
 
-  const { retrieveDocumentDetail } = useDocumentProvider();
-
   const retrieveDocuments = useCallback(async () => {
     const documents = await retrieveDocumentRelationship(props.relationshipType, props.parentId);
     if (documents !== undefined && isMounted()) {
@@ -57,32 +51,6 @@ const DocumentListContainer: React.FunctionComponent<
   useEffect(() => {
     retrieveDocuments();
   }, [retrieveDocuments]);
-
-  useDeepCompareEffect(() => {
-    const getDetails = async () => {
-      const currentPage = getPage<DocumentRow>(
-        pageProps.pageIndex ?? 0,
-        pageProps.pageSize,
-        documentResults,
-      );
-      const newDocumentResults = [...currentPage];
-      let updated = false;
-      await newDocumentResults.forEach(async (d, index) => {
-        if (d?.mayanDocumentId && d?.isFileAvailable === undefined) {
-          updated = true;
-          const detail = await retrieveDocumentDetail(d.mayanDocumentId);
-          const matchingResult = documentResults.find(dr => dr.id === d.id);
-          if (matchingResult && detail?.status === ExternalResultStatus.Success) {
-            matchingResult.isFileAvailable = !!detail.payload.file_latest?.id;
-          }
-        }
-      });
-      if (updated) {
-        setDocumentResults([...documentResults]);
-      }
-    };
-    getDetails();
-  }, [retrieveDocumentDetail, documentResults, pageProps]);
 
   useEffect(() => {
     if (staleFile) {

--- a/source/frontend/src/features/documents/list/DocumentListView.test.tsx
+++ b/source/frontend/src/features/documents/list/DocumentListView.test.tsx
@@ -133,30 +133,11 @@ describe('Document List View', () => {
     await act(async () => expect(getByText('Add a Document')).toBeInTheDocument());
   });
 
-  it('should display the warning tooltip instead of the download icon', async () => {
-    const { findAllByTestId } = setup({
-      hideFilters: false,
-      isLoading: false,
-      parentId: 0,
-      relationshipType: DocumentRelationshipType.RESEARCH_FILES,
-      documentResults: mockDocumentRowResponse(),
-      onDelete: deleteMock,
-      onSuccess: noop,
-      claims: [Claims.DOCUMENT_ADD, Claims.DOCUMENT_DELETE, Claims.DOCUMENT_VIEW],
-      onPageChange,
-      pageProps: { pageSize: 10, pageIndex: 0 },
-    });
-    const downloadButtonTooltip = await findAllByTestId(
-      'tooltip-icon-document-not-available-tooltip',
-    );
-    await act(async () => expect(downloadButtonTooltip[0]).toBeInTheDocument());
-  });
-
-  it('should display the download icon if download is available', async () => {
+  it('should not display the download icon on the listview', async () => {
     mockAxios.onGet().reply(200, mockDocumentDetailResponse());
     const documentRows = mockDocumentRowResponse();
     documentRows[0].isFileAvailable = true;
-    const { findByTestId } = setup({
+    const { queryByTestId } = setup({
       hideFilters: false,
       isLoading: false,
       parentId: 0,
@@ -168,8 +149,8 @@ describe('Document List View', () => {
       onPageChange,
       pageProps: { pageSize: 10, pageIndex: 0 },
     });
-    const downloadButtonTooltip = await findByTestId('document-download-button');
-    await act(async () => expect(downloadButtonTooltip).toBeInTheDocument());
+    const downloadButtonTooltip = await queryByTestId('document-download-button');
+    await act(async () => expect(downloadButtonTooltip).toBeNull());
   });
 
   it('should call on delete for a document when the document id does not equal the document relationship id', async () => {

--- a/source/frontend/src/features/documents/list/DocumentResults/DocumentResultsColumns.tsx
+++ b/source/frontend/src/features/documents/list/DocumentResults/DocumentResultsColumns.tsx
@@ -4,7 +4,6 @@ import TooltipIcon from 'components/common/TooltipIcon';
 import { ColumnWithProps, renderTypeCode } from 'components/Table';
 import { Claims } from 'constants/index';
 import { DocumentRow } from 'features/documents/ComposedDocument';
-import DownloadDocumentButton from 'features/documents/DownloadDocumentButton';
 import useKeycloakWrapper from 'hooks/useKeycloakWrapper';
 import { Api_DocumentRelationship, Api_DocumentType } from 'models/api/Document';
 import { Col, Row } from 'react-bootstrap';
@@ -108,14 +107,6 @@ const renderActions = (
     const { hasClaim } = useKeycloakWrapper();
     return (
       <StyledIconsRow className="no-gutters">
-        {hasClaim(Claims.DOCUMENT_VIEW) && original?.mayanDocumentId !== undefined && (
-          <Col>
-            <DownloadDocumentButton
-              mayanDocumentId={original?.mayanDocumentId}
-              isFileAvailable={original?.isFileAvailable}
-            />
-          </Col>
-        )}
         {hasClaim(Claims.DOCUMENT_VIEW) && (
           <Col>
             <Button


### PR DESCRIPTION
based on discussion, mayan file details api performs badly when many concurrent requests are made. Moving that call to just the view files popup as it performs better in that context. Download only possible from view screen now.