### PR TITLE
psp-5356 left border of unit and building fields made visible

### DIFF
--- a/source/frontend/src/features/leases/detail/LeasePages/improvements/AddImprovementsForm.tsx
+++ b/source/frontend/src/features/leases/detail/LeasePages/improvements/AddImprovementsForm.tsx
@@ -47,7 +47,7 @@ const StyledFormBody = styled.form`
   .form-group {
     flex-direction: column;
     input {
-      border-left: 0;
+      border-left: 1;
       width: 70%;
     }
     textarea {

--- a/source/frontend/src/features/leases/detail/LeasePages/improvements/__snapshots__/AddImprovementsContainer.test.tsx.snap
+++ b/source/frontend/src/features/leases/detail/LeasePages/improvements/__snapshots__/AddImprovementsContainer.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`Add Improvements container component renders as expected 1`] = `
 }
 
 .c0 .form-group input {
-  border-left: 0;
+  border-left: 1;
   width: 70%;
 }
 


### PR DESCRIPTION
The left border of unit # and building rate fields were not visible so fixed the CSS border-left property. 