### PR TITLE
PSP-8203 FT: map icon that hovers when you try to choose property on the map is not displayed

### DIFF
--- a/source/frontend/src/features/properties/map/MapContainer.tsx
+++ b/source/frontend/src/features/properties/map/MapContainer.tsx
@@ -45,6 +45,7 @@ const MapContainer: React.FC<React.PropsWithChildren<MapContainerProps>> = () =>
   );
 };
 
+// prettier-ignore
 const StyleMapView = styled.div`
   display: flex;
   flex-direction: row;
@@ -52,7 +53,9 @@ const StyleMapView = styled.div`
   &.draft-cursor,
   &.draft-cursor .leaflet-grab,
   &.draft-cursor .leaflet-interactive {
-    cursor: url(${DraftSvg}) 15 45, pointer;
+    // when passing a URL of SVG to a manually constructed url(), the variable should be wrapped within double quotes.
+    // ref: https://vitejs.dev/guide/assets
+    cursor: url("${DraftSvg}") 15 45, pointer;
   }
 `;
 

--- a/source/frontend/src/features/properties/map/__snapshots__/MapContainer.test.tsx.snap
+++ b/source/frontend/src/features/properties/map/__snapshots__/MapContainer.test.tsx.snap
@@ -393,7 +393,7 @@ exports[`MapContainer Renders the map 1`] = `
 .c0.draft-cursor,
 .c0.draft-cursor .leaflet-grab,
 .c0.draft-cursor .leaflet-interactive {
-  cursor: url(icon-draft.svg) 15 45,pointer;
+  cursor: url("icon-draft.svg") 15 45,pointer;
 }
 
 <div


### PR DESCRIPTION
This was a weird asset loading bug caused by migration to **vite**. Inlined SVGs are converted to data URLs when small enough (< 4kb) and those data urls need to be surrounded with quotes - ie in CSS: 

```css
.c0.draft-cursor .leaflet-interactive {
  cursor: url("data:image/svg+xml, ...") 15 45, pointer;
}
```

our code was missing those quotes in the CSS for `url()` and so the icon was not loading on production builds. launching the frontend via "npm start" locally does not show this bug because the asset/svg is loaded via an URL in development mode (vs a data URL).