### PR TITLE
psp-5863 remove popup when expand arrow clicked on layer controls

### DIFF
--- a/source/frontend/src/components/maps/leaflet/LayersControl/LayersMenu.tsx
+++ b/source/frontend/src/components/maps/leaflet/LayersControl/LayersMenu.tsx
@@ -203,9 +203,25 @@ const LayersTree: React.FC<React.PropsWithChildren<{ items: TreeMenuItem[] }>> =
           return (
             <ParentNode key={node.key} id={node.key}>
               {node.isOpen ? (
-                <OpenedIcon onClick={node.toggleNode} />
+                <OpenedIcon
+                  onClick={(event: React.MouseEvent<SVGElement>) => {
+                    if (node?.toggleNode) {
+                      node.toggleNode();
+                    }
+
+                    event.stopPropagation();
+                  }}
+                />
               ) : (
-                <ClosedIcon onClick={node.toggleNode} />
+                <ClosedIcon
+                  onClick={(event: any) => {
+                    if (node?.toggleNode) {
+                      node.toggleNode();
+                    }
+
+                    event.stopPropagation();
+                  }}
+                />
               )}
               <ParentCheckbox
                 index={node.index}


### PR DESCRIPTION
Disabled map layer popup from displaying when expand arrow gets clicked on the layer controls. 