### PR TITLE
PSP-6279 Add a tooltip to the Compensation tab for "Total Payment"

### DIFF
--- a/source/frontend/src/features/leases/add/__snapshots__/AddLeaseContainer.test.tsx.snap
+++ b/source/frontend/src/features/leases/add/__snapshots__/AddLeaseContainer.test.tsx.snap
@@ -743,9 +743,6 @@ exports[`AddLeaseContainer component renders as expected 1`] = `
                 >
                   Properties to include in this file:
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div
@@ -1262,9 +1259,6 @@ exports[`AddLeaseContainer component renders as expected 1`] = `
                     >
                       Selected properties
                     </div>
-                    <div
-                      class="col-1"
-                    />
                   </div>
                 </h2>
                 <div
@@ -1331,9 +1325,6 @@ exports[`AddLeaseContainer component renders as expected 1`] = `
               >
                 Administration
               </div>
-              <div
-                class="col-1"
-              />
             </div>
           </h2>
           <div
@@ -2783,9 +2774,6 @@ exports[`AddLeaseContainer component renders as expected 1`] = `
               >
                 Documentation
               </div>
-              <div
-                class="col-1"
-              />
             </div>
           </h2>
           <div

--- a/source/frontend/src/features/leases/add/__snapshots__/AdministrationSubForm.test.tsx.snap
+++ b/source/frontend/src/features/leases/add/__snapshots__/AdministrationSubForm.test.tsx.snap
@@ -77,9 +77,6 @@ exports[`AdministrationSubForm component renders as expected 1`] = `
         >
           Administration
         </div>
-        <div
-          class="col-1"
-        />
       </div>
     </h2>
     <div

--- a/source/frontend/src/features/leases/detail/LeasePages/deposits/__snapshots__/DepositsContainer.test.tsx.snap
+++ b/source/frontend/src/features/leases/detail/LeasePages/deposits/__snapshots__/DepositsContainer.test.tsx.snap
@@ -188,9 +188,6 @@ exports[`DepositsContainer renders as expected 1`] = `
           >
             Deposits Received
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -316,9 +313,6 @@ exports[`DepositsContainer renders as expected 1`] = `
           >
             Deposits Returned
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div

--- a/source/frontend/src/features/leases/detail/LeasePages/deposits/components/DepositsReceivedContainer/__snapshots__/DepositsReceivedContainer.test.tsx.snap
+++ b/source/frontend/src/features/leases/detail/LeasePages/deposits/components/DepositsReceivedContainer/__snapshots__/DepositsReceivedContainer.test.tsx.snap
@@ -190,9 +190,6 @@ exports[`DepositsReceivedContainer component renders as expected 1`] = `
         >
           Deposits Received
         </div>
-        <div
-          class="col-1"
-        />
       </div>
     </h2>
     <div

--- a/source/frontend/src/features/leases/detail/LeasePages/deposits/components/DepositsReturnedContainer/__snapshots__/DepositsReturnedContainer.test.tsx.snap
+++ b/source/frontend/src/features/leases/detail/LeasePages/deposits/components/DepositsReturnedContainer/__snapshots__/DepositsReturnedContainer.test.tsx.snap
@@ -49,9 +49,6 @@ exports[`DepositsReturnedContainer component renders as expected 1`] = `
         >
           Deposits Returned
         </div>
-        <div
-          class="col-1"
-        />
       </div>
     </h2>
     <div

--- a/source/frontend/src/features/leases/detail/LeasePages/details/__snapshots__/UpdateLeaseContainer.test.tsx.snap
+++ b/source/frontend/src/features/leases/detail/LeasePages/details/__snapshots__/UpdateLeaseContainer.test.tsx.snap
@@ -694,9 +694,6 @@ exports[`Update lease container component renders as expected 1`] = `
             >
               Properties to include in this file:
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div
@@ -1213,9 +1210,6 @@ exports[`Update lease container component renders as expected 1`] = `
                 >
                   Selected properties
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div
@@ -1282,9 +1276,6 @@ exports[`Update lease container component renders as expected 1`] = `
           >
             Administration
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -2734,9 +2725,6 @@ exports[`Update lease container component renders as expected 1`] = `
           >
             Documentation
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div

--- a/source/frontend/src/features/leases/detail/LeasePages/improvements/__snapshots__/AddImprovementsContainer.test.tsx.snap
+++ b/source/frontend/src/features/leases/detail/LeasePages/improvements/__snapshots__/AddImprovementsContainer.test.tsx.snap
@@ -114,9 +114,6 @@ exports[`Add Improvements container component displays the improvement types in 
             >
               Commercial Improvements
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div
@@ -222,9 +219,6 @@ exports[`Add Improvements container component displays the improvement types in 
             >
               Residential Improvements
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div
@@ -330,9 +324,6 @@ exports[`Add Improvements container component displays the improvement types in 
             >
               Other Improvements
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div
@@ -546,9 +537,6 @@ exports[`Add Improvements container component renders as expected 1`] = `
             >
               Commercial Improvements
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div
@@ -656,9 +644,6 @@ exports[`Add Improvements container component renders as expected 1`] = `
             >
               Residential Improvements
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div
@@ -766,9 +751,6 @@ exports[`Add Improvements container component renders as expected 1`] = `
             >
               Other Improvements
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div

--- a/source/frontend/src/features/leases/detail/LeasePages/insurance/details/__snapshots__/Insurance.test.tsx.snap
+++ b/source/frontend/src/features/leases/detail/LeasePages/insurance/details/__snapshots__/Insurance.test.tsx.snap
@@ -62,9 +62,6 @@ exports[`Lease Insurance renders as expected 1`] = `
           >
             Required insurance
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -96,9 +93,6 @@ exports[`Lease Insurance renders as expected 1`] = `
             >
               Home Insurance
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div

--- a/source/frontend/src/features/leases/detail/LeasePages/payment/__snapshots__/TermsPaymentsContainer.test.tsx.snap
+++ b/source/frontend/src/features/leases/detail/LeasePages/payment/__snapshots__/TermsPaymentsContainer.test.tsx.snap
@@ -216,9 +216,6 @@ exports[`TermsPaymentsContainer component renders as expected 1`] = `
         >
           Payments by Term
         </div>
-        <div
-          class="col-1"
-        />
       </div>
     </h2>
     <div
@@ -718,9 +715,6 @@ exports[`TermsPaymentsContainer component renders with data as expected 1`] = `
         >
           Payments by Term
         </div>
-        <div
-          class="col-1"
-        />
       </div>
     </h2>
     <div

--- a/source/frontend/src/features/leases/detail/LeasePages/payment/table/terms/__snapshots__/TermsForm.test.tsx.snap
+++ b/source/frontend/src/features/leases/detail/LeasePages/payment/table/terms/__snapshots__/TermsForm.test.tsx.snap
@@ -34,9 +34,6 @@ exports[`TermsForm component renders as expected 1`] = `
         >
           Payments by Term
         </div>
-        <div
-          class="col-1"
-        />
       </div>
     </h2>
     <div
@@ -532,9 +529,6 @@ exports[`TermsForm component renders with data as expected 1`] = `
         >
           Payments by Term
         </div>
-        <div
-          class="col-1"
-        />
       </div>
     </h2>
     <div

--- a/source/frontend/src/features/leases/detail/LeasePages/tenant/__snapshots__/Tenant.test.tsx.snap
+++ b/source/frontend/src/features/leases/detail/LeasePages/tenant/__snapshots__/Tenant.test.tsx.snap
@@ -85,9 +85,6 @@ exports[`Tenant component renders as expected 1`] = `
           >
             Tenant
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -108,9 +105,6 @@ exports[`Tenant component renders as expected 1`] = `
           >
             Representative
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -131,9 +125,6 @@ exports[`Tenant component renders as expected 1`] = `
           >
             Property Manager
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -154,9 +145,6 @@ exports[`Tenant component renders as expected 1`] = `
           >
             Unknown
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div

--- a/source/frontend/src/features/mapSideBar/tabs/Section.tsx
+++ b/source/frontend/src/features/mapSideBar/tabs/Section.tsx
@@ -26,24 +26,26 @@ export const Section: React.FC<
         <StyledSectionHeader>
           <Row className="no-gutters">
             <Col>{header}</Col>
-            <Col xs="1">
-              {isCollapsable && isCollapsed && (
-                <ArrowDropDownIcon
-                  title={`expand-${title ?? 'section'}`}
-                  onClick={() => {
-                    setIsCollapsed(!isCollapsed);
-                  }}
-                />
-              )}
-              {isCollapsable && !isCollapsed && (
-                <ArrowDropUpIcon
-                  title={`collapse-${title ?? 'section'}`}
-                  onClick={() => {
-                    setIsCollapsed(!isCollapsed);
-                  }}
-                />
-              )}
-            </Col>
+            {isCollapsable && (
+              <Col xs="1">
+                {isCollapsed && (
+                  <ArrowDropDownIcon
+                    title={`expand-${title ?? 'section'}`}
+                    onClick={() => {
+                      setIsCollapsed(!isCollapsed);
+                    }}
+                  />
+                )}
+                {!isCollapsed && (
+                  <ArrowDropUpIcon
+                    title={`collapse-${title ?? 'section'}`}
+                    onClick={() => {
+                      setIsCollapsed(!isCollapsed);
+                    }}
+                  />
+                )}
+              </Col>
+            )}
           </Row>
         </StyledSectionHeader>
       )}

--- a/source/frontend/src/features/mapSideBar/tabs/propertyDetails/detail/__snapshots__/PropertyDetailsTabView.test.tsx.snap
+++ b/source/frontend/src/features/mapSideBar/tabs/propertyDetails/detail/__snapshots__/PropertyDetailsTabView.test.tsx.snap
@@ -95,9 +95,6 @@ exports[`PropertyDetailsTabView component renders as expected when provided vali
           >
             Property Address
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -220,9 +217,6 @@ exports[`PropertyDetailsTabView component renders as expected when provided vali
           >
             Property Attributes
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -445,9 +439,6 @@ exports[`PropertyDetailsTabView component renders as expected when provided vali
           >
             Tenure Status
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -546,9 +537,6 @@ exports[`PropertyDetailsTabView component renders as expected when provided vali
           >
             Measurements
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -718,9 +706,6 @@ exports[`PropertyDetailsTabView component renders as expected when provided vali
           >
             Notes
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div

--- a/source/frontend/src/features/mapSideBar/tabs/propertyDetails/update/__snapshots__/UpdatePropertyDetailsContainer.test.tsx.snap
+++ b/source/frontend/src/features/mapSideBar/tabs/propertyDetails/update/__snapshots__/UpdatePropertyDetailsContainer.test.tsx.snap
@@ -330,9 +330,6 @@ exports[`UpdatePropertyDetailsContainer component renders as expected 1`] = `
             >
               Property Address
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div
@@ -593,9 +590,6 @@ exports[`UpdatePropertyDetailsContainer component renders as expected 1`] = `
             >
               Property Attributes
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div
@@ -1151,9 +1145,6 @@ exports[`UpdatePropertyDetailsContainer component renders as expected 1`] = `
             >
               Tenure Status
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div
@@ -1668,9 +1659,6 @@ exports[`UpdatePropertyDetailsContainer component renders as expected 1`] = `
             >
               First Nations Information
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div
@@ -1732,9 +1720,6 @@ exports[`UpdatePropertyDetailsContainer component renders as expected 1`] = `
             >
               Measurements
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div
@@ -2081,9 +2066,6 @@ exports[`UpdatePropertyDetailsContainer component renders as expected 1`] = `
             >
               Notes
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div

--- a/source/frontend/src/features/mapSideBar/tabs/propertyDetails/update/__snapshots__/UpdatePropertyDetailsForm.test.tsx.snap
+++ b/source/frontend/src/features/mapSideBar/tabs/propertyDetails/update/__snapshots__/UpdatePropertyDetailsForm.test.tsx.snap
@@ -308,9 +308,6 @@ exports[`UpdatePropertyDetailsForm component renders as expected 1`] = `
           >
             Property Address
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -571,9 +568,6 @@ exports[`UpdatePropertyDetailsForm component renders as expected 1`] = `
           >
             Property Attributes
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -1129,9 +1123,6 @@ exports[`UpdatePropertyDetailsForm component renders as expected 1`] = `
           >
             Tenure Status
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -1646,9 +1637,6 @@ exports[`UpdatePropertyDetailsForm component renders as expected 1`] = `
           >
             First Nations Information
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -1710,9 +1698,6 @@ exports[`UpdatePropertyDetailsForm component renders as expected 1`] = `
           >
             Measurements
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -2059,9 +2044,6 @@ exports[`UpdatePropertyDetailsForm component renders as expected 1`] = `
           >
             Notes
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div

--- a/source/frontend/src/features/mapSideBar/tabs/propertyResearch/__snapshots__/PropertyResearchTabView.test.tsx.snap
+++ b/source/frontend/src/features/mapSideBar/tabs/propertyResearch/__snapshots__/PropertyResearchTabView.test.tsx.snap
@@ -74,9 +74,6 @@ exports[`PropertyResearchTabView component renders as expected when provided val
           >
             Property of Interest
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -188,9 +185,6 @@ exports[`PropertyResearchTabView component renders as expected when provided val
           >
             Research Summary
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div

--- a/source/frontend/src/features/mapSideBar/tabs/takes/update/__snapshots__/TakesUpdateForm.test.tsx.snap
+++ b/source/frontend/src/features/mapSideBar/tabs/takes/update/__snapshots__/TakesUpdateForm.test.tsx.snap
@@ -597,9 +597,6 @@ exports[`TakesUpdateForm component renders as expected 1`] = `
               >
                 Area
               </div>
-              <div
-                class="col-1"
-              />
             </div>
           </h2>
           <div
@@ -1525,9 +1522,6 @@ exports[`TakesUpdateForm component renders as expected 1`] = `
               >
                 Surplus
               </div>
-              <div
-                class="col-1"
-              />
             </div>
           </h2>
           <div

--- a/source/frontend/src/features/properties/map/acquisition/__snapshots__/AcquisitionView.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/acquisition/__snapshots__/AcquisitionView.test.tsx.snap
@@ -662,9 +662,6 @@ exports[`AcquisitionView component renders as expected 1`] = `
                           >
                             Project
                           </div>
-                          <div
-                            class="col-1"
-                          />
                         </div>
                       </h2>
                       <div
@@ -738,9 +735,6 @@ exports[`AcquisitionView component renders as expected 1`] = `
                           >
                             Schedule
                           </div>
-                          <div
-                            class="col-1"
-                          />
                         </div>
                       </h2>
                       <div
@@ -862,9 +856,6 @@ exports[`AcquisitionView component renders as expected 1`] = `
                           >
                             Acquisition Details
                           </div>
-                          <div
-                            class="col-1"
-                          />
                         </div>
                       </h2>
                       <div
@@ -998,9 +989,6 @@ exports[`AcquisitionView component renders as expected 1`] = `
                           >
                             Acquisition Team
                           </div>
-                          <div
-                            class="col-1"
-                          />
                         </div>
                       </h2>
                       <div
@@ -1104,9 +1092,6 @@ exports[`AcquisitionView component renders as expected 1`] = `
                           >
                             Owner Information
                           </div>
-                          <div
-                            class="col-1"
-                          />
                         </div>
                       </h2>
                       <div

--- a/source/frontend/src/features/properties/map/acquisition/add/__snapshots__/AcquisitionPropertiesSubForm.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/acquisition/add/__snapshots__/AcquisitionPropertiesSubForm.test.tsx.snap
@@ -1020,9 +1020,6 @@ exports[`AcquisitionProperties component renders as expected 1`] = `
         >
           Selected properties
         </div>
-        <div
-          class="col-1"
-        />
       </div>
     </h2>
     <div

--- a/source/frontend/src/features/properties/map/acquisition/add/__snapshots__/AddAcquisitionContainer.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/acquisition/add/__snapshots__/AddAcquisitionContainer.test.tsx.snap
@@ -486,9 +486,6 @@ exports[`AddAcquisitionContainer component renders as expected 1`] = `
                 >
                   Project
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div
@@ -690,9 +687,6 @@ exports[`AddAcquisitionContainer component renders as expected 1`] = `
                 >
                   Schedule
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div
@@ -790,9 +784,6 @@ exports[`AddAcquisitionContainer component renders as expected 1`] = `
                 >
                   Properties to include in this file:
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div
@@ -1314,9 +1305,6 @@ exports[`AddAcquisitionContainer component renders as expected 1`] = `
                     >
                       Selected properties
                     </div>
-                    <div
-                      class="col-1"
-                    />
                   </div>
                 </h2>
                 <div
@@ -1377,9 +1365,6 @@ exports[`AddAcquisitionContainer component renders as expected 1`] = `
                 >
                   Acquisition Details
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div
@@ -1635,9 +1620,6 @@ exports[`AddAcquisitionContainer component renders as expected 1`] = `
                 >
                   Acquisition Team
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div
@@ -1672,9 +1654,6 @@ exports[`AddAcquisitionContainer component renders as expected 1`] = `
                 >
                   Owners
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div

--- a/source/frontend/src/features/properties/map/acquisition/add/__snapshots__/AddAcquisitionForm.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/acquisition/add/__snapshots__/AddAcquisitionForm.test.tsx.snap
@@ -375,9 +375,6 @@ exports[`AddAcquisitionForm component renders as expected 1`] = `
           >
             Project
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -579,9 +576,6 @@ exports[`AddAcquisitionForm component renders as expected 1`] = `
           >
             Schedule
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -679,9 +673,6 @@ exports[`AddAcquisitionForm component renders as expected 1`] = `
           >
             Properties to include in this file:
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -1203,9 +1194,6 @@ exports[`AddAcquisitionForm component renders as expected 1`] = `
               >
                 Selected properties
               </div>
-              <div
-                class="col-1"
-              />
             </div>
           </h2>
           <div
@@ -1266,9 +1254,6 @@ exports[`AddAcquisitionForm component renders as expected 1`] = `
           >
             Acquisition Details
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -1530,9 +1515,6 @@ exports[`AddAcquisitionForm component renders as expected 1`] = `
           >
             Acquisition Team
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -1567,9 +1549,6 @@ exports[`AddAcquisitionForm component renders as expected 1`] = `
           >
             Owners
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div

--- a/source/frontend/src/features/properties/map/acquisition/detail/__snapshots__/AcquisitionFileTabs.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/acquisition/detail/__snapshots__/AcquisitionFileTabs.test.tsx.snap
@@ -387,9 +387,6 @@ exports[`AcquisitionFileTabs component matches snapshot 1`] = `
                 >
                   Project
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div
@@ -463,9 +460,6 @@ exports[`AcquisitionFileTabs component matches snapshot 1`] = `
                 >
                   Schedule
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div
@@ -587,9 +581,6 @@ exports[`AcquisitionFileTabs component matches snapshot 1`] = `
                 >
                   Acquisition Details
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div
@@ -723,9 +714,6 @@ exports[`AcquisitionFileTabs component matches snapshot 1`] = `
                 >
                   Acquisition Team
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div
@@ -829,9 +817,6 @@ exports[`AcquisitionFileTabs component matches snapshot 1`] = `
                 >
                   Owner Information
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div

--- a/source/frontend/src/features/properties/map/acquisition/detail/fileDetails/__snapshots__/AcquisitionSummaryView.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/acquisition/detail/fileDetails/__snapshots__/AcquisitionSummaryView.test.tsx.snap
@@ -96,9 +96,6 @@ exports[`AcquisitionSummaryView component matches snapshot 1`] = `
           >
             Project
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -172,9 +169,6 @@ exports[`AcquisitionSummaryView component matches snapshot 1`] = `
           >
             Schedule
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -296,9 +290,6 @@ exports[`AcquisitionSummaryView component matches snapshot 1`] = `
           >
             Acquisition Details
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -432,9 +423,6 @@ exports[`AcquisitionSummaryView component matches snapshot 1`] = `
           >
             Acquisition Team
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -538,9 +526,6 @@ exports[`AcquisitionSummaryView component matches snapshot 1`] = `
           >
             Owner Information
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div

--- a/source/frontend/src/features/properties/map/acquisition/update/checklist/__snapshots__/UpdateAcquisitionChecklistForm.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/acquisition/update/checklist/__snapshots__/UpdateAcquisitionChecklistForm.test.tsx.snap
@@ -77,9 +77,6 @@ exports[`UpdateAcquisitionChecklist form renders as expected 1`] = `
           >
             File Initiation
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -365,9 +362,6 @@ exports[`UpdateAcquisitionChecklist form renders as expected 1`] = `
           >
             Active File Management
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -1229,9 +1223,6 @@ exports[`UpdateAcquisitionChecklist form renders as expected 1`] = `
           >
             Section 3 - Agreement
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -1637,9 +1628,6 @@ exports[`UpdateAcquisitionChecklist form renders as expected 1`] = `
           >
             Section 6 - Expropriation
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -2045,9 +2033,6 @@ exports[`UpdateAcquisitionChecklist form renders as expected 1`] = `
           >
             Acquisition Completion
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div

--- a/source/frontend/src/features/properties/map/acquisition/update/stakeholders/__snapshots__/UpdateStakeHolderForm.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/acquisition/update/stakeholders/__snapshots__/UpdateStakeHolderForm.test.tsx.snap
@@ -258,9 +258,6 @@ exports[`UpdateStakeHolderForm component renders as expected 1`] = `
           >
             Interests
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -644,9 +641,6 @@ exports[`UpdateStakeHolderForm component renders as expected 1`] = `
           >
             Non-interest Payees
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div

--- a/source/frontend/src/features/properties/map/acquisition/update/summary/__snapshots__/UpdateAcquisitionForm.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/acquisition/update/summary/__snapshots__/UpdateAcquisitionForm.test.tsx.snap
@@ -493,9 +493,6 @@ exports[`UpdateAcquisitionForm component renders as expected 1`] = `
           >
             Project
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -698,9 +695,6 @@ exports[`UpdateAcquisitionForm component renders as expected 1`] = `
           >
             Schedule
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -885,9 +879,6 @@ exports[`UpdateAcquisitionForm component renders as expected 1`] = `
           >
             Acquisition Details
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -1149,9 +1140,6 @@ exports[`UpdateAcquisitionForm component renders as expected 1`] = `
           >
             Acquisition Team
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -1578,9 +1566,6 @@ exports[`UpdateAcquisitionForm component renders as expected 1`] = `
           >
             Owners
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div

--- a/source/frontend/src/features/properties/map/activity/detail/__snapshots__/ActivityControlsBar.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/activity/detail/__snapshots__/ActivityControlsBar.test.tsx.snap
@@ -168,9 +168,6 @@ exports[`ActivityControlsBar test Renders as expected 1`] = `
         >
           Details
         </div>
-        <div
-          class="col-1"
-        />
       </div>
     </h2>
     <div

--- a/source/frontend/src/features/properties/map/activity/detail/__snapshots__/ActivityForm.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/activity/detail/__snapshots__/ActivityForm.test.tsx.snap
@@ -386,9 +386,6 @@ exports[`ActivityForm test Renders as expected 1`] = `
           >
             Details
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div

--- a/source/frontend/src/features/properties/map/activity/detail/__snapshots__/ActivityPropertyModal.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/activity/detail/__snapshots__/ActivityPropertyModal.test.tsx.snap
@@ -253,9 +253,6 @@ exports[`ActivityPropertyModal tests Renders as expected 1`] = `
                 >
                   Properties (0)
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div

--- a/source/frontend/src/features/properties/map/activity/detail/__snapshots__/ActivityView.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/activity/detail/__snapshots__/ActivityView.test.tsx.snap
@@ -297,9 +297,6 @@ exports[`ActivityView test Renders as expected 1`] = `
           >
             Details
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div

--- a/source/frontend/src/features/properties/map/activity/list/__snapshots__/ActivityListView.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/activity/list/__snapshots__/ActivityListView.test.tsx.snap
@@ -275,9 +275,6 @@ exports[`Activity List View renders as expected 1`] = `
         >
           Activities
         </div>
-        <div
-          class="col-1"
-        />
       </div>
     </h2>
     <div

--- a/source/frontend/src/features/properties/map/compensation/detail/__snapshots__/CompensationRequisitionDetailView.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/compensation/detail/__snapshots__/CompensationRequisitionDetailView.test.tsx.snap
@@ -346,9 +346,6 @@ exports[`Compensation Detail View Component renders as expected 1`] = `
           >
             Requisition Details
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div

--- a/source/frontend/src/features/properties/map/compensation/list/CompensationListView.tsx
+++ b/source/frontend/src/features/properties/map/compensation/list/CompensationListView.tsx
@@ -51,8 +51,8 @@ export const CompensationListView: React.FunctionComponent<ICompensationListView
         }
       >
         <SectionField
-          label="Total compensation for this file"
-          tooltip={`This is the total of all requisitions in the "Final" status. Draft entries are not included here.`}
+          label="Total payment amount for this file"
+          tooltip={`This is the total of all requisitions in the "Final" status.\nDraft entries are not included here.`}
           labelWidth="9"
         >
           {formatMoney(fileCompensationTotal)}

--- a/source/frontend/src/features/properties/map/compensation/list/CompensationListView.tsx
+++ b/source/frontend/src/features/properties/map/compensation/list/CompensationListView.tsx
@@ -50,7 +50,11 @@ export const CompensationListView: React.FunctionComponent<ICompensationListView
           />
         }
       >
-        <SectionField label={'Total compensation for this file'} labelWidth="9">
+        <SectionField
+          label="Total compensation for this file"
+          tooltip={`This is the total of all requisitions in the "Final" status. Draft entries are not included here.`}
+          labelWidth="9"
+        >
           {formatMoney(fileCompensationTotal)}
         </SectionField>
       </Section>

--- a/source/frontend/src/features/properties/map/compensation/list/__snapshots__/CompensationListView.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/compensation/list/__snapshots__/CompensationListView.test.tsx.snap
@@ -72,9 +72,6 @@ exports[`compensation list view renders as expected 1`] = `
             />
           </div>
         </div>
-        <div
-          class="col-1"
-        />
       </div>
     </h2>
     <div
@@ -89,7 +86,31 @@ exports[`compensation list view renders as expected 1`] = `
           <label
             class="c3"
           >
-            Total compensation for this file:
+            Total payment amount for this file:
+            <span
+              class="ml-2"
+            >
+              <span
+                class="tooltip-icon"
+                data-testid="tooltip-icon-section-field-tooltip"
+                id="section-field-tooltip"
+              >
+                <svg
+                  class="tooltip-icon"
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                  />
+                </svg>
+              </span>
+            </span>
           </label>
         </div>
         <div

--- a/source/frontend/src/features/properties/map/compensation/update/__snapshots__/UpdateCompensationRequisitionForm.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/compensation/update/__snapshots__/UpdateCompensationRequisitionForm.test.tsx.snap
@@ -241,9 +241,6 @@ exports[`TakesUpdateForm component renders as expected 1`] = `
             >
               Requisition details
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div
@@ -452,9 +449,6 @@ exports[`TakesUpdateForm component renders as expected 1`] = `
             >
               Financial coding
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div

--- a/source/frontend/src/features/properties/map/project/add/__snapshots__/AddProjectContainer.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/project/add/__snapshots__/AddProjectContainer.test.tsx.snap
@@ -298,9 +298,6 @@ exports[`AddProjectContainer component renders as expected 1`] = `
                 >
                   Project Details
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div
@@ -543,9 +540,6 @@ exports[`AddProjectContainer component renders as expected 1`] = `
                 >
                   Associated Codes
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div
@@ -663,9 +657,6 @@ exports[`AddProjectContainer component renders as expected 1`] = `
                 >
                   Associated products
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div

--- a/source/frontend/src/features/properties/map/project/add/__snapshots__/AddProjectForm.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/project/add/__snapshots__/AddProjectForm.test.tsx.snap
@@ -197,9 +197,6 @@ exports[`AddProjectForm component renders as expected 1`] = `
             >
               Project Details
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div
@@ -425,9 +422,6 @@ exports[`AddProjectForm component renders as expected 1`] = `
             >
               Associated Codes
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div
@@ -545,9 +539,6 @@ exports[`AddProjectForm component renders as expected 1`] = `
             >
               Associated products
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div
@@ -821,9 +812,6 @@ exports[`AddProjectForm component renders as expected with existing data 1`] = `
             >
               Project Details
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div
@@ -1051,9 +1039,6 @@ exports[`AddProjectForm component renders as expected with existing data 1`] = `
             >
               Associated Codes
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div
@@ -1171,9 +1156,6 @@ exports[`AddProjectForm component renders as expected with existing data 1`] = `
             >
               Associated products
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div

--- a/source/frontend/src/features/properties/map/research/__snapshots__/ResearchContainer.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/research/__snapshots__/ResearchContainer.test.tsx.snap
@@ -611,9 +611,6 @@ exports[`ResearchContainer component renders as expected 1`] = `
                             >
                               Project
                             </div>
-                            <div
-                              class="col-1"
-                            />
                           </div>
                         </h2>
                         <div
@@ -656,9 +653,6 @@ exports[`ResearchContainer component renders as expected 1`] = `
                             >
                               Roads
                             </div>
-                            <div
-                              class="col-1"
-                            />
                           </div>
                         </h2>
                         <div
@@ -718,9 +712,6 @@ exports[`ResearchContainer component renders as expected 1`] = `
                             >
                               Research Request
                             </div>
-                            <div
-                              class="col-1"
-                            />
                           </div>
                         </h2>
                         <div
@@ -835,9 +826,6 @@ exports[`ResearchContainer component renders as expected 1`] = `
                             >
                               Result
                             </div>
-                            <div
-                              class="col-1"
-                            />
                           </div>
                         </h2>
                         <div
@@ -896,9 +884,6 @@ exports[`ResearchContainer component renders as expected 1`] = `
                             >
                               Expropriation
                             </div>
-                            <div
-                              class="col-1"
-                            />
                           </div>
                         </h2>
                         <div

--- a/source/frontend/src/features/properties/map/research/__snapshots__/ResearchTabsContainer.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/research/__snapshots__/ResearchTabsContainer.test.tsx.snap
@@ -327,9 +327,6 @@ exports[`ResearchFileTabs component matches snapshot 1`] = `
                 >
                   Project
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div
@@ -371,9 +368,6 @@ exports[`ResearchFileTabs component matches snapshot 1`] = `
                 >
                   Roads
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div
@@ -431,9 +425,6 @@ exports[`ResearchFileTabs component matches snapshot 1`] = `
                 >
                   Research Request
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div
@@ -542,9 +533,6 @@ exports[`ResearchFileTabs component matches snapshot 1`] = `
                 >
                   Result
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div
@@ -601,9 +589,6 @@ exports[`ResearchFileTabs component matches snapshot 1`] = `
                 >
                   Expropriation
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div

--- a/source/frontend/src/features/properties/map/research/add/__snapshots__/AddResearchContainer.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/research/add/__snapshots__/AddResearchContainer.test.tsx.snap
@@ -602,9 +602,6 @@ exports[`AddResearchContainer component renders as expected 1`] = `
                 >
                   Project
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div
@@ -637,9 +634,6 @@ exports[`AddResearchContainer component renders as expected 1`] = `
                 >
                   Properties to include in this file:
                 </div>
-                <div
-                  class="col-1"
-                />
               </div>
             </h2>
             <div
@@ -1161,9 +1155,6 @@ exports[`AddResearchContainer component renders as expected 1`] = `
                     >
                       Selected properties
                     </div>
-                    <div
-                      class="col-1"
-                    />
                   </div>
                 </h2>
                 <div

--- a/source/frontend/src/features/properties/map/research/add/__snapshots__/AddResearchForm.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/research/add/__snapshots__/AddResearchForm.test.tsx.snap
@@ -479,9 +479,6 @@ exports[`AddResearchForm component renders as expected 1`] = `
           >
             Project
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -514,9 +511,6 @@ exports[`AddResearchForm component renders as expected 1`] = `
           >
             Properties to include in this file:
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -1038,9 +1032,6 @@ exports[`AddResearchForm component renders as expected 1`] = `
               >
                 Selected properties
               </div>
-              <div
-                class="col-1"
-              />
             </div>
           </h2>
           <div

--- a/source/frontend/src/features/properties/map/research/add/__snapshots__/ResearchProperties.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/research/add/__snapshots__/ResearchProperties.test.tsx.snap
@@ -376,9 +376,6 @@ exports[`ResearchProperties component renders as expected when provided no prope
         >
           Properties to include in this file:
         </div>
-        <div
-          class="col-1"
-        />
       </div>
     </h2>
     <div
@@ -900,9 +897,6 @@ exports[`ResearchProperties component renders as expected when provided no prope
             >
               Selected properties
             </div>
-            <div
-              class="col-1"
-            />
           </div>
         </h2>
         <div

--- a/source/frontend/src/features/properties/map/research/detail/__snapshots__/ResearchSummaryView.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/research/detail/__snapshots__/ResearchSummaryView.test.tsx.snap
@@ -59,9 +59,6 @@ exports[`ResearchSummaryView component renders as expected when research file is
           >
             Project
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -103,9 +100,6 @@ exports[`ResearchSummaryView component renders as expected when research file is
           >
             Roads
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -163,9 +157,6 @@ exports[`ResearchSummaryView component renders as expected when research file is
           >
             Research Request
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -274,9 +265,6 @@ exports[`ResearchSummaryView component renders as expected when research file is
           >
             Result
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -333,9 +321,6 @@ exports[`ResearchSummaryView component renders as expected when research file is
           >
             Expropriation
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div

--- a/source/frontend/src/features/properties/map/research/update/property/__snapshots__/UpdatePropertyForm.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/research/update/property/__snapshots__/UpdatePropertyForm.test.tsx.snap
@@ -52,9 +52,6 @@ exports[`UpdatePropertyForm component renders as expected when provided no resea
           >
             Property of Interest
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -422,9 +419,6 @@ exports[`UpdatePropertyForm component renders as expected when provided no resea
           >
             Research Summary
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div

--- a/source/frontend/src/features/properties/map/research/update/summary/__snapshots__/UpdateSummaryForm.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/research/update/summary/__snapshots__/UpdateSummaryForm.test.tsx.snap
@@ -342,9 +342,6 @@ exports[`UpdateResearchForm component renders as expected when provided no resea
           >
             Research File Information
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -537,9 +534,6 @@ exports[`UpdateResearchForm component renders as expected when provided no resea
           >
             Project
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -572,9 +566,6 @@ exports[`UpdateResearchForm component renders as expected when provided no resea
           >
             Roads
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -652,9 +643,6 @@ exports[`UpdateResearchForm component renders as expected when provided no resea
           >
             Research Request
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -1014,9 +1002,6 @@ exports[`UpdateResearchForm component renders as expected when provided no resea
           >
             Result
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div
@@ -1104,9 +1089,6 @@ exports[`UpdateResearchForm component renders as expected when provided no resea
           >
             Expropriation
           </div>
-          <div
-            class="col-1"
-          />
         </div>
       </h2>
       <div

--- a/source/frontend/src/features/properties/map/shared/update/properties/__snapshots__/UpdateProperties.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/shared/update/properties/__snapshots__/UpdateProperties.test.tsx.snap
@@ -948,9 +948,6 @@ exports[`UpdateProperties component renders as expected 1`] = `
               >
                 Selected properties
               </div>
-              <div
-                class="col-1"
-              />
             </div>
           </h2>
           <div


### PR DESCRIPTION
* Also updated shared **Section** component to not render an empty column when section is not collapsable. 
* That allows the section header to take the full width of non-collapsable sections

![image](https://github.com/bcgov/PSP/assets/24322224/96ee75dd-b5d8-4f45-88c6-f3ab01cb547d)
