### PR TITLE
PSP-8198 Vite fix

### DIFF
--- a/source/frontend/src/tenants/tenant.tsx
+++ b/source/frontend/src/tenants/tenant.tsx
@@ -48,7 +48,7 @@ export const TenantProvider: React.FC<React.PropsWithChildren<unknown>> = props 
       }
     } else {
       // Fetch the configuration file generated for the environment.
-      const r = await axios.get<ITenantConfig>('tenants/tenant.json');
+      const r = await axios.get<ITenantConfig>('/tenants/tenant.json');
       const fileTenantConfig = await r.data;
       setTenant({ ...defaultTenant, ...fileTenantConfig });
     }

--- a/source/frontend/vite.config.ts
+++ b/source/frontend/vite.config.ts
@@ -64,6 +64,8 @@ export default defineConfig({
     svgr({
       include: '**/*.svg?react',
     }),
-    viteCompression(),
+    viteCompression({
+      filter: /\.(js|mjs|css|html)$/i,
+    }),
   ],
 });


### PR DESCRIPTION
Load **tenant.json** from root URL. Also disable gzip compression of json files because we override the original json on OpenShift but if the gzip remains, it takes precedence over the override.