### PR TITLE
HOTFIX: PSP-6343 Update GitHub Actions to run Node16 instead of Node12

### DIFF
--- a/.github/workflows/api-dotnetcore.yml
+++ b/.github/workflows/api-dotnetcore.yml
@@ -143,7 +143,7 @@ jobs:
         env:
           MS_TEAMS_NOTIFY_URL: ${{ secrets.MS_TEAMS_NOTIFY_URL }}
         if: env.MS_TEAMS_NOTIFY_URL != '' && failure() && steps.scan.outcome == 'failure'
-        uses: jdcargile/ms-teams-notification@v1.3
+        uses: dragos-cojocari/ms-teams-notification@v1.0.2
         with:
           github-token: ${{ github.token }}
           ms-teams-webhook-uri: ${{ env.MS_TEAMS_NOTIFY_URL }}

--- a/.github/workflows/api-dotnetcore.yml
+++ b/.github/workflows/api-dotnetcore.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Extract Branch Name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
         id: extract_branch
 
       - name: Setup .NET 6

--- a/.github/workflows/api-dotnetcore.yml
+++ b/.github/workflows/api-dotnetcore.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -32,7 +32,7 @@ jobs:
       GIT_BRANCH: "${{github.ref}}"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Extract Branch Name
         shell: bash

--- a/.github/workflows/app-react.yml
+++ b/.github/workflows/app-react.yml
@@ -40,7 +40,7 @@ jobs:
         id: extract_branch
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: "16.15.0"
       - run: npm ci

--- a/.github/workflows/app-react.yml
+++ b/.github/workflows/app-react.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Extract Branch Name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
         id: extract_branch
 
       - name: Use Node.js

--- a/.github/workflows/app-react.yml
+++ b/.github/workflows/app-react.yml
@@ -92,7 +92,7 @@ jobs:
         env:
           MS_TEAMS_NOTIFY_URL: ${{ secrets.MS_TEAMS_NOTIFY_URL }}
         if: env.MS_TEAMS_NOTIFY_URL != '' && failure() && steps.scan.outcome == 'failure'
-        uses: jdcargile/ms-teams-notification@v1.3
+        uses: dragos-cojocari/ms-teams-notification@v1.0.2
         with:
           github-token: ${{ github.token }}
           ms-teams-webhook-uri: ${{ env.MS_TEAMS_NOTIFY_URL }}

--- a/.github/workflows/app-react.yml
+++ b/.github/workflows/app-react.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -32,7 +32,7 @@ jobs:
       GIT_BRANCH: "${{github.ref}}"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Extract Branch Name
         shell: bash

--- a/.github/workflows/ci-cd-pims-dev.yml
+++ b/.github/workflows/ci-cd-pims-dev.yml
@@ -105,7 +105,7 @@ jobs:
     if: ${{ always() && github.event.pull_request.merged == true }}
     steps:
       - name: check workflow status
-        uses: martialonline/workflow-status@v2
+        uses: martialonline/workflow-status@v4
         id: check
       - name: End notification to Teams Channel
         uses: dragos-cojocari/ms-teams-notification@v1.0.2

--- a/.github/workflows/ci-cd-pims-dev.yml
+++ b/.github/workflows/ci-cd-pims-dev.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Start notification to Teams Channel
-        uses: jdcargile/ms-teams-notification@v1.3
+        uses: dragos-cojocari/ms-teams-notification@v1.0.2
         with:
           github-token: ${{ github.token }}
           ms-teams-webhook-uri: ${{ env.MS_TEAMS_WEBHOOK_BUILD_CHANNEL }}
@@ -108,7 +108,7 @@ jobs:
         uses: martialonline/workflow-status@v2
         id: check
       - name: End notification to Teams Channel
-        uses: jdcargile/ms-teams-notification@v1.3
+        uses: dragos-cojocari/ms-teams-notification@v1.0.2
         with:
           github-token: ${{ github.token }}
           ms-teams-webhook-uri: ${{ env.MS_TEAMS_WEBHOOK_BUILD_CHANNEL }}

--- a/.github/workflows/ci-cd-pims-dev.yml
+++ b/.github/workflows/ci-cd-pims-dev.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:

--- a/.github/workflows/ci-cd-pims-master.yml
+++ b/.github/workflows/ci-cd-pims-master.yml
@@ -130,7 +130,7 @@ jobs:
     needs: deploy
     steps:
       - name: check workflow status
-        uses: martialonline/workflow-status@v2
+        uses: martialonline/workflow-status@v4
         id: check
       - name: End notification to Teams Channel
         uses: dragos-cojocari/ms-teams-notification@v1.0.2

--- a/.github/workflows/ci-cd-pims-master.yml
+++ b/.github/workflows/ci-cd-pims-master.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Start notification to Teams Channel
-        uses: jdcargile/ms-teams-notification@v1.3
+        uses: dragos-cojocari/ms-teams-notification@v1.0.2
         with:
           github-token: ${{ github.token }}
           ms-teams-webhook-uri: ${{ env.MS_TEAMS_WEBHOOK_BUILD_CHANNEL }}
@@ -133,7 +133,7 @@ jobs:
         uses: martialonline/workflow-status@v2
         id: check
       - name: End notification to Teams Channel
-        uses: jdcargile/ms-teams-notification@v1.3
+        uses: dragos-cojocari/ms-teams-notification@v1.0.2
         with:
           github-token: ${{ github.token }}
           ms-teams-webhook-uri: ${{ env.MS_TEAMS_WEBHOOK_BUILD_CHANNEL }}

--- a/.github/workflows/ci-cd-pims-master.yml
+++ b/.github/workflows/ci-cd-pims-master.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: master
       - name: Login to OpenShift
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: master
       - name: Login to OpenShift
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: master
       - name: Fetch Tags
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: master
       - name: Login to OpenShift

--- a/.github/workflows/ci-cd-pims-test.yml
+++ b/.github/workflows/ci-cd-pims-test.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Start notification to Teams Channel
-        uses: jdcargile/ms-teams-notification@v1.3
+        uses: dragos-cojocari/ms-teams-notification@v1.0.2
         with:
           github-token: ${{ github.token }}
           ms-teams-webhook-uri: ${{ env.MS_TEAMS_WEBHOOK_BUILD_CHANNEL }}
@@ -138,7 +138,7 @@ jobs:
         uses: martialonline/workflow-status@v2
         id: check
       - name: End notification to Teams Channel
-        uses: jdcargile/ms-teams-notification@v1.3
+        uses: dragos-cojocari/ms-teams-notification@v1.0.2
         with:
           github-token: ${{ github.token }}
           ms-teams-webhook-uri: ${{ env.MS_TEAMS_WEBHOOK_BUILD_CHANNEL }}

--- a/.github/workflows/ci-cd-pims-test.yml
+++ b/.github/workflows/ci-cd-pims-test.yml
@@ -135,7 +135,7 @@ jobs:
     if: ${{ always() && github.event.pull_request.merged == true }}
     steps:
       - name: check workflow status
-        uses: martialonline/workflow-status@v2
+        uses: martialonline/workflow-status@v4
         id: check
       - name: End notification to Teams Channel
         uses: dragos-cojocari/ms-teams-notification@v1.0.2

--- a/.github/workflows/ci-cd-pims-test.yml
+++ b/.github/workflows/ci-cd-pims-test.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: test
       - name: Login to OpenShift
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: test
       - name: Login to OpenShift
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: test
       - name: Fetch Tags
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: test
       - name: Login to OpenShift

--- a/.github/workflows/credentials-comment-pr.yml
+++ b/.github/workflows/credentials-comment-pr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download artifact
         uses: actions/github-script@v3.1.0
         with:

--- a/.github/workflows/credentials-scan.yml
+++ b/.github/workflows/credentials-scan.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup python
         uses: actions/setup-python@v2

--- a/.github/workflows/deploy-prod-end.yml
+++ b/.github/workflows/deploy-prod-end.yml
@@ -38,7 +38,7 @@ jobs:
         uses: martialonline/workflow-status@v2
         id: check
       - name: End notification to Teams Channel
-        uses: jdcargile/ms-teams-notification@v1.3
+        uses: dragos-cojocari/ms-teams-notification@v1.0.2
         with:
           github-token: ${{ github.token }}
           ms-teams-webhook-uri: ${{ env.MS_TEAMS_WEBHOOK_BUILD_CHANNEL }}

--- a/.github/workflows/deploy-prod-end.yml
+++ b/.github/workflows/deploy-prod-end.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: master
           fetch-depth: 0

--- a/.github/workflows/deploy-prod-end.yml
+++ b/.github/workflows/deploy-prod-end.yml
@@ -35,7 +35,7 @@ jobs:
     needs: maintenance-page
     steps:
       - name: check workflow status
-        uses: martialonline/workflow-status@v2
+        uses: martialonline/workflow-status@v4
         id: check
       - name: End notification to Teams Channel
         uses: dragos-cojocari/ms-teams-notification@v1.0.2

--- a/.github/workflows/depoy-prod-start.yml
+++ b/.github/workflows/depoy-prod-start.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Start notification to Teams Channel
-        uses: jdcargile/ms-teams-notification@v1.3
+        uses: dragos-cojocari/ms-teams-notification@v1.0.2
         with:
           github-token: ${{ github.token }}
           ms-teams-webhook-uri: ${{ env.MS_TEAMS_WEBHOOK_BUILD_CHANNEL }}

--- a/.github/workflows/depoy-prod-start.yml
+++ b/.github/workflows/depoy-prod-start.yml
@@ -48,7 +48,7 @@ jobs:
     needs: ci-cd-start-notification
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: master
           fetch-depth: 0

--- a/.github/workflows/image-scan-analysis.yml
+++ b/.github/workflows/image-scan-analysis.yml
@@ -83,7 +83,7 @@ jobs:
       OPENSHIFT_NAMESPACE: 3cd915-tools
       output-filename: nodejs14.txt
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download artifact
         id: artifact
         uses: actions/download-artifact@master
@@ -96,10 +96,10 @@ jobs:
         run: |
           cd ${{env.image-name}}/
           if [ -s ${{env.output-filename}} ]; then
-          body="$(cat ${{env.output-filename}})" 
+          body="$(cat ${{env.output-filename}})"
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}" 
+          body="${body//$'\r'/'%0D'}"
           echo "::set-output name=body::$body"
           fi
       - name: Find Comment
@@ -212,7 +212,7 @@ jobs:
       tag: ${{secrets.NGINX_BASE_TAG}}
       output-filename: nginx-base.txt
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download artifact
         id: artifact
         uses: actions/download-artifact@master
@@ -226,11 +226,11 @@ jobs:
         run: |
           cd ${{env.image-name}}/
           if [ -s ${{env.output-filename}} ]; then
-          body="$(cat ${{env.output-filename}})" 
+          body="$(cat ${{env.output-filename}})"
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}" 
-          echo "::set-output name=body::$body" 
+          body="${body//$'\r'/'%0D'}"
+          echo "::set-output name=body::$body"
           fi
       - name: Find Comment
         if: github.event_name == 'pull_request'
@@ -345,7 +345,7 @@ jobs:
       tag: latest
       output-filename: pims-app.txt
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download artifact
         id: artifact
         uses: actions/download-artifact@master
@@ -359,11 +359,11 @@ jobs:
         run: |
           cd ${{env.image-name}}/
           if [ -s ${{env.output-filename}} ]; then
-          body="$(cat ${{env.output-filename}})" 
+          body="$(cat ${{env.output-filename}})"
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}" 
-          echo "::set-output name=body::$body" 
+          body="${body//$'\r'/'%0D'}"
+          echo "::set-output name=body::$body"
           fi
       - name: Find Comment
         if: github.event_name == 'pull_request'
@@ -475,7 +475,7 @@ jobs:
       tag: "5.0"
       output-filename: dotnet-aspnet.txt
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download artifact
         id: artifact
         uses: actions/download-artifact@master
@@ -489,11 +489,11 @@ jobs:
         run: |
           cd ${{env.image-name}}/
           if [ -s ${{env.output-filename}} ]; then
-          body="$(cat ${{env.output-filename}})" 
+          body="$(cat ${{env.output-filename}})"
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}" 
-          echo "::set-output name=body::$body" 
+          body="${body//$'\r'/'%0D'}"
+          echo "::set-output name=body::$body"
           fi
       - name: Find Comment
         if: github.event_name == 'pull_request'
@@ -530,7 +530,7 @@ jobs:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            ## ${{secrets.OPENSHIFT_REGISTRY}}/${{env.image-name}}:${{env.tag}} vulnerability report     
+            ## ${{secrets.OPENSHIFT_REGISTRY}}/${{env.image-name}}:${{env.tag}} vulnerability report
             ``` echo "${{ steps.get-comment-body.outputs.body }}"```
           edit-mode: replace
           reactions: confused
@@ -605,7 +605,7 @@ jobs:
       tag: "5.0"
       output-filename: dotnet-sdk.txt
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download artifact
         id: artifact
         uses: actions/download-artifact@master
@@ -619,11 +619,11 @@ jobs:
         run: |
           cd ${{env.image-name}}/
           if [ -s ${{env.output-filename}} ]; then
-          body="$(cat ${{env.output-filename}})" 
+          body="$(cat ${{env.output-filename}})"
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}" 
-          echo "::set-output name=body::$body" 
+          body="${body//$'\r'/'%0D'}"
+          echo "::set-output name=body::$body"
           fi
       - name: Find Comment
         if: github.event_name == 'pull_request'
@@ -660,7 +660,7 @@ jobs:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            ## ${{secrets.OPENSHIFT_REGISTRY}}/${{env.image-name}}:${{env.tag}} vulnerability report     
+            ## ${{secrets.OPENSHIFT_REGISTRY}}/${{env.image-name}}:${{env.tag}} vulnerability report
             ``` echo "${{ steps.get-comment-body.outputs.body }}"```
           edit-mode: replace
           reactions: confused
@@ -736,7 +736,7 @@ jobs:
       tag: latest
       output-filename: pims-api.txt
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download artifact
         id: artifact
         uses: actions/download-artifact@master
@@ -750,11 +750,11 @@ jobs:
         run: |
           cd ${{env.image-name}}/
           if [ -s ${{env.output-filename}} ]; then
-          body="$(cat ${{env.output-filename}})" 
+          body="$(cat ${{env.output-filename}})"
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}" 
-          echo "::set-output name=body::$body" 
+          body="${body//$'\r'/'%0D'}"
+          echo "::set-output name=body::$body"
           fi
       - name: Find Comment
         if: github.event_name == 'pull_request'
@@ -868,7 +868,7 @@ jobs:
       tag: latest
       output-filename: pims-logging.txt
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download artifact
         id: artifact
         uses: actions/download-artifact@master
@@ -881,10 +881,10 @@ jobs:
         run: |
           cd ${{env.image-name}}/
           if [ -s ${{env.output-filename}} ]; then
-          body="$(cat ${{env.output-filename}})" 
+          body="$(cat ${{env.output-filename}})"
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}" 
+          body="${body//$'\r'/'%0D'}"
           echo "::set-output name=body::$body"
           fi
       - name: Find Comment
@@ -999,7 +999,7 @@ jobs:
       tag: latest
       output-filename: jenkins-agent-dotnet.txt
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download artifact
         id: artifact
         uses: actions/download-artifact@master
@@ -1012,10 +1012,10 @@ jobs:
         run: |
           cd ${{env.image-name}}/
           if [ -s ${{env.output-filename}} ]; then
-          body="$(cat ${{env.output-filename}})" 
+          body="$(cat ${{env.output-filename}})"
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}" 
+          body="${body//$'\r'/'%0D'}"
           echo "::set-output name=body::$body"
           fi
       - name: Find Comment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "16"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,8 @@ jobs:
           RELEASE_VERSION=${{ github.ref_name }}
           RELEASE_URL=$(gh release view ${{ github.ref_name }} --json url --jq '.url')
 
-          echo "::set-output name=release_version::$RELEASE_VERSION"
-          echo "::set-output name=release_url::$RELEASE_URL"
+          echo "release_version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+          echo "release_url=${RELEASE_URL}" >> $GITHUB_OUTPUT
 
       # This is so we can use a "Card Message" template for notifications and replace it with relevant values; e.g. __RELEASEVERSION__ etc
       # Template found in: .github/notifications/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+env:
+  MS_TEAMS_WEBHOOK_BUILD_CHANNEL: ${{ secrets.MS_TEAMS_WEBHOOK_URI_BUILD_CHANNEL }}
 
 on:
   push:
@@ -52,10 +54,8 @@ jobs:
           INPUT_RELEASEVERSION: ${{ steps.create_release.outputs.release_version }}
           INPUT_RELEASEURL: ${{ steps.create_release.outputs.release_url }}
 
-      # Send notifications only if MS_TEAMS_NOTIFY_URL secret has been set
+      # Send notifications only if MS_TEAMS_WEBHOOK_BUILD_CHANNEL secret has been set
       - name: Post notification to MS Teams
-        env:
-          MS_TEAMS_NOTIFY_URL: ${{ secrets.MS_TEAMS_NOTIFY_URL }}
-        if: env.MS_TEAMS_NOTIFY_URL != ''
+        if: env.MS_TEAMS_WEBHOOK_BUILD_CHANNEL != ''
         run: |
-          curl -H 'Content-Type: application/json' ${{ secrets.MS_TEAMS_NOTIFY_URL }} --data @release_notification.json
+          curl -H 'Content-Type: application/json' ${{ env.MS_TEAMS_WEBHOOK_BUILD_CHANNEL }} --data @release_notification.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -21,7 +21,7 @@ jobs:
       - name: Setup git
         run: |
           git config user.name "github-actions"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.email "github-actions@github.com"
 
       - name: Create release
         id: create_release

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }} # with this we can bypass branch protection rules here (no-push)
 
@@ -23,7 +23,7 @@ jobs:
       - name: Setup git
         run: |
           git config user.name "github-actions"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.email "github-actions@github.com"
 
       - name: Check release version
         run: |

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }} # with this we can bypass branch protection rules here (no-push)
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "16"
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }} # with this we can bypass branch protection rules here (no-push)
 
@@ -22,7 +22,7 @@ jobs:
       - name: Setup git
         run: |
           git config user.name "github-actions"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.email "github-actions@github.com"
 
       - name: Bump version number
         run: |

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }} # with this we can bypass branch protection rules here (no-push)
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "16"
 


### PR DESCRIPTION
Summary of changes:

- Change checkout action to v3
- Replace the MS Teams Notification action (un-maintained) with: https://github.com/marketplace/actions/microsoft-teams-notifications-dc
- The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/