### PR TITLE
set table to not reset page when data changes.

### DIFF
--- a/source/frontend/src/components/Table/Table.tsx
+++ b/source/frontend/src/components/Table/Table.tsx
@@ -343,6 +343,7 @@ export const Table = <T extends IIdentifiedObject, TFilter extends object = {}>(
       manualSortBy: manualSortBy,
       pageCount,
       autoResetSelectedRows: false,
+      autoResetPage: false,
     },
     useFlexLayout,
     useSortBy,


### PR DESCRIPTION
as documented in react-table, this parameter prevents the table from automatically resetting the page when the data changes.