### PR TITLE
PSP-7922 Completing disposition file - selected properties and errors

### DIFF
--- a/source/backend/tests/unit/api/Services/DispositionFileServiceTest.cs
+++ b/source/backend/tests/unit/api/Services/DispositionFileServiceTest.cs
@@ -414,6 +414,7 @@ namespace Pims.Api.Test.Services
             // Arrange
             var service = this.CreateDispositionServiceWithPermissions(Permissions.DispositionEdit);
             var repository = this._helper.GetService<Mock<IDispositionFileRepository>>();
+            var dispositionFilePropertyRepository = this._helper.GetService<Mock<IDispositionFilePropertyRepository>>();
 
             var dispFile = EntityHelper.CreateDispositionFile(1);
 
@@ -428,6 +429,8 @@ namespace Pims.Api.Test.Services
             repository.Setup(x => x.GetRegion(It.IsAny<long>())).Returns(1);
             repository.Setup(x => x.Update(It.IsAny<long>(), It.IsAny<PimsDispositionFile>())).Returns(dispFile);
             repository.Setup(x => x.GetById(It.IsAny<long>())).Returns(dispFile);
+
+            dispositionFilePropertyRepository.Setup(x => x.GetPropertiesByDispositionFileId(It.IsAny<long>())).Returns(new List<PimsDispositionFileProperty>() { });
 
             // Act
             Action act = () => service.Update(2, updateDispFile, new List<UserOverrideCode>() { UserOverrideCode.DispositionFileFinalStatus });
@@ -443,6 +446,7 @@ namespace Pims.Api.Test.Services
             // Arrange
             var service = this.CreateDispositionServiceWithPermissions(Permissions.DispositionEdit);
             var repository = this._helper.GetService<Mock<IDispositionFileRepository>>();
+            var dispositionFilePropertyRepository = this._helper.GetService<Mock<IDispositionFilePropertyRepository>>();
 
             var statusMock = this._helper.GetService<Mock<IDispositionStatusSolver>>();
             statusMock.Setup(x => x.CanEditDetails(It.IsAny<DispositionStatusTypes>())).Returns(true);
@@ -456,6 +460,7 @@ namespace Pims.Api.Test.Services
             repository.Setup(x => x.GetRegion(It.IsAny<long>())).Returns(1);
             repository.Setup(x => x.Update(It.IsAny<long>(), It.IsAny<PimsDispositionFile>())).Returns(dispFile);
             repository.Setup(x => x.GetById(It.IsAny<long>())).Returns(dispFile);
+            dispositionFilePropertyRepository.Setup(x => x.GetPropertiesByDispositionFileId(It.IsAny<long>())).Returns(new List<PimsDispositionFileProperty>() { });
 
             // Act
             Action act = () => service.Update(2, updateDispFile, new List<UserOverrideCode>() { UserOverrideCode.DispositionFileFinalStatus });

--- a/source/frontend/src/features/mapSideBar/disposition/tabs/fileDetails/detail/update/UpdateDispositionForm.tsx
+++ b/source/frontend/src/features/mapSideBar/disposition/tabs/fileDetails/detail/update/UpdateDispositionForm.tsx
@@ -93,7 +93,7 @@ const UpdateDispositionForm: React.FC<IUpdateDispositionFormProps> = ({
             <LoadingBackdrop show={loading} parentScreen />
 
             <Container>
-              <Section header="">
+              <Section>
                 <SectionField label="Status" required>
                   <Select
                     field="fileStatusTypeCode"
@@ -244,10 +244,8 @@ const UpdateDispositionForm: React.FC<IUpdateDispositionFormProps> = ({
 export default UpdateDispositionForm;
 
 const Container = styled.div`
-  .form-section {
-    margin: 0;
-    padding-left: 0;
-  }
+  background-color: ${props => props.theme.css.filterBackgroundColor};
+  padding-top: 1rem;
 
   .tab-pane {
     .form-section {

--- a/source/frontend/src/features/mapSideBar/disposition/tabs/fileDetails/detail/update/__snapshots__/UpdateDispositionForm.test.tsx.snap
+++ b/source/frontend/src/features/mapSideBar/disposition/tabs/fileDetails/detail/update/__snapshots__/UpdateDispositionForm.test.tsx.snap
@@ -202,7 +202,7 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
   line-height: 2rem;
 }
 
-.c2 {
+.c4 {
   font-weight: bold;
   border-bottom: 0.2rem solid;
   margin-bottom: 2rem;
@@ -216,14 +216,14 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
   border-radius: 0.5rem;
 }
 
-.c4.required::before {
+.c3.required::before {
   content: '*';
   position: absolute;
   top: 0.75rem;
   left: 0rem;
 }
 
-.c3 {
+.c2 {
   font-weight: bold;
 }
 
@@ -261,9 +261,8 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
   opacity: unset;
 }
 
-.c0 .form-section {
-  margin: 0;
-  padding-left: 0;
+.c0 {
+  padding-top: 1rem;
 }
 
 .c0 .tab-pane .form-section {
@@ -281,17 +280,6 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
     <div
       class="c1 form-section"
     >
-      <h2
-        class="c2"
-      >
-        <div
-          class="no-gutters row"
-        >
-          <div
-            class="col"
-          />
-        </div>
-      </h2>
       <div
         class="collapse show"
       >
@@ -302,13 +290,13 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
             class="pr-0 text-left col-4"
           >
             <label
-              class="c3"
+              class="c2"
             >
               Status:
             </label>
           </div>
           <div
-            class="c4 required text-left col"
+            class="c3 required text-left col"
           >
             <div
               class="required form-group"
@@ -371,7 +359,7 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
       class="c1 form-section"
     >
       <h2
-        class="c2"
+        class="c4"
       >
         <div
           class="no-gutters row"
@@ -393,13 +381,13 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
             class="pr-0 text-left col-4"
           >
             <label
-              class="c3"
+              class="c2"
             >
               Ministry project:
             </label>
           </div>
           <div
-            class="c4 text-left col"
+            class="c3 text-left col"
           >
             <div
               class="c5 form-group"
@@ -466,13 +454,13 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
             class="pr-0 text-left col-4"
           >
             <label
-              class="c3"
+              class="c2"
             >
               Funding:
             </label>
           </div>
           <div
-            class="c4 text-left col"
+            class="c3 text-left col"
           >
             <div
               class="form-group"
@@ -497,7 +485,7 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
       class="c1 form-section"
     >
       <h2
-        class="c2"
+        class="c4"
       >
         <div
           class="no-gutters row"
@@ -519,13 +507,13 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
             class="pr-0 text-left col-4"
           >
             <label
-              class="c3"
+              class="c2"
             >
               Assigned date:
             </label>
           </div>
           <div
-            class="c4 text-left col"
+            class="c3 text-left col"
           >
             <div
               class="c6 form-group"
@@ -566,13 +554,13 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
             class="pr-0 text-left col-4"
           >
             <label
-              class="c3"
+              class="c2"
             >
               Disposition completed date:
             </label>
           </div>
           <div
-            class="c4 text-left col"
+            class="c3 text-left col"
           >
             <div
               class="c6 form-group"
@@ -613,7 +601,7 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
       class="c1 form-section"
     >
       <h2
-        class="c2"
+        class="c4"
       >
         <div
           class="no-gutters row"
@@ -635,13 +623,13 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
             class="pr-0 text-left col-4"
           >
             <label
-              class="c3"
+              class="c2"
             >
               Disposition file name:
             </label>
           </div>
           <div
-            class="c4 text-left col"
+            class="c3 text-left col"
           >
             <div
               class="input form-group"
@@ -663,7 +651,7 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
             class="pr-0 text-left col-4"
           >
             <label
-              class="c3"
+              class="c2"
             >
               Reference number:
               <span
@@ -693,7 +681,7 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
             </label>
           </div>
           <div
-            class="c4 text-left col"
+            class="c3 text-left col"
           >
             <div
               class="input form-group"
@@ -715,13 +703,13 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
             class="pr-0 text-left col-4"
           >
             <label
-              class="c3"
+              class="c2"
             >
               Disposition status:
             </label>
           </div>
           <div
-            class="c4 required text-left col"
+            class="c3 required text-left col"
           >
             <div
               class="required form-group"
@@ -785,13 +773,13 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
             class="pr-0 text-left col-4"
           >
             <label
-              class="c3"
+              class="c2"
             >
               Disposition type:
             </label>
           </div>
           <div
-            class="c4 required text-left col"
+            class="c3 required text-left col"
           >
             <div
               class="required form-group"
@@ -846,7 +834,7 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
             class="pr-0 text-left col-4"
           >
             <label
-              class="c3"
+              class="c2"
             >
               Initiating document:
               <span
@@ -876,7 +864,7 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
             </label>
           </div>
           <div
-            class="c4 text-left col"
+            class="c3 text-left col"
           >
             <div
               class="required form-group"
@@ -931,7 +919,7 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
             class="pr-0 text-left col-4"
           >
             <label
-              class="c3"
+              class="c2"
             >
               Initiating document date:
               <span
@@ -961,7 +949,7 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
             </label>
           </div>
           <div
-            class="c4 text-left col"
+            class="c3 text-left col"
           >
             <div
               class="c6 form-group"
@@ -1002,13 +990,13 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
             class="pr-0 text-left col-4"
           >
             <label
-              class="c3"
+              class="c2"
             >
               Physical file status:
             </label>
           </div>
           <div
-            class="c4 text-left col"
+            class="c3 text-left col"
           >
             <div
               class="form-group"
@@ -1055,13 +1043,13 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
             class="pr-0 text-left col-4"
           >
             <label
-              class="c3"
+              class="c2"
             >
               Initiating branch:
             </label>
           </div>
           <div
-            class="c4 text-left col"
+            class="c3 text-left col"
           >
             <div
               class="form-group"
@@ -1122,13 +1110,13 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
             class="pr-0 text-left col-4"
           >
             <label
-              class="c3"
+              class="c2"
             >
               Ministry region:
             </label>
           </div>
           <div
-            class="c4 required text-left col"
+            class="c3 required text-left col"
           >
             <div
               class="required d-flex form-group"
@@ -1174,7 +1162,7 @@ exports[`UpdateDispositionForm component renders as expected 1`] = `
       class="c1 form-section"
     >
       <h2
-        class="c2"
+        class="c4"
       >
         <div
           class="no-gutters row"


### PR DESCRIPTION
In this PR the file validation logic was refactored/moved into a separate method to encapsulate all checks in one place. Previous implementation had the checks spread out across several code paths.
Having it in a single method also increases maintainability - if the business rules driving those checks ever change.