### PR TITLE
PSP-8198 tenant json loading bug

### DIFF
--- a/source/frontend/.gitignore
+++ b/source/frontend/.gitignore
@@ -19,6 +19,8 @@ build/
 .env.development.local
 .env.test.local
 .env.production.local
+# ignore config file for a local web server (to test production builds)
+lws.config.js
 
 npm-debug.log*
 yarn-debug.log*

--- a/source/frontend/public/tenants/tenant.json
+++ b/source/frontend/public/tenants/tenant.json
@@ -1,20 +1,46 @@
 {
-  "title": "Default Tenant Name test",
+  "id": "MOTI",
+  "title": "Property Information Management System",
   "shortName": "PIMS",
+  "colour": "#003366",
   "logo": {
-    "favicon": "",
-    "image": "",
-    "imageWithText": ""
+    "favicon": "/tenants/MOTI/favicon.ico",
+    "image": "/tenants/MOTI/PIMS-logo.png",
+    "imageWithText": "/tenants/MOTI/PIMS-logo-with-text.png"
   },
   "login": {
-    "title": "",
-    "heading": "",
-    "body": ""
+    "title": "MOTI Property Information Management System (PIMS)",
+    "heading": "PIMS enables you to view highways and properties owned by the Ministry of Transportation and Infrastructure",
+    "body": "WARNING: Not all data included within has been vetted for accuracy and completeness. Please use caution when proceeding and confirm data before relying on it.",
+    "backgroundImage": "/tenants/MOTI/background-image.jpg"
   },
   "layers": [],
   "propertiesUrl": "ogs-internal/ows?service=wfs&request=GetFeature&typeName=PIMS_PROPERTY_LOCATION_VW&outputformat=json&srsName=EPSG:4326&version=2.0.0&",
   "parcelMap": {
     "url": "https://openmaps.gov.bc.ca/geo/pub/WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_SVW/ows",
     "name": "pub:WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_SVW"
-  }
+  },
+  "electoralLayerUrl": "https://openmaps.gov.bc.ca/geo/pub/WHSE_ADMIN_BOUNDARIES.EBC_ELECTORAL_DISTS_BS10_SVW/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=1.3.0&outputFormat=application/json&typeNames=pub:WHSE_ADMIN_BOUNDARIES.EBC_ELECTORAL_DISTS_BS10_SVW",
+  "municipalLayerUrl": "https://openmaps.gov.bc.ca/geo/pub/WHSE_LEGAL_ADMIN_BOUNDARIES.ABMS_MUNICIPALITIES_SP/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=1.3.0&outputFormat=application/json&typeNames=pub:WHSE_LEGAL_ADMIN_BOUNDARIES.ABMS_MUNICIPALITIES_SP",
+  "parcelsLayerUrl": "https://openmaps.gov.bc.ca/geo/pub/WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_SVW/wfs?service=WFS&REQUEST=GetFeature&VERSION=1.3.0&outputFormat=application/json&typeNames=pub:WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_SVW",
+  "regionalLayerUrl": "https://openmaps.gov.bc.ca/geo/pub/WHSE_LEGAL_ADMIN_BOUNDARIES.ABMS_REGIONAL_DISTRICTS_SP/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=1.3.0&outputFormat=application/json&typeNames=pub:WHSE_LEGAL_ADMIN_BOUNDARIES.ABMS_REGIONAL_DISTRICTS_SP",
+  "motiRegionLayerUrl": "https://openmaps.gov.bc.ca/geo/pub/WHSE_ADMIN_BOUNDARIES.TADM_MOT_REGIONAL_BNDRY_POLY/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=1.3.0&outputFormat=application/json&typeNames=pub:WHSE_ADMIN_BOUNDARIES.TADM_MOT_REGIONAL_BNDRY_POLY",
+  "hwyDistrictLayerUrl": "https://openmaps.gov.bc.ca/geo/pub/WHSE_ADMIN_BOUNDARIES.TADM_MOT_DISTRICT_BNDRY_POLY/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=1.3.0&outputFormat=application/json&typeNames=pub:WHSE_ADMIN_BOUNDARIES.TADM_MOT_DISTRICT_BNDRY_POLY",
+  "alrLayerUrl": "https://openmaps.gov.bc.ca/geo/pub/WHSE_LEGAL_ADMIN_BOUNDARIES.OATS_ALR_POLYS/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=1.3.0&outputFormat=application/json&typeNames=pub:WHSE_LEGAL_ADMIN_BOUNDARIES.OATS_ALR_POLYS",
+  "reservesLayerUrl": "https://openmaps.gov.bc.ca/geo/pub/WHSE_ADMIN_BOUNDARIES.ADM_INDIAN_RESERVES_BANDS_SP/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=1.3.0&outputFormat=application/json&typeNames=pub:WHSE_ADMIN_BOUNDARIES.ADM_INDIAN_RESERVES_BANDS_SP",
+  "boundaryLayerUrl": "/ogs-internal/ows?service=wfs&request=GetFeature&typeName=PIMS_PROPERTY_BOUNDARY_VW&outputformat=json&version=2.0.0",
+  "bcAssessment": {
+    "url": "https://delivery.apps.gov.bc.ca/ext/sgw/geo.bca",
+    "names": {
+      "LEGAL_DESCRIPTION": "geo.bca:WHSE_HUMAN_CULTURAL_ECONOMIC.BCA_FOLIO_LEGAL_DESCRIPTS_SV",
+      "ADDRESSES": "geo.bca:WHSE_HUMAN_CULTURAL_ECONOMIC.BCA_FOLIO_ADDRESSES_SV",
+      "FOLIO_DESCRIPTION": "geo.bca:WHSE_HUMAN_CULTURAL_ECONOMIC.BCA_FOLIO_DESCRIPTIONS_SV",
+      "CHARGES": "geo.bca:WHSE_HUMAN_CULTURAL_ECONOMIC.BCA_FOLIO_LAND_CHARS_SV",
+      "VALUES": "geo.bca:WHSE_HUMAN_CULTURAL_ECONOMIC.BCA_FOLIO_GNRL_PROP_VALUES_SV",
+      "SALES": "geo.bca:WHSE_HUMAN_CULTURAL_ECONOMIC.BCA_FOLIO_SALES_SV"
+    }
+  },
+  "idlePromptTimeout": 15,
+  "idleTimeout": 15,
+  "pimsTrainingResourceUrl": "https://sp.th.gov.bc.ca/sites/PropertiesServices/Project%20Management/03.%20Execution%20and%20Control/PIMS%20Training"
 }

--- a/source/frontend/src/serviceWorker.ignore.ts
+++ b/source/frontend/src/serviceWorker.ignore.ts
@@ -26,7 +26,7 @@ type Config = {
 export function register(config?: Config) {
   if (import.meta.env.PROD && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
-    const publicUrl = new URL(import.meta.env.PUBLIC_URL, window.location.href);
+    const publicUrl = new URL(import.meta.env.BASE_URL, window.location.href);
     if (publicUrl.origin !== window.location.origin) {
       // Our service worker won't work if PUBLIC_URL is on a different origin
       // from what our page is served on. This might happen if a CDN is used to
@@ -35,7 +35,7 @@ export function register(config?: Config) {
     }
 
     window.addEventListener('load', () => {
-      const swUrl = `${import.meta.env.PUBLIC_URL}/service-worker.js`;
+      const swUrl = `${import.meta.env.BASE_URL}/service-worker.js`;
 
       if (isLocalhost) {
         // This is running on localhost. Let's check if a service worker still exists or not.

--- a/source/frontend/src/tenants/tenant.tsx
+++ b/source/frontend/src/tenants/tenant.tsx
@@ -48,7 +48,7 @@ export const TenantProvider: React.FC<React.PropsWithChildren<unknown>> = props 
       }
     } else {
       // Fetch the configuration file generated for the environment.
-      const r = await axios.get<ITenantConfig>(`${import.meta.env.PUBLIC_URL}/tenants/tenant.json`);
+      const r = await axios.get<ITenantConfig>('tenants/tenant.json');
       const fileTenantConfig = await r.data;
       setTenant({ ...defaultTenant, ...fileTenantConfig });
     }

--- a/source/frontend/vite.config.ts
+++ b/source/frontend/vite.config.ts
@@ -1,10 +1,10 @@
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import { defineConfig } from 'vite';
+import viteCompression from 'vite-plugin-compression';
 import eslint from 'vite-plugin-eslint';
 import svgr from 'vite-plugin-svgr';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
-import viteCompression from 'vite-plugin-compression';
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
The transition to VITE surfaced a bug loading the **tenant.json** file that contains application configuration information. This file is injected into live environments via a config-map. However, in local development we use a hard-coded typescript file with the configuration (which made it harder to reproduce this issue locally)

This PR:

- fixes the loading of tenant.json (PUBLIC_URL env var is not available in vite)
- adds a default tenant.json for local development 
  - this can be achieved by deleting the env var `VITE_TENANT=MOTI` from your env file. If you keep the env var, then the hard-coded configuration will be used.
