### PR TITLE
PSP-8094, PSP-8095: Warn user that property is part of an existing file

### DIFF
--- a/source/backend/api/Areas/Property/Controllers/PropertyController.cs
+++ b/source/backend/api/Areas/Property/Controllers/PropertyController.cs
@@ -95,9 +95,25 @@ namespace Pims.Api.Areas.Property.Controllers
         [ProducesResponseType(typeof(PropertyModel), 200)]
         [SwaggerOperation(Tags = new[] { "property" })]
         [TypeFilter(typeof(NullJsonResultFilter))]
-        public IActionResult GetConceptPropertyWithId(string pid)
+        public IActionResult GetConceptPropertyWithPid(string pid)
         {
             var property = _propertyService.GetByPid(pid);
+            return new JsonResult(_mapper.Map<PropertyModel>(property));
+        }
+
+        /// <summary>
+        /// Get the property for the specified 'pin'.
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet("pin/{pin:int}")]
+        [HasPermission(Permissions.PropertyView)]
+        [Produces("application/json")]
+        [ProducesResponseType(typeof(PropertyModel), 200)]
+        [SwaggerOperation(Tags = new[] { "property" })]
+        [TypeFilter(typeof(NullJsonResultFilter))]
+        public IActionResult GetConceptPropertyWithPin(int pin)
+        {
+            var property = _propertyService.GetByPin(pin);
             return new JsonResult(_mapper.Map<PropertyModel>(property));
         }
 

--- a/source/backend/api/Services/IPropertyService.cs
+++ b/source/backend/api/Services/IPropertyService.cs
@@ -13,6 +13,8 @@ namespace Pims.Api.Services
 
         PimsProperty GetByPid(string pid);
 
+        PimsProperty GetByPin(int pin);
+
         PimsProperty Update(PimsProperty property, bool commitTransaction = true);
 
         PimsProperty RetireProperty(PimsProperty property, bool commitTransaction = true);

--- a/source/backend/api/Services/PropertyService.cs
+++ b/source/backend/api/Services/PropertyService.cs
@@ -98,6 +98,21 @@ namespace Pims.Api.Services
             return property;
         }
 
+        public PimsProperty GetByPin(int pin)
+        {
+            _logger.LogInformation("Getting property with pin {pin}", pin);
+            _user.ThrowIfNotAuthorized(Permissions.PropertyView);
+
+            // return property spatial location in lat/long (4326)
+            var property = _propertyRepository.GetByPin(pin);
+            if (property?.Location != null)
+            {
+                var newCoords = _coordinateService.TransformCoordinates(SpatialReference.BCALBERS, SpatialReference.WGS84, property.Location.Coordinate);
+                property.Location = GeometryHelper.CreatePoint(newCoords, SpatialReference.WGS84);
+            }
+            return property;
+        }
+
         public PimsProperty Update(PimsProperty property, bool commitTransaction = true)
         {
             _logger.LogInformation("Updating property with id {id}", property.Internal_Id);

--- a/source/frontend/src/AppRouter.test.tsx
+++ b/source/frontend/src/AppRouter.test.tsx
@@ -23,7 +23,7 @@ import { lookupCodesSlice } from './store/slices/lookupCodes';
 import { networkSlice } from './store/slices/network/networkSlice';
 import { tenantsSlice } from './store/slices/tenants';
 import { defaultTenant } from './tenants/config/defaultTenant';
-import { act, mockKeycloak, render, RenderOptions, screen, waitFor } from './utils/test-utils';
+import { RenderOptions, mockKeycloak, render, screen } from './utils/test-utils';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -97,6 +97,7 @@ jest.mock('./hooks/pims-api/useApiProperties');
   getPropertyConceptWithIdApi: jest.fn(),
   putPropertyConceptApi: jest.fn(),
   getPropertyConceptWithPidApi: jest.fn(),
+  getPropertyConceptWithPinApi: jest.fn(),
 });
 
 jest.mock('./hooks/pims-api/useApiLeases');

--- a/source/frontend/src/components/propertySelector/search/PropertySelectorSearchContainer.tsx
+++ b/source/frontend/src/components/propertySelector/search/PropertySelectorSearchContainer.tsx
@@ -2,8 +2,7 @@ import { Feature, FeatureCollection, GeoJsonProperties, Geometry } from 'geojson
 import { LatLngLiteral } from 'leaflet';
 import debounce from 'lodash/debounce';
 import isNumber from 'lodash/isNumber';
-import * as React from 'react';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { toast } from 'react-toastify';
 
 import { DistrictCodes, RegionCodes } from '@/constants/index';
@@ -24,9 +23,10 @@ export interface IPropertySelectorSearchContainerProps {
   setSelectedProperties: (properties: IMapProperty[]) => void;
 }
 
-export const PropertySelectorSearchContainer: React.FunctionComponent<
-  React.PropsWithChildren<IPropertySelectorSearchContainerProps>
-> = ({ selectedProperties, setSelectedProperties }) => {
+export const PropertySelectorSearchContainer: React.FC<IPropertySelectorSearchContainerProps> = ({
+  selectedProperties,
+  setSelectedProperties,
+}) => {
   const [layerSearch, setLayerSearch] = useState<ILayerSearchCriteria | undefined>();
   const [searchResults, setSearchResults] = useState<IMapProperty[]>([]);
   const [addressResults, setAddressResults] = useState<IGeocoderResponse[]>([]);
@@ -163,26 +163,24 @@ export const PropertySelectorSearchContainer: React.FunctionComponent<
   };
 
   return (
-    <>
-      <PropertySearchSelectorFormView
-        onSearch={setLayerSearch}
-        selectedProperties={selectedProperties}
-        search={layerSearch}
-        searchResults={searchResults}
-        loading={
-          isMapLayerLoading ||
-          isLoadingSearchAddress ||
-          isLoadingNearestToPoint ||
-          isLoadingSitePids ||
-          findRegionLoading ||
-          findDistrictLoading
-        }
-        onSelectedProperties={setSelectedProperties}
-        addressResults={addressResults}
-        onAddressChange={handleOnAddressChange}
-        onAddressSelect={handleOnAddressSelect}
-      />
-    </>
+    <PropertySearchSelectorFormView
+      onSearch={setLayerSearch}
+      selectedProperties={selectedProperties}
+      search={layerSearch}
+      searchResults={searchResults}
+      loading={
+        isMapLayerLoading ||
+        isLoadingSearchAddress ||
+        isLoadingNearestToPoint ||
+        isLoadingSitePids ||
+        findRegionLoading ||
+        findDistrictLoading
+      }
+      onSelectedProperties={setSelectedProperties}
+      addressResults={addressResults}
+      onAddressChange={handleOnAddressChange}
+      onAddressSelect={handleOnAddressSelect}
+    />
   );
 };
 

--- a/source/frontend/src/features/mapSideBar/acquisition/AcquisitionContainer.tsx
+++ b/source/frontend/src/features/mapSideBar/acquisition/AcquisitionContainer.tsx
@@ -263,6 +263,10 @@ export const AcquisitionContainer: React.FunctionComponent<IAcquisitionContainer
     return true;
   };
 
+  const confirmBeforeAdd = async () => {
+    return false;
+  };
+
   const onUpdateProperties = (
     file: ApiGen_Concepts_File,
   ): Promise<ApiGen_Concepts_File | undefined> => {
@@ -321,6 +325,7 @@ export const AcquisitionContainer: React.FunctionComponent<IAcquisitionContainer
       onCancelConfirm={handleCancelConfirm}
       onUpdateProperties={onUpdateProperties}
       onSuccess={onSuccess}
+      confirmBeforeAdd={confirmBeforeAdd}
       canRemove={canRemove}
       formikRef={formikRef}
       isFormValid={isValid}

--- a/source/frontend/src/features/mapSideBar/acquisition/AcquisitionView.test.tsx
+++ b/source/frontend/src/features/mapSideBar/acquisition/AcquisitionView.test.tsx
@@ -20,12 +20,12 @@ import { mockNotesResponse } from '@/mocks/noteResponses.mock';
 import { getUserMock } from '@/mocks/user.mock';
 import { lookupCodesSlice } from '@/store/slices/lookupCodes';
 import { prettyFormatUTCDate } from '@/utils';
-import { act, render, RenderOptions, userEvent, waitFor } from '@/utils/test-utils';
+import { RenderOptions, act, render, userEvent, waitFor } from '@/utils/test-utils';
 
+import { getMockApiTakes } from '@/mocks/takes.mock';
 import { SideBarContextProvider } from '../context/sidebarContext';
 import { FileTabType } from '../shared/detail/FileTabs';
 import AcquisitionView, { IAcquisitionViewProps } from './AcquisitionView';
-import { getMockApiTakes } from '@/mocks/takes.mock';
 
 // mock auth library
 jest.mock('@react-keycloak/web');
@@ -50,6 +50,7 @@ const onMenuChange = jest.fn();
 const onSuccess = jest.fn();
 const onCancelConfirm = jest.fn();
 const onUpdateProperties = jest.fn();
+const confirmBeforeAdd = jest.fn();
 const canRemove = jest.fn();
 const setContainerState = jest.fn();
 const setIsEditing = jest.fn();
@@ -73,6 +74,7 @@ const DEFAULT_PROPS: IAcquisitionViewProps = {
   onSuccess,
   onCancelConfirm,
   onUpdateProperties,
+  confirmBeforeAdd,
   canRemove,
   isEditing: false,
   setIsEditing,

--- a/source/frontend/src/features/mapSideBar/acquisition/AcquisitionView.tsx
+++ b/source/frontend/src/features/mapSideBar/acquisition/AcquisitionView.tsx
@@ -26,6 +26,7 @@ import { SideBarContext } from '../context/sidebarContext';
 import { InventoryTabNames } from '../property/InventoryTabs';
 import { FilePropertyRouter } from '../router/FilePropertyRouter';
 import { FileTabType } from '../shared/detail/FileTabs';
+import { PropertyForm } from '../shared/models';
 import SidebarFooter from '../shared/SidebarFooter';
 import UpdateProperties from '../shared/update/properties/UpdateProperties';
 import { AcquisitionContainerState } from './AcquisitionContainer';
@@ -43,7 +44,7 @@ export interface IAcquisitionViewProps {
   onSuccess: () => void;
   onCancelConfirm: () => void;
   onUpdateProperties: (file: ApiGen_Concepts_File) => Promise<ApiGen_Concepts_File | undefined>;
-  confirmBeforeAdd: (propertyId: number) => Promise<boolean>;
+  confirmBeforeAdd: (propertyForm: PropertyForm) => Promise<boolean>;
   canRemove: (propertyId: number) => Promise<boolean>;
   isEditing: boolean;
   setIsEditing: (value: boolean) => void;

--- a/source/frontend/src/features/mapSideBar/acquisition/AcquisitionView.tsx
+++ b/source/frontend/src/features/mapSideBar/acquisition/AcquisitionView.tsx
@@ -115,6 +115,12 @@ export const AcquisitionView: React.FunctionComponent<IAcquisitionViewProps> = (
             onSuccess={onSuccess}
             updateFileProperties={onUpdateProperties}
             confirmBeforeAdd={confirmBeforeAdd}
+            confirmBeforeAddMessage={
+              <>
+                <p>This property has already been added to one or more acquisition files.</p>
+                <p>Do you want to acknowledge and proceed?</p>
+              </>
+            }
             canRemove={canRemove}
             formikRef={formikRef}
           />

--- a/source/frontend/src/features/mapSideBar/acquisition/AcquisitionView.tsx
+++ b/source/frontend/src/features/mapSideBar/acquisition/AcquisitionView.tsx
@@ -43,6 +43,7 @@ export interface IAcquisitionViewProps {
   onSuccess: () => void;
   onCancelConfirm: () => void;
   onUpdateProperties: (file: ApiGen_Concepts_File) => Promise<ApiGen_Concepts_File | undefined>;
+  confirmBeforeAdd: (propertyId: number) => Promise<boolean>;
   canRemove: (propertyId: number) => Promise<boolean>;
   isEditing: boolean;
   setIsEditing: (value: boolean) => void;
@@ -61,6 +62,7 @@ export const AcquisitionView: React.FunctionComponent<IAcquisitionViewProps> = (
   onShowPropertySelector,
   onSuccess,
   onUpdateProperties,
+  confirmBeforeAdd,
   canRemove,
   isEditing,
   setIsEditing,
@@ -112,6 +114,7 @@ export const AcquisitionView: React.FunctionComponent<IAcquisitionViewProps> = (
             setIsShowingPropertySelector={closePropertySelector}
             onSuccess={onSuccess}
             updateFileProperties={onUpdateProperties}
+            confirmBeforeAdd={confirmBeforeAdd}
             canRemove={canRemove}
             formikRef={formikRef}
           />

--- a/source/frontend/src/features/mapSideBar/acquisition/add/AcquisitionPropertiesSubForm.test.tsx
+++ b/source/frontend/src/features/mapSideBar/acquisition/add/AcquisitionPropertiesSubForm.test.tsx
@@ -20,11 +20,22 @@ jest.mock('@/components/common/mapFSM/MapStateMachineContext');
 
 describe('AcquisitionProperties component', () => {
   // render component under test
-  const setup = (props: { initialForm: AcquisitionForm }, renderOptions: RenderOptions = {}) => {
+  const setup = (
+    props: {
+      initialForm: AcquisitionForm;
+      confirmBeforeAdd?: (propertyId: number) => Promise<boolean>;
+    },
+    renderOptions: RenderOptions = {},
+  ) => {
     const utils = render(
       <>
         <Formik initialValues={props.initialForm} onSubmit={noop}>
-          {formikProps => <AcquisitionPropertiesSubForm formikProps={formikProps} />}
+          {formikProps => (
+            <AcquisitionPropertiesSubForm
+              formikProps={formikProps}
+              confirmBeforeAdd={props.confirmBeforeAdd ?? jest.fn()}
+            />
+          )}
         </Formik>
       </>,
       {

--- a/source/frontend/src/features/mapSideBar/acquisition/add/AcquisitionPropertiesSubForm.tsx
+++ b/source/frontend/src/features/mapSideBar/acquisition/add/AcquisitionPropertiesSubForm.tsx
@@ -8,19 +8,23 @@ import { IMapProperty } from '@/components/propertySelector/models';
 import SelectedPropertyHeaderRow from '@/components/propertySelector/selectedPropertyList/SelectedPropertyHeaderRow';
 import SelectedPropertyRow from '@/components/propertySelector/selectedPropertyList/SelectedPropertyRow';
 import { useBcaAddress } from '@/features/properties/map/hooks/useBcaAddress';
+import { useModalContext } from '@/hooks/useModalContext';
 
 import { AddressForm, PropertyForm } from '../../shared/models';
 import { AcquisitionForm } from './models';
 
-interface AcquisitionPropertiesProp {
+export interface IAcquisitionPropertiesProps {
   formikProps: FormikProps<AcquisitionForm>;
+  confirmBeforeAdd: (propertyId: number) => Promise<boolean>;
 }
 
-export const AcquisitionPropertiesSubForm: React.FunctionComponent<
-  React.PropsWithChildren<AcquisitionPropertiesProp>
-> = ({ formikProps }) => {
+export const AcquisitionPropertiesSubForm: React.FunctionComponent<IAcquisitionPropertiesProps> = ({
+  formikProps,
+  confirmBeforeAdd,
+}) => {
   const { values } = formikProps;
   const { getPrimaryAddressByPid, bcaLoading } = useBcaAddress();
+  const { setModalContent, setDisplayModal } = useModalContext();
 
   return (
     <>
@@ -46,14 +50,48 @@ export const AcquisitionPropertiesSubForm: React.FunctionComponent<
                             ? AddressForm.fromBcaAddress(bcaSummary?.address)
                             : undefined;
                         }
-                        if (
-                          values.properties?.length === 0 &&
-                          index === 0 &&
-                          formProperty.regionName !== 'Cannot determine'
-                        ) {
-                          formikProps.setFieldValue(`region`, formProperty.region);
+
+                        if (formProperty.apiId && (await confirmBeforeAdd(formProperty.apiId))) {
+                          // Require user confirmation before adding property to file
+                          setModalContent({
+                            variant: 'warning',
+                            title: 'User Override Required',
+                            message: (
+                              <>
+                                <p>
+                                  This property has already been added to one or more acquisition
+                                  files.
+                                </p>
+                                <p>Do you want to acknowledge and proceed?</p>
+                              </>
+                            ),
+                            okButtonText: 'Yes',
+                            cancelButtonText: 'No',
+                            handleOk: () => {
+                              if (
+                                values.properties?.length === 0 &&
+                                index === 0 &&
+                                formProperty.regionName !== 'Cannot determine'
+                              ) {
+                                formikProps.setFieldValue(`region`, formProperty.region);
+                              }
+                              push(formProperty);
+                              setDisplayModal(false);
+                            },
+                            handleCancel: () => setDisplayModal(false),
+                          });
+                          setDisplayModal(true);
+                        } else {
+                          // No confirmation needed - just add the property to the file
+                          if (
+                            values.properties?.length === 0 &&
+                            index === 0 &&
+                            formProperty.regionName !== 'Cannot determine'
+                          ) {
+                            formikProps.setFieldValue(`region`, formProperty.region);
+                          }
+                          push(formProperty);
                         }
-                        push(formProperty);
                       });
                     }, Promise.resolve());
                   }}

--- a/source/frontend/src/features/mapSideBar/acquisition/add/AddAcquisitionContainer.tsx
+++ b/source/frontend/src/features/mapSideBar/acquisition/add/AddAcquisitionContainer.tsx
@@ -1,5 +1,5 @@
 import { FormikProps } from 'formik';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import styled from 'styled-components';
@@ -8,8 +8,10 @@ import RealEstateAgent from '@/assets/images/real-estate-agent.svg?react';
 import LoadingBackdrop from '@/components/common/LoadingBackdrop';
 import { useMapStateMachine } from '@/components/common/mapFSM/MapStateMachineContext';
 import MapSideBarLayout from '@/features/mapSideBar/layout/MapSideBarLayout';
+import { usePropertyAssociations } from '@/hooks/repositories/usePropertyAssociations';
 import { getCancelModalProps, useModalContext } from '@/hooks/useModalContext';
 import { ApiGen_Concepts_AcquisitionFile } from '@/models/api/generated/ApiGen_Concepts_AcquisitionFile';
+import { exists } from '@/utils';
 import { featuresetToMapProperty } from '@/utils/mapPropertyUtils';
 
 import { PropertyForm } from '../../shared/models';
@@ -32,6 +34,20 @@ export const AddAcquisitionContainer: React.FC<IAddAcquisitionContainerProps> = 
   const mapMachine = useMapStateMachine();
   const selectedFeatureDataset = mapMachine.selectedFeatureDataset;
 
+  const { execute: getPropertyAssociations } = usePropertyAssociations();
+  const [needsUserConfirmation, setNeedsUserConfirmation] = useState<boolean>(true);
+
+  // Warn user that property is part of an existing research file
+  const confirmBeforeAdd = useCallback(
+    async (propertyId: number) => {
+      const response = await getPropertyAssociations(propertyId);
+      const acquisitionAssociations = response?.acquisitionAssociations ?? [];
+      const otherAcqFiles = acquisitionAssociations.filter(a => exists(a.id));
+      return otherAcqFiles.length > 0;
+    },
+    [getPropertyAssociations],
+  );
+
   const initialForm = useMemo(() => {
     const acquisitionForm = new AcquisitionForm();
     if (selectedFeatureDataset !== null) {
@@ -44,15 +60,6 @@ export const AddAcquisitionContainer: React.FC<IAddAcquisitionContainerProps> = 
     }
     return acquisitionForm;
   }, [selectedFeatureDataset]);
-
-  useEffect(() => {
-    if (!!selectedFeatureDataset && !!formikRef.current) {
-      formikRef.current.resetForm();
-      formikRef.current?.setFieldValue('properties', [
-        PropertyForm.fromMapProperty(featuresetToMapProperty(selectedFeatureDataset)),
-      ]);
-    }
-  }, [initialForm, selectedFeatureDataset]);
 
   const handleSave = async () => {
     // Sets the formik field `isValid` to false at start
@@ -104,6 +111,60 @@ export const AddAcquisitionContainer: React.FC<IAddAcquisitionContainerProps> = 
     }
   };
 
+  const { initialValues } = helper;
+  // Require user confirmation before adding a property to file
+  // This is the flow for Map Marker -> right-click -> create Acquisition File
+  useEffect(() => {
+    const runAsync = async () => {
+      if (exists(initialValues) && exists(formikRef.current) && needsUserConfirmation) {
+        if (initialValues.properties.length > 0) {
+          const formProperty = initialValues.properties[0];
+          if (formProperty.apiId && (await confirmBeforeAdd(formProperty.apiId))) {
+            setModalContent({
+              variant: 'warning',
+              title: 'User Override Required',
+              message: (
+                <>
+                  <p>This property has already been added to one or more acquisition files.</p>
+                  <p>Do you want to acknowledge and proceed?</p>
+                </>
+              ),
+              okButtonText: 'Yes',
+              cancelButtonText: 'No',
+              handleOk: () => {
+                // allow the property to be added to the file being created
+                formikRef.current.resetForm();
+                formikRef.current.setFieldValue('properties', initialValues.properties);
+                setDisplayModal(false);
+                // show the user confirmation modal only once when creating a file
+                setNeedsUserConfirmation(false);
+              },
+              handleCancel: () => {
+                // clear out the properties array as the user did not agree to the popup
+                initialValues.properties.splice(0, initialValues.properties.length);
+                formikRef.current.resetForm();
+                formikRef.current.setFieldValue('properties', initialValues.properties);
+                setDisplayModal(false);
+                // show the user confirmation modal only once when creating a file
+                setNeedsUserConfirmation(false);
+              },
+            });
+            setDisplayModal(true);
+          }
+        }
+      }
+    };
+
+    runAsync();
+  }, [
+    confirmBeforeAdd,
+    initialValues,
+    needsUserConfirmation,
+    selectedFeatureDataset,
+    setDisplayModal,
+    setModalContent,
+  ]);
+
   return (
     <MapSideBarLayout
       showCloseButton
@@ -134,6 +195,7 @@ export const AddAcquisitionContainer: React.FC<IAddAcquisitionContainerProps> = 
           initialValues={helper.initialValues}
           onSubmit={helper.handleSubmit}
           validationSchema={helper.validationSchema}
+          confirmBeforeAdd={confirmBeforeAdd}
         />
       </StyledFormWrapper>
     </MapSideBarLayout>

--- a/source/frontend/src/features/mapSideBar/acquisition/add/AddAcquisitionContainer.tsx
+++ b/source/frontend/src/features/mapSideBar/acquisition/add/AddAcquisitionContainer.tsx
@@ -37,7 +37,7 @@ export const AddAcquisitionContainer: React.FC<IAddAcquisitionContainerProps> = 
   const { execute: getPropertyAssociations } = usePropertyAssociations();
   const [needsUserConfirmation, setNeedsUserConfirmation] = useState<boolean>(true);
 
-  // Warn user that property is part of an existing research file
+  // Warn user that property is part of an existing acquisition file
   const confirmBeforeAdd = useCallback(
     async (propertyId: number) => {
       const response = await getPropertyAssociations(propertyId);

--- a/source/frontend/src/features/mapSideBar/acquisition/add/AddAcquisitionForm.test.tsx
+++ b/source/frontend/src/features/mapSideBar/acquisition/add/AddAcquisitionForm.test.tsx
@@ -16,7 +16,7 @@ const history = createMemoryHistory();
 const validationSchema = jest.fn().mockReturnValue(AddAcquisitionFileYupSchema);
 const onSubmit = jest.fn();
 
-type TestProps = Pick<IAddAcquisitionFormProps, 'initialValues'>;
+type TestProps = Partial<Pick<IAddAcquisitionFormProps, 'initialValues' | 'confirmBeforeAdd'>>;
 jest.mock('@react-keycloak/web');
 
 describe('AddAcquisitionForm component', () => {
@@ -26,7 +26,8 @@ describe('AddAcquisitionForm component', () => {
     const utils = render(
       <AddAcquisitionForm
         ref={formikRef}
-        initialValues={props.initialValues}
+        initialValues={props.initialValues ?? new AcquisitionForm()}
+        confirmBeforeAdd={props.confirmBeforeAdd ?? jest.fn()}
         validationSchema={validationSchema}
         onSubmit={onSubmit}
       />,

--- a/source/frontend/src/features/mapSideBar/acquisition/add/AddAcquisitionForm.tsx
+++ b/source/frontend/src/features/mapSideBar/acquisition/add/AddAcquisitionForm.tsx
@@ -45,13 +45,14 @@ export interface IAddAcquisitionFormProps {
     setSubmitting: (isSubmitting: boolean) => void,
     userOverrides: UserOverrideCode[],
   ) => void | Promise<any>;
+  confirmBeforeAdd: (propertyId: number) => Promise<boolean>;
 }
 
 export const AddAcquisitionForm = React.forwardRef<
   FormikProps<AcquisitionForm>,
   IAddAcquisitionFormProps
 >((props, ref) => {
-  const { initialValues, validationSchema, onSubmit } = props;
+  const { initialValues, validationSchema, onSubmit, confirmBeforeAdd } = props;
   const [showDiffMinistryRegionModal, setShowDiffMinistryRegionModal] =
     React.useState<boolean>(false);
 
@@ -75,7 +76,6 @@ export const AddAcquisitionForm = React.forwardRef<
 
   return (
     <Formik<AcquisitionForm>
-      enableReinitialize
       innerRef={ref}
       initialValues={initialValues}
       validationSchema={validationSchema}
@@ -88,6 +88,7 @@ export const AddAcquisitionForm = React.forwardRef<
             onSubmit={onSubmit}
             showDiffMinistryRegionModal={showDiffMinistryRegionModal}
             setShowDiffMinistryRegionModal={setShowDiffMinistryRegionModal}
+            confirmBeforeAdd={confirmBeforeAdd}
           ></AddAcquisitionDetailSubForm>
         );
       }}
@@ -104,7 +105,14 @@ const AddAcquisitionDetailSubForm: React.FC<{
   ) => void | Promise<any>;
   showDiffMinistryRegionModal: boolean;
   setShowDiffMinistryRegionModal: React.Dispatch<React.SetStateAction<boolean>>;
-}> = ({ formikProps, onSubmit, showDiffMinistryRegionModal, setShowDiffMinistryRegionModal }) => {
+  confirmBeforeAdd: (propertyId: number) => Promise<boolean>;
+}> = ({
+  formikProps,
+  onSubmit,
+  showDiffMinistryRegionModal,
+  setShowDiffMinistryRegionModal,
+  confirmBeforeAdd,
+}) => {
   const [projectProducts, setProjectProducts] = React.useState<
     ApiGen_Concepts_Product[] | undefined
   >(undefined);
@@ -218,7 +226,10 @@ const AddAcquisitionDetailSubForm: React.FC<{
           </SectionField>
         </Section>
         <Section header="Properties to include in this file:">
-          <AcquisitionPropertiesSubForm formikProps={formikProps} />
+          <AcquisitionPropertiesSubForm
+            formikProps={formikProps}
+            confirmBeforeAdd={confirmBeforeAdd}
+          />
         </Section>
 
         <Section header="Acquisition Details">

--- a/source/frontend/src/features/mapSideBar/acquisition/add/__snapshots__/AddAcquisitionContainer.test.tsx.snap
+++ b/source/frontend/src/features/mapSideBar/acquisition/add/__snapshots__/AddAcquisitionContainer.test.tsx.snap
@@ -555,7 +555,7 @@ exports[`AddAcquisitionContainer component renders as expected 1`] = `
                           aria-hidden="true"
                           class="rbt-input-hint"
                           readonly=""
-                          style="background-color: transparent; border-color: transparent; box-shadow: none; color: rgba(0, 0, 0, 0.54); left: 0px; pointer-events: none; position: absolute; top: 0px; width: 100%; border-style: inset inset inset inset; border-width: 2px 2px 2px 2px; line-height: normal; padding: 1px 1px 1px 1px;"
+                          style="background-color: transparent; border-color: transparent; box-shadow: none; color: rgba(0, 0, 0, 0.54); left: 0px; pointer-events: none; position: absolute; top: 0px; width: 100%;"
                           tabindex="-1"
                           value=""
                         />

--- a/source/frontend/src/features/mapSideBar/acquisition/add/__snapshots__/AddAcquisitionForm.test.tsx.snap
+++ b/source/frontend/src/features/mapSideBar/acquisition/add/__snapshots__/AddAcquisitionForm.test.tsx.snap
@@ -444,7 +444,7 @@ exports[`AddAcquisitionForm component renders as expected 1`] = `
                     aria-hidden="true"
                     class="rbt-input-hint"
                     readonly=""
-                    style="background-color: transparent; border-color: transparent; box-shadow: none; color: rgba(0, 0, 0, 0.54); left: 0px; pointer-events: none; position: absolute; top: 0px; width: 100%; border-style: inset inset inset inset; border-width: 2px 2px 2px 2px; line-height: normal; padding: 1px 1px 1px 1px;"
+                    style="background-color: transparent; border-color: transparent; box-shadow: none; color: rgba(0, 0, 0, 0.54); left: 0px; pointer-events: none; position: absolute; top: 0px; width: 100%;"
                     tabindex="-1"
                     value=""
                   />

--- a/source/frontend/src/features/mapSideBar/disposition/DispositionContainer.tsx
+++ b/source/frontend/src/features/mapSideBar/disposition/DispositionContainer.tsx
@@ -268,6 +268,10 @@ export const DispositionContainer: React.FunctionComponent<IDispositionContainer
     return true;
   };
 
+  const confirmBeforeAdd = async () => {
+    return false;
+  };
+
   // UI components
   const loading =
     loadingDispositionFile ||
@@ -288,6 +292,7 @@ export const DispositionContainer: React.FunctionComponent<IDispositionContainer
         onShowPropertySelector={onShowPropertySelector}
         onUpdateProperties={onUpdateProperties}
         onSuccess={onSuccess}
+        confirmBeforeAdd={confirmBeforeAdd}
         canRemove={canRemove}
         formikRef={formikRef}
         isFormValid={isValid}

--- a/source/frontend/src/features/mapSideBar/disposition/DispositionView.test.tsx
+++ b/source/frontend/src/features/mapSideBar/disposition/DispositionView.test.tsx
@@ -16,7 +16,7 @@ import { rest, server } from '@/mocks/msw/server';
 import { getUserMock } from '@/mocks/user.mock';
 import { lookupCodesSlice } from '@/store/slices/lookupCodes';
 import { prettyFormatUTCDate } from '@/utils';
-import { act, render, RenderOptions, userEvent, waitFor } from '@/utils/test-utils';
+import { RenderOptions, act, render, userEvent } from '@/utils/test-utils';
 
 import DispositionView, { IDispositionViewProps } from './DispositionView';
 
@@ -33,6 +33,7 @@ const onCancel = jest.fn();
 const onMenuChange = jest.fn();
 const onSuccess = jest.fn();
 const onUpdateProperties = jest.fn();
+const confirmBeforeAdd = jest.fn();
 const canRemove = jest.fn();
 const setIsEditing = jest.fn();
 const onEditFileProperties = jest.fn();
@@ -54,6 +55,7 @@ const DEFAULT_PROPS: IDispositionViewProps = {
   onMenuChange,
   onSuccess,
   onUpdateProperties,
+  confirmBeforeAdd,
   canRemove,
   isEditing: false,
   setIsEditing,

--- a/source/frontend/src/features/mapSideBar/disposition/DispositionView.tsx
+++ b/source/frontend/src/features/mapSideBar/disposition/DispositionView.tsx
@@ -40,6 +40,7 @@ export interface IDispositionViewProps {
   onShowPropertySelector: () => void;
   onSuccess: (updateProperties?: boolean, updateFile?: boolean) => void;
   onUpdateProperties: (file: ApiGen_Concepts_File) => Promise<ApiGen_Concepts_File | undefined>;
+  confirmBeforeAdd: (propertyId: number) => Promise<boolean>;
   canRemove: (propertyId: number) => Promise<boolean>;
   isEditing: boolean;
   setIsEditing: (value: boolean) => void;
@@ -57,6 +58,7 @@ export const DispositionView: React.FunctionComponent<IDispositionViewProps> = (
   onShowPropertySelector,
   onSuccess,
   onUpdateProperties,
+  confirmBeforeAdd,
   canRemove,
   isEditing,
   setIsEditing,
@@ -105,6 +107,7 @@ export const DispositionView: React.FunctionComponent<IDispositionViewProps> = (
             setIsShowingPropertySelector={closePropertySelector}
             onSuccess={onSuccess}
             updateFileProperties={onUpdateProperties}
+            confirmBeforeAdd={confirmBeforeAdd}
             canRemove={canRemove}
             formikRef={formikRef}
           />

--- a/source/frontend/src/features/mapSideBar/disposition/DispositionView.tsx
+++ b/source/frontend/src/features/mapSideBar/disposition/DispositionView.tsx
@@ -26,6 +26,7 @@ import { SideBarContext } from '../context/sidebarContext';
 import { InventoryTabNames } from '../property/InventoryTabs';
 import FilePropertyRouter from '../router/FilePropertyRouter';
 import { FileTabType } from '../shared/detail/FileTabs';
+import { PropertyForm } from '../shared/models';
 import SidebarFooter from '../shared/SidebarFooter';
 import UpdateProperties from '../shared/update/properties/UpdateProperties';
 import { DispositionHeader } from './common/DispositionHeader';
@@ -40,7 +41,7 @@ export interface IDispositionViewProps {
   onShowPropertySelector: () => void;
   onSuccess: (updateProperties?: boolean, updateFile?: boolean) => void;
   onUpdateProperties: (file: ApiGen_Concepts_File) => Promise<ApiGen_Concepts_File | undefined>;
-  confirmBeforeAdd: (propertyId: number) => Promise<boolean>;
+  confirmBeforeAdd: (propertyForm: PropertyForm) => Promise<boolean>;
   canRemove: (propertyId: number) => Promise<boolean>;
   isEditing: boolean;
   setIsEditing: (value: boolean) => void;

--- a/source/frontend/src/features/mapSideBar/research/ResearchContainer.test.tsx
+++ b/source/frontend/src/features/mapSideBar/research/ResearchContainer.test.tsx
@@ -15,6 +15,7 @@ import { act, render, RenderOptions, waitForElementToBeRemoved } from '@/utils/t
 
 import { SideBarContextProvider, TypedFile } from '../context/sidebarContext';
 import ResearchContainer, { IResearchContainerProps } from './ResearchContainer';
+import ResearchView from './ResearchView';
 
 const history = createMemoryHistory();
 const mockAxios = new MockAdapter(axios);
@@ -44,7 +45,11 @@ describe('ResearchContainer component', () => {
   ) => {
     const utils = render(
       <SideBarContextProvider {...renderOptions?.context}>
-        <ResearchContainer researchFileId={getMockResearchFile().id as number} onClose={onClose} />
+        <ResearchContainer
+          researchFileId={getMockResearchFile().id as number}
+          onClose={onClose}
+          View={ResearchView}
+        />
       </SideBarContextProvider>,
       {
         ...renderOptions,

--- a/source/frontend/src/features/mapSideBar/research/ResearchContainer.tsx
+++ b/source/frontend/src/features/mapSideBar/research/ResearchContainer.tsx
@@ -1,6 +1,5 @@
 import { FormikProps } from 'formik';
-import * as React from 'react';
-import { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 
 import LoadingBackdrop from '@/components/common/LoadingBackdrop';
@@ -205,14 +204,17 @@ export const ResearchContainer: React.FunctionComponent<IResearchContainerProps>
   const canRemove = async () => true;
 
   // Warn user that property is part of an existing research file
-  const confirmBeforeAdd = async (propertyId: number) => {
-    const response = await getPropertyAssociations(propertyId);
-    const researchAssociations = response?.researchAssociations ?? [];
-    const otherResearchFiles = researchAssociations.filter(
-      a => exists(a.id) && a.id !== researchFileId,
-    );
-    return otherResearchFiles.length > 0;
-  };
+  const confirmBeforeAdd = useCallback(
+    async (propertyId: number) => {
+      const response = await getPropertyAssociations(propertyId);
+      const researchAssociations = response?.researchAssociations ?? [];
+      const otherResearchFiles = researchAssociations.filter(
+        a => exists(a.id) && a.id !== researchFileId,
+      );
+      return otherResearchFiles.length > 0;
+    },
+    [getPropertyAssociations, researchFileId],
+  );
 
   const onUpdateProperties = (
     file: ApiGen_Concepts_File,

--- a/source/frontend/src/features/mapSideBar/research/ResearchView.tsx
+++ b/source/frontend/src/features/mapSideBar/research/ResearchView.tsx
@@ -15,6 +15,7 @@ import { exists, getFilePropertyName, stripTrailingSlash } from '@/utils';
 import { SideBarContext } from '../context/sidebarContext';
 import FilePropertyRouter from '../router/FilePropertyRouter';
 import { FileTabType } from '../shared/detail/FileTabs';
+import { PropertyForm } from '../shared/models';
 import SidebarFooter from '../shared/SidebarFooter';
 import UpdateProperties from '../shared/update/properties/UpdateProperties';
 import ResearchHeader from './common/ResearchHeader';
@@ -36,7 +37,7 @@ export interface IResearchViewProps {
   onCancel: () => void;
   onMenuChange: (selectedIndex: number) => void;
   onUpdateProperties: (file: ApiGen_Concepts_File) => Promise<ApiGen_Concepts_File | undefined>;
-  confirmBeforeAdd: (propertyId: number) => Promise<boolean>;
+  confirmBeforeAdd: (propertyForm: PropertyForm) => Promise<boolean>;
   canRemove: (propertyId: number) => Promise<boolean>;
   onSuccess: () => void;
 }

--- a/source/frontend/src/features/mapSideBar/research/ResearchView.tsx
+++ b/source/frontend/src/features/mapSideBar/research/ResearchView.tsx
@@ -1,26 +1,47 @@
 import { FormikProps } from 'formik';
-import * as React from 'react';
+import React, { useContext } from 'react';
+import { MdTopic } from 'react-icons/md';
 import { matchPath, Route, useHistory, useRouteMatch } from 'react-router-dom';
+import styled from 'styled-components';
 
 import { FileTypes } from '@/constants';
+import FileLayout from '@/features/mapSideBar/layout/FileLayout';
+import MapSideBarLayout from '@/features/mapSideBar/layout/MapSideBarLayout';
 import { InventoryTabNames } from '@/features/mapSideBar/property/InventoryTabs';
+import { ApiGen_Concepts_File } from '@/models/api/generated/ApiGen_Concepts_File';
 import { ApiGen_Concepts_ResearchFile } from '@/models/api/generated/ApiGen_Concepts_ResearchFile';
-import { stripTrailingSlash } from '@/utils';
+import { exists, getFilePropertyName, stripTrailingSlash } from '@/utils';
 
+import { SideBarContext } from '../context/sidebarContext';
 import FilePropertyRouter from '../router/FilePropertyRouter';
 import { FileTabType } from '../shared/detail/FileTabs';
+import SidebarFooter from '../shared/SidebarFooter';
+import { UpdateProperties } from '../shared/update/properties/UpdateProperties';
+import ResearchHeader from './common/ResearchHeader';
+import ResearchMenu from './common/ResearchMenu';
 import ResearchRouter from './ResearchRouter';
 
-export interface IViewSelectorProps {
+export interface IResearchViewProps {
+  // props
   researchFile?: ApiGen_Concepts_ResearchFile;
-  setEditMode: (isEditing: boolean) => void;
+  formikRef: React.RefObject<FormikProps<any>>;
   isEditing: boolean;
+  setEditMode: (isEditing: boolean) => void;
+  isShowingPropertySelector: boolean;
+  setIsShowingPropertySelector: React.Dispatch<React.SetStateAction<boolean>>;
+  isFormValid: boolean;
+  // event handlers
+  onClose: (() => void) | undefined;
+  onSave: () => Promise<void>;
+  onCancel: () => void;
+  onMenuChange: (selectedIndex: number) => void;
+  onUpdateProperties: (file: ApiGen_Concepts_File) => Promise<ApiGen_Concepts_File | undefined>;
+  canRemove: (propertyId: number) => Promise<boolean>;
   onSuccess: () => void;
 }
 
-const ResearchView = React.forwardRef<FormikProps<any>, IViewSelectorProps>((props, formikRef) => {
+const ResearchView: React.FunctionComponent<IResearchViewProps> = props => {
   const match = useRouteMatch();
-
   const { location } = useHistory();
   const propertiesMatch = matchPath<Record<string, string>>(
     location.pathname,
@@ -28,36 +49,97 @@ const ResearchView = React.forwardRef<FormikProps<any>, IViewSelectorProps>((pro
   );
 
   const selectedMenuIndex = propertiesMatch !== null ? Number(propertiesMatch.params.menuIndex) : 0;
+  const menuItems =
+    props.researchFile?.fileProperties?.map(x => getFilePropertyName(x).value) || [];
+  menuItems.unshift('File Summary');
 
-  return (
-    <>
-      <ResearchRouter
-        formikRef={formikRef}
-        isEditing={props.isEditing}
-        setIsEditing={props.setEditMode}
-        defaultFileTab={FileTabType.FILE_DETAILS}
-        defaultPropertyTab={InventoryTabNames.research}
+  const { lastUpdatedBy } = useContext(SideBarContext);
+
+  if (props.isShowingPropertySelector && exists(props.researchFile)) {
+    return (
+      <UpdateProperties
+        file={props.researchFile}
+        setIsShowingPropertySelector={props.setIsShowingPropertySelector}
         onSuccess={props.onSuccess}
-        researchFile={props.researchFile}
+        updateFileProperties={props.onUpdateProperties}
+        canRemove={props.canRemove}
+        formikRef={props.formikRef}
       />
-      <Route
-        path={`${stripTrailingSlash(match.path)}/property/:menuIndex`}
-        render={() => (
-          <FilePropertyRouter
-            formikRef={formikRef}
-            selectedMenuIndex={selectedMenuIndex}
-            file={props.researchFile}
-            fileType={FileTypes.Research}
-            isEditing={props.isEditing}
-            setIsEditing={props.setEditMode}
-            defaultFileTab={FileTabType.FILE_DETAILS}
-            defaultPropertyTab={InventoryTabNames.research}
-            onSuccess={props.onSuccess}
-          />
-        )}
-      />
-    </>
-  );
-});
+    );
+  } else {
+    return (
+      <MapSideBarLayout
+        title={props.isEditing ? 'Update Research File' : 'Research File'}
+        icon={<MdTopic title="User Profile" size="2.5rem" className="mr-2" />}
+        header={<ResearchHeader researchFile={props.researchFile} lastUpdatedBy={lastUpdatedBy} />}
+        footer={
+          props.isEditing && (
+            <SidebarFooter
+              isOkDisabled={props.formikRef?.current?.isSubmitting}
+              onSave={props.onSave}
+              onCancel={props.onCancel}
+              displayRequiredFieldError={!props.isFormValid}
+            />
+          )
+        }
+        onClose={props.onClose}
+        showCloseButton
+      >
+        <FileLayout
+          leftComponent={
+            <ResearchMenu
+              items={menuItems}
+              selectedIndex={selectedMenuIndex}
+              onChange={props.onMenuChange}
+              onEdit={() => {
+                props.setIsShowingPropertySelector(true);
+              }}
+            />
+          }
+          bodyComponent={
+            <StyledFormWrapper>
+              <ResearchRouter
+                formikRef={props.formikRef}
+                isEditing={props.isEditing}
+                setIsEditing={props.setEditMode}
+                defaultFileTab={FileTabType.FILE_DETAILS}
+                defaultPropertyTab={InventoryTabNames.research}
+                onSuccess={props.onSuccess}
+                researchFile={props.researchFile}
+              />
+              <Route
+                path={`${stripTrailingSlash(match.path)}/property/:menuIndex`}
+                render={() => (
+                  <FilePropertyRouter
+                    formikRef={props.formikRef}
+                    selectedMenuIndex={selectedMenuIndex}
+                    file={props.researchFile}
+                    fileType={FileTypes.Research}
+                    isEditing={props.isEditing}
+                    setIsEditing={props.setEditMode}
+                    defaultFileTab={FileTabType.FILE_DETAILS}
+                    defaultPropertyTab={InventoryTabNames.research}
+                    onSuccess={props.onSuccess}
+                  />
+                )}
+              />
+            </StyledFormWrapper>
+          }
+        ></FileLayout>
+      </MapSideBarLayout>
+    );
+  }
+};
 
 export default ResearchView;
+
+const StyledFormWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  text-align: left;
+  height: 100%;
+  overflow-y: auto;
+  padding-right: 1rem;
+  padding-bottom: 1rem;
+`;

--- a/source/frontend/src/features/mapSideBar/research/ResearchView.tsx
+++ b/source/frontend/src/features/mapSideBar/research/ResearchView.tsx
@@ -16,7 +16,7 @@ import { SideBarContext } from '../context/sidebarContext';
 import FilePropertyRouter from '../router/FilePropertyRouter';
 import { FileTabType } from '../shared/detail/FileTabs';
 import SidebarFooter from '../shared/SidebarFooter';
-import { UpdateProperties } from '../shared/update/properties/UpdateProperties';
+import UpdateProperties from '../shared/update/properties/UpdateProperties';
 import ResearchHeader from './common/ResearchHeader';
 import ResearchMenu from './common/ResearchMenu';
 import ResearchRouter from './ResearchRouter';
@@ -36,6 +36,7 @@ export interface IResearchViewProps {
   onCancel: () => void;
   onMenuChange: (selectedIndex: number) => void;
   onUpdateProperties: (file: ApiGen_Concepts_File) => Promise<ApiGen_Concepts_File | undefined>;
+  confirmBeforeAdd: (propertyId: number) => Promise<boolean>;
   canRemove: (propertyId: number) => Promise<boolean>;
   onSuccess: () => void;
 }
@@ -62,6 +63,13 @@ const ResearchView: React.FunctionComponent<IResearchViewProps> = props => {
         setIsShowingPropertySelector={props.setIsShowingPropertySelector}
         onSuccess={props.onSuccess}
         updateFileProperties={props.onUpdateProperties}
+        confirmBeforeAdd={props.confirmBeforeAdd}
+        confirmBeforeAddMessage={
+          <>
+            <p>This property has already been added to one or more research files.</p>
+            <p>Do you want to acknowledge and proceed?</p>
+          </>
+        }
         canRemove={props.canRemove}
         formikRef={props.formikRef}
       />

--- a/source/frontend/src/features/mapSideBar/research/__snapshots__/ResearchContainer.test.tsx.snap
+++ b/source/frontend/src/features/mapSideBar/research/__snapshots__/ResearchContainer.test.tsx.snap
@@ -80,6 +80,20 @@ exports[`ResearchContainer component renders as expected 1`] = `
   cursor: pointer;
 }
 
+.c17 {
+  height: 100%;
+}
+
+.c17 .tab-content {
+  border-radius: 0 0.4rem 0.4rem 0.4rem;
+  height: calc(100% - 2.5rem);
+  overflow-y: auto;
+}
+
+.c17 .tab-content .tab-pane {
+  position: relative;
+}
+
 .c19 {
   padding-top: 1rem;
 }
@@ -111,20 +125,6 @@ exports[`ResearchContainer component renders as expected 1`] = `
 
 .c23 {
   font-weight: bold;
-}
-
-.c17 {
-  height: 100%;
-}
-
-.c17 .tab-content {
-  border-radius: 0 0.4rem 0.4rem 0.4rem;
-  height: calc(100% - 2.5rem);
-  overflow-y: auto;
-}
-
-.c17 .tab-content .tab-pane {
-  position: relative;
 }
 
 .c4 {
@@ -223,7 +223,45 @@ exports[`ResearchContainer component renders as expected 1`] = `
   <div>
     <div
       class="Toastify"
-    />
+    >
+      <div
+        class="Toastify__toast-container Toastify__toast-container--top-right"
+      >
+        <div
+          class="Toastify__toast Toastify__toast--error Toastify--animate Toastify__bounce-enter--top-right"
+          id="eo2d437kf"
+        >
+          <div
+            class="Toastify__toast-body"
+            role="alert"
+          >
+            Failed to retrive last-updated-by information for research file.
+          </div>
+          <button
+            aria-label="close"
+            class="Toastify__close-button Toastify__close-button--error"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 14 16"
+            >
+              <path
+                d="M7.71 8.23l3.75 3.75-1.48 1.48-3.75-3.75-3.75 3.75L1 11.98l3.75-3.75L1 4.48 2.48 3l3.75 3.75L9.98 3l1.48 1.48-3.75 3.75z"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </button>
+          <div
+            aria-hidden="true"
+            aria-label="notification timer"
+            class="Toastify__progress-bar Toastify__progress-bar--animated Toastify__progress-bar--error"
+            role="progressbar"
+            style="animation-duration: 5000ms; animation-play-state: running; opacity: 0;"
+          />
+        </div>
+      </div>
+    </div>
     <div />
     <div
       class=""

--- a/source/frontend/src/features/mapSideBar/research/__snapshots__/ResearchContainer.test.tsx.snap
+++ b/source/frontend/src/features/mapSideBar/research/__snapshots__/ResearchContainer.test.tsx.snap
@@ -223,45 +223,7 @@ exports[`ResearchContainer component renders as expected 1`] = `
   <div>
     <div
       class="Toastify"
-    >
-      <div
-        class="Toastify__toast-container Toastify__toast-container--top-right"
-      >
-        <div
-          class="Toastify__toast Toastify__toast--error Toastify--animate Toastify__bounce-enter--top-right"
-          id="eo2d437kf"
-        >
-          <div
-            class="Toastify__toast-body"
-            role="alert"
-          >
-            Failed to retrive last-updated-by information for research file.
-          </div>
-          <button
-            aria-label="close"
-            class="Toastify__close-button Toastify__close-button--error"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              viewBox="0 0 14 16"
-            >
-              <path
-                d="M7.71 8.23l3.75 3.75-1.48 1.48-3.75-3.75-3.75 3.75L1 11.98l3.75-3.75L1 4.48 2.48 3l3.75 3.75L9.98 3l1.48 1.48-3.75 3.75z"
-                fill-rule="evenodd"
-              />
-            </svg>
-          </button>
-          <div
-            aria-hidden="true"
-            aria-label="notification timer"
-            class="Toastify__progress-bar Toastify__progress-bar--animated Toastify__progress-bar--error"
-            role="progressbar"
-            style="animation-duration: 5000ms; animation-play-state: running; opacity: 0;"
-          />
-        </div>
-      </div>
-    </div>
+    />
     <div />
     <div
       class=""

--- a/source/frontend/src/features/mapSideBar/research/add/AddResearchContainer.test.tsx
+++ b/source/frontend/src/features/mapSideBar/research/add/AddResearchContainer.test.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/components/common/mapFSM/MapStateMachineContext';
 import { mapMachineBaseMock } from '@/mocks/mapFSM.mock';
 import { PMBC_Feature_Properties } from '@/models/layers/parcelMapBC';
-import { act, renderAsync, RenderOptions, userEvent, waitFor } from '@/utils/test-utils';
+import { RenderOptions, act, renderAsync, userEvent, waitFor } from '@/utils/test-utils';
 
 import AddResearchContainer, { IAddResearchContainerProps } from './AddResearchContainer';
 
@@ -36,22 +36,41 @@ jest.mock('react-visibility-sensor', () => {
 jest.mock('@/components/common/mapFSM/MapStateMachineContext');
 (useMapStateMachine as jest.Mock).mockImplementation(() => mapMachineBaseMock);
 
+const mockGetByPidWrapper = {
+  error: undefined,
+  response: undefined,
+  execute: jest.fn(),
+  loading: false,
+};
+
+const mockGetByPinWrapper = {
+  error: undefined,
+  response: undefined,
+  execute: jest.fn(),
+  loading: false,
+};
+
+jest.mock('@/hooks/repositories/usePimsPropertyRepository', () => ({
+  usePimsPropertyRepository: () => {
+    return {
+      getPropertyByPidWrapper: mockGetByPidWrapper,
+      getPropertyByPinWrapper: mockGetByPinWrapper,
+    };
+  },
+}));
+
 describe('AddResearchContainer component', () => {
   const setup = async (
     renderOptions: RenderOptions & IAddResearchContainerProps & Partial<IMapStateMachineContext>,
   ) => {
     // render component under test
-    const utils = await renderAsync(
-      <>
-        <AddResearchContainer onClose={renderOptions.onClose} />
-      </>,
-      {
-        ...renderOptions,
-        claims: [],
-        store: store,
-        history: history,
-      },
-    );
+    const utils = await renderAsync(<AddResearchContainer onClose={renderOptions.onClose} />, {
+      claims: [],
+      useMockAuthentication: true,
+      store,
+      history,
+      ...renderOptions,
+    });
 
     return {
       ...utils,

--- a/source/frontend/src/features/mapSideBar/research/add/AddResearchContainer.tsx
+++ b/source/frontend/src/features/mapSideBar/research/add/AddResearchContainer.tsx
@@ -1,6 +1,5 @@
 import { Formik, FormikProps } from 'formik';
-import * as React from 'react';
-import { useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { MdTopic } from 'react-icons/md';
 import { useHistory } from 'react-router-dom';
 import { toast } from 'react-toastify';
@@ -8,11 +7,13 @@ import styled from 'styled-components';
 
 import { useMapStateMachine } from '@/components/common/mapFSM/MapStateMachineContext';
 import MapSideBarLayout from '@/features/mapSideBar/layout/MapSideBarLayout';
+import { usePropertyAssociations } from '@/hooks/repositories/usePropertyAssociations';
 import useApiUserOverride from '@/hooks/useApiUserOverride';
 import { useInitialMapSelectorProperties } from '@/hooks/useInitialMapSelectorProperties';
 import { getCancelModalProps, useModalContext } from '@/hooks/useModalContext';
 import { ApiGen_Concepts_ResearchFile } from '@/models/api/generated/ApiGen_Concepts_ResearchFile';
 import { UserOverrideCode } from '@/models/api/UserOverrideCode';
+import { exists } from '@/utils';
 import { featuresetToMapProperty } from '@/utils/mapPropertyUtils';
 
 import { PropertyForm } from '../../shared/models';
@@ -26,16 +27,26 @@ export interface IAddResearchContainerProps {
   onClose: () => void;
 }
 
-export const AddResearchContainer: React.FunctionComponent<
-  React.PropsWithChildren<IAddResearchContainerProps>
-> = props => {
+export const AddResearchContainer: React.FunctionComponent<IAddResearchContainerProps> = props => {
   const { onClose } = props;
-
   const history = useHistory();
   const formikRef = useRef<FormikProps<ResearchForm>>(null);
   const mapMachine = useMapStateMachine();
   const selectedFeatureDataset = mapMachine.selectedFeatureDataset;
   const { setModalContent, setDisplayModal } = useModalContext();
+  const { execute: getPropertyAssociations } = usePropertyAssociations();
+  const [needsUserConfirmation, setNeedsUserConfirmation] = useState<boolean>(true);
+
+  // Warn user that property is part of an existing research file
+  const confirmBeforeAdd = useCallback(
+    async (propertyId: number) => {
+      const response = await getPropertyAssociations(propertyId);
+      const researchAssociations = response?.researchAssociations ?? [];
+      const otherResearchFiles = researchAssociations.filter(a => exists(a.id));
+      return otherResearchFiles.length > 0;
+    },
+    [getPropertyAssociations],
+  );
 
   const initialForm = useMemo(() => {
     const researchForm = new ResearchForm();
@@ -46,6 +57,7 @@ export const AddResearchContainer: React.FunctionComponent<
     }
     return researchForm;
   }, [selectedFeatureDataset]);
+
   const { addResearchFile } = useAddResearch();
   const { bcaLoading, initialProperty } = useInitialMapSelectorProperties(selectedFeatureDataset);
   if (initialForm?.properties.length && initialProperty) {
@@ -55,12 +67,51 @@ export const AddResearchContainer: React.FunctionComponent<
     (userOverrideCodes: UserOverrideCode[]) => Promise<any | void>
   >('Failed to add Research File');
 
+  // Require user confirmation before adding a property to file
+  // This is the flow for Map Marker -> right-click -> create Research File
   useEffect(() => {
-    if (!!initialForm && !!formikRef.current) {
-      formikRef.current.resetForm();
-      formikRef.current?.setFieldValue('properties', initialForm.properties);
-    }
-  }, [initialForm]);
+    const runAsync = async () => {
+      if (exists(initialForm) && exists(formikRef.current) && needsUserConfirmation) {
+        if (initialForm.properties.length > 0) {
+          const formProperty = initialForm.properties[0];
+          if (formProperty.apiId && (await confirmBeforeAdd(formProperty.apiId))) {
+            setModalContent({
+              variant: 'warning',
+              title: 'User Override Required',
+              message: (
+                <>
+                  <p>This property has already been added to one or more research files.</p>
+                  <p>Do you want to acknowledge and proceed?</p>
+                </>
+              ),
+              okButtonText: 'Yes',
+              cancelButtonText: 'No',
+              handleOk: () => {
+                // allow the property to be added to the file being created
+                formikRef.current.resetForm();
+                formikRef.current.setFieldValue('properties', initialForm.properties);
+                setDisplayModal(false);
+                // show the user confirmation modal only once when creating a file
+                setNeedsUserConfirmation(false);
+              },
+              handleCancel: () => {
+                // clear out the properties array as the user did not agree to the popup
+                initialForm.properties.splice(0, initialForm.properties.length);
+                formikRef.current.resetForm();
+                formikRef.current.setFieldValue('properties', initialForm.properties);
+                setDisplayModal(false);
+                // show the user confirmation modal only once when creating a file
+                setNeedsUserConfirmation(false);
+              },
+            });
+            setDisplayModal(true);
+          }
+        }
+      }
+    };
+
+    runAsync();
+  }, [confirmBeforeAdd, initialForm, needsUserConfirmation, setDisplayModal, setModalContent]);
 
   const saveResearchFile = async (
     researchFile: ApiGen_Concepts_ResearchFile,
@@ -135,7 +186,7 @@ export const AddResearchContainer: React.FunctionComponent<
           onClose={() => cancelFunc(formikProps.resetForm, formikProps.dirty)}
         >
           <StyledFormWrapper>
-            <AddResearchForm />
+            <AddResearchForm confirmBeforeAdd={confirmBeforeAdd} />
           </StyledFormWrapper>
         </MapSideBarLayout>
       )}

--- a/source/frontend/src/features/mapSideBar/research/add/AddResearchForm.test.tsx
+++ b/source/frontend/src/features/mapSideBar/research/add/AddResearchForm.test.tsx
@@ -9,6 +9,7 @@ import { mapMachineBaseMock } from '@/mocks/mapFSM.mock';
 import { lookupCodesSlice } from '@/store/slices/lookupCodes';
 import { fakeText, fillInput, render, RenderOptions } from '@/utils/test-utils';
 
+import { PropertyForm } from '../../shared/models';
 import { AddResearchFileYupSchema } from './AddResearchFileYupSchema';
 import AddResearchForm from './AddResearchForm';
 import { ResearchForm } from './models';
@@ -27,7 +28,7 @@ describe('AddResearchForm component', () => {
   const setup = (
     renderOptions: RenderOptions & {
       initialValues: ResearchForm;
-      confirmBeforeAdd?: (propertyId: number) => Promise<boolean>;
+      confirmBeforeAdd?: (propertyForm: PropertyForm) => Promise<boolean>;
     },
   ) => {
     const component = render(

--- a/source/frontend/src/features/mapSideBar/research/add/AddResearchForm.test.tsx
+++ b/source/frontend/src/features/mapSideBar/research/add/AddResearchForm.test.tsx
@@ -24,14 +24,21 @@ jest.mock('@/components/common/mapFSM/MapStateMachineContext');
 
 describe('AddResearchForm component', () => {
   // render component under test
-  const setup = (renderOptions: RenderOptions & { initialValues: ResearchForm }) => {
+  const setup = (
+    renderOptions: RenderOptions & {
+      initialValues: ResearchForm;
+      confirmBeforeAdd?: (propertyId: number) => Promise<boolean>;
+    },
+  ) => {
     const component = render(
       <Formik<ResearchForm>
         onSubmit={noop}
         initialValues={renderOptions.initialValues}
         validationSchema={AddResearchFileYupSchema}
       >
-        {formikProps => <AddResearchForm />}
+        {formikProps => (
+          <AddResearchForm confirmBeforeAdd={renderOptions.confirmBeforeAdd ?? jest.fn()} />
+        )}
       </Formik>,
       {
         ...renderOptions,

--- a/source/frontend/src/features/mapSideBar/research/add/AddResearchForm.tsx
+++ b/source/frontend/src/features/mapSideBar/research/add/AddResearchForm.tsx
@@ -5,12 +5,13 @@ import styled from 'styled-components';
 import { Input } from '@/components/common/form/';
 import { Section } from '@/components/common/Section/Section';
 
+import { PropertyForm } from '../../shared/models';
 import { ResearchFileNameGuide } from '../common/ResearchFileNameGuide';
 import { UpdateProjectsSubForm } from '../common/updateProjects/UpdateProjectsSubForm';
 import ResearchProperties from './ResearchProperties';
 
 export interface IAddResearchFormProps {
-  confirmBeforeAdd: (propertyId: number) => Promise<boolean>;
+  confirmBeforeAdd: (formProperty: PropertyForm) => Promise<boolean>;
 }
 
 const AddResearchForm: React.FC<IAddResearchFormProps> = props => {

--- a/source/frontend/src/features/mapSideBar/research/add/AddResearchForm.tsx
+++ b/source/frontend/src/features/mapSideBar/research/add/AddResearchForm.tsx
@@ -11,7 +11,7 @@ import { UpdateProjectsSubForm } from '../common/updateProjects/UpdateProjectsSu
 import ResearchProperties from './ResearchProperties';
 
 export interface IAddResearchFormProps {
-  confirmBeforeAdd: (formProperty: PropertyForm) => Promise<boolean>;
+  confirmBeforeAdd: (propertyForm: PropertyForm) => Promise<boolean>;
 }
 
 const AddResearchForm: React.FC<IAddResearchFormProps> = props => {

--- a/source/frontend/src/features/mapSideBar/research/add/AddResearchForm.tsx
+++ b/source/frontend/src/features/mapSideBar/research/add/AddResearchForm.tsx
@@ -9,7 +9,11 @@ import { ResearchFileNameGuide } from '../common/ResearchFileNameGuide';
 import { UpdateProjectsSubForm } from '../common/updateProjects/UpdateProjectsSubForm';
 import ResearchProperties from './ResearchProperties';
 
-const AddResearchForm: React.FC = () => {
+export interface IAddResearchFormProps {
+  confirmBeforeAdd: (propertyId: number) => Promise<boolean>;
+}
+
+const AddResearchForm: React.FC<IAddResearchFormProps> = props => {
   return (
     <StyledFormWrapper>
       <Section>
@@ -27,7 +31,7 @@ const AddResearchForm: React.FC = () => {
       <Section header="Project">
         <UpdateProjectsSubForm field="researchFileProjects" />
       </Section>
-      <ResearchProperties />
+      <ResearchProperties confirmBeforeAdd={props.confirmBeforeAdd} />
     </StyledFormWrapper>
   );
 };

--- a/source/frontend/src/features/mapSideBar/research/add/ResearchProperties.test.tsx
+++ b/source/frontend/src/features/mapSideBar/research/add/ResearchProperties.test.tsx
@@ -31,7 +31,7 @@ describe('ResearchProperties component', () => {
   const setup = (
     renderOptions: RenderOptions & {
       initialForm: ResearchForm;
-      confirmBeforeAdd?: (propertyId: number) => Promise<boolean>;
+      confirmBeforeAdd?: (propertyForm: PropertyForm) => Promise<boolean>;
     } & Partial<IMapStateMachineContext>,
   ) => {
     // render component under test

--- a/source/frontend/src/features/mapSideBar/research/add/ResearchProperties.test.tsx
+++ b/source/frontend/src/features/mapSideBar/research/add/ResearchProperties.test.tsx
@@ -31,13 +31,14 @@ describe('ResearchProperties component', () => {
   const setup = (
     renderOptions: RenderOptions & {
       initialForm: ResearchForm;
+      confirmBeforeAdd?: (propertyId: number) => Promise<boolean>;
     } & Partial<IMapStateMachineContext>,
   ) => {
     // render component under test
     const component = render(
       <MapStateMachineProvider /*values={{}}*/>
         <Formik initialValues={renderOptions.initialForm} onSubmit={noop}>
-          <ResearchProperties />
+          <ResearchProperties confirmBeforeAdd={renderOptions.confirmBeforeAdd ?? jest.fn()} />
         </Formik>
       </MapStateMachineProvider>,
       {

--- a/source/frontend/src/features/mapSideBar/research/add/ResearchProperties.tsx
+++ b/source/frontend/src/features/mapSideBar/research/add/ResearchProperties.tsx
@@ -8,13 +8,19 @@ import { IMapProperty } from '@/components/propertySelector/models';
 import SelectedPropertyHeaderRow from '@/components/propertySelector/selectedPropertyList/SelectedPropertyHeaderRow';
 import SelectedPropertyRow from '@/components/propertySelector/selectedPropertyList/SelectedPropertyRow';
 import { useBcaAddress } from '@/features/properties/map/hooks/useBcaAddress';
+import { useModalContext } from '@/hooks/useModalContext';
 
 import { AddressForm, PropertyForm } from '../../shared/models';
 import { ResearchForm } from './models';
 
-const ResearchProperties: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => {
+export interface IResearchPropertiesProps {
+  confirmBeforeAdd: (propertyId: number) => Promise<boolean>;
+}
+
+const ResearchProperties: React.FunctionComponent<IResearchPropertiesProps> = props => {
   const { values } = useFormikContext<ResearchForm>();
   const { getPrimaryAddressByPid, bcaLoading } = useBcaAddress();
+  const { setModalContent, setDisplayModal } = useModalContext();
 
   return (
     <Section header="Properties to include in this file:">
@@ -40,7 +46,37 @@ const ResearchProperties: React.FunctionComponent<React.PropsWithChildren<unknow
                             ? AddressForm.fromBcaAddress(bcaSummary?.address)
                             : undefined;
                         }
-                        push(formProperty);
+
+                        if (
+                          formProperty.apiId &&
+                          (await props.confirmBeforeAdd(formProperty.apiId))
+                        ) {
+                          // Require user confirmation before adding property to file
+                          setModalContent({
+                            variant: 'warning',
+                            title: 'User Override Required',
+                            message: (
+                              <>
+                                <p>
+                                  This property has already been added to one or more research
+                                  files.
+                                </p>
+                                <p>Do you want to acknowledge and proceed?</p>
+                              </>
+                            ),
+                            okButtonText: 'Yes',
+                            cancelButtonText: 'No',
+                            handleOk: () => {
+                              push(formProperty);
+                              setDisplayModal(false);
+                            },
+                            handleCancel: () => setDisplayModal(false),
+                          });
+                          setDisplayModal(true);
+                        } else {
+                          // No confirmation needed - just add the property to the file
+                          push(formProperty);
+                        }
                       });
                     }, Promise.resolve());
                   }}

--- a/source/frontend/src/features/mapSideBar/research/add/ResearchProperties.tsx
+++ b/source/frontend/src/features/mapSideBar/research/add/ResearchProperties.tsx
@@ -14,7 +14,7 @@ import { AddressForm, PropertyForm } from '../../shared/models';
 import { ResearchForm } from './models';
 
 export interface IResearchPropertiesProps {
-  confirmBeforeAdd: (formProperty: PropertyForm) => Promise<boolean>;
+  confirmBeforeAdd: (propertyForm: PropertyForm) => Promise<boolean>;
 }
 
 const ResearchProperties: React.FC<IResearchPropertiesProps> = ({ confirmBeforeAdd }) => {

--- a/source/frontend/src/features/mapSideBar/research/add/ResearchProperties.tsx
+++ b/source/frontend/src/features/mapSideBar/research/add/ResearchProperties.tsx
@@ -14,10 +14,10 @@ import { AddressForm, PropertyForm } from '../../shared/models';
 import { ResearchForm } from './models';
 
 export interface IResearchPropertiesProps {
-  confirmBeforeAdd: (propertyId: number) => Promise<boolean>;
+  confirmBeforeAdd: (formProperty: PropertyForm) => Promise<boolean>;
 }
 
-const ResearchProperties: React.FunctionComponent<IResearchPropertiesProps> = props => {
+const ResearchProperties: React.FC<IResearchPropertiesProps> = ({ confirmBeforeAdd }) => {
   const { values } = useFormikContext<ResearchForm>();
   const { getPrimaryAddressByPid, bcaLoading } = useBcaAddress();
   const { setModalContent, setDisplayModal } = useModalContext();
@@ -47,10 +47,7 @@ const ResearchProperties: React.FunctionComponent<IResearchPropertiesProps> = pr
                             : undefined;
                         }
 
-                        if (
-                          formProperty.apiId &&
-                          (await props.confirmBeforeAdd(formProperty.apiId))
-                        ) {
+                        if (await confirmBeforeAdd(formProperty)) {
                           // Require user confirmation before adding property to file
                           setModalContent({
                             variant: 'warning',

--- a/source/frontend/src/features/mapSideBar/router/MapRouter.tsx
+++ b/source/frontend/src/features/mapSideBar/router/MapRouter.tsx
@@ -25,6 +25,7 @@ import ProjectContainer from '../project/ProjectContainer';
 import ProjectContainerView from '../project/ProjectContainerView';
 import AddResearchContainer from '../research/add/AddResearchContainer';
 import ResearchContainer from '../research/ResearchContainer';
+import ResearchView from '../research/ResearchView';
 import AddSubdivisionContainer from '../subdivision/AddSubdivisionContainer';
 import AddSubdivisionContainerView from '../subdivision/AddSubdivisionView';
 
@@ -181,7 +182,11 @@ export const MapRouter: React.FunctionComponent = memo(() => {
       <AppRoute
         path={`/mapview/sidebar/research/:researchId`}
         customRender={({ match }) => (
-          <ResearchContainer researchFileId={Number(match.params.researchId)} onClose={onClose} />
+          <ResearchContainer
+            researchFileId={Number(match.params.researchId)}
+            onClose={onClose}
+            View={ResearchView}
+          />
         )}
         claim={Claims.RESEARCH_VIEW}
         key={'Research'}

--- a/source/frontend/src/features/mapSideBar/shared/update/properties/UpdateProperties.test.tsx
+++ b/source/frontend/src/features/mapSideBar/shared/update/properties/UpdateProperties.test.tsx
@@ -12,8 +12,8 @@ import { getMockResearchFile } from '@/mocks/researchFile.mock';
 import { lookupCodesSlice } from '@/store/slices/lookupCodes';
 import { fillInput, render, RenderOptions, userEvent } from '@/utils/test-utils';
 
-import UpdateProperties, { IUpdatePropertiesProps } from './UpdateProperties';
 import React from 'react';
+import UpdateProperties, { IUpdatePropertiesProps } from './UpdateProperties';
 
 const mockAxios = new MockAdapter(axios);
 jest.mock('@react-keycloak/web');
@@ -45,6 +45,7 @@ describe('UpdateProperties component', () => {
           setIsShowingPropertySelector={setIsShowingPropertySelector}
           onSuccess={onSuccess}
           updateFileProperties={updateFileProperties}
+          confirmBeforeAdd={props.confirmBeforeAdd ?? jest.fn()}
           canRemove={props.canRemove ?? jest.fn()}
           formikRef={React.createRef() as any}
         />

--- a/source/frontend/src/features/mapSideBar/shared/update/properties/UpdateProperties.tsx
+++ b/source/frontend/src/features/mapSideBar/shared/update/properties/UpdateProperties.tsx
@@ -35,9 +35,7 @@ export interface IUpdatePropertiesProps {
   formikRef?: React.RefObject<FormikProps<any>>;
 }
 
-export const UpdateProperties: React.FunctionComponent<
-  React.PropsWithChildren<IUpdatePropertiesProps>
-> = props => {
+export const UpdateProperties: React.FunctionComponent<IUpdatePropertiesProps> = props => {
   const localRef = useRef<FormikProps<FileForm>>(null);
   const formikRef = props.formikRef ? props.formikRef : localRef;
   const formFile = FileForm.fromApi(props.file);

--- a/source/frontend/src/features/mapSideBar/shared/update/properties/UpdateProperties.tsx
+++ b/source/frontend/src/features/mapSideBar/shared/update/properties/UpdateProperties.tsx
@@ -32,7 +32,7 @@ export interface IUpdatePropertiesProps {
     userOverrideCodes: UserOverrideCode[],
   ) => Promise<ApiGen_Concepts_File | undefined>;
   canRemove: (propertyId: number) => Promise<boolean>;
-  confirmBeforeAdd: (propertyId: number) => Promise<boolean>;
+  confirmBeforeAdd: (propertyForm: PropertyForm) => Promise<boolean>;
   confirmBeforeAddMessage?: React.ReactNode;
   formikRef?: React.RefObject<FormikProps<any>>;
 }
@@ -169,10 +169,7 @@ export const UpdateProperties: React.FunctionComponent<IUpdatePropertiesProps> =
                                   : undefined;
                               }
 
-                              if (
-                                formProperty.apiId &&
-                                (await props.confirmBeforeAdd(formProperty.apiId))
-                              ) {
+                              if (await props.confirmBeforeAdd(formProperty)) {
                                 // Require user confirmation before adding property to file
                                 setModalContent({
                                   variant: 'warning',

--- a/source/frontend/src/features/properties/map/MapContainer.test.tsx
+++ b/source/frontend/src/features/properties/map/MapContainer.test.tsx
@@ -11,10 +11,10 @@ import {
   useMapStateMachine,
 } from '@/components/common/mapFSM/MapStateMachineContext';
 import {
+  FeatureSelected,
   emptyPimsBoundaryFeatureCollection,
   emptyPimsLocationFeatureCollection,
   emptyPmbcFeatureCollection,
-  FeatureSelected,
 } from '@/components/common/mapFSM/models';
 import {
   Claims,
@@ -32,21 +32,20 @@ import {
 import leafletMouseSlice from '@/store/slices/leafletMouse/LeafletMouseSlice';
 import { lookupCodesSlice } from '@/store/slices/lookupCodes';
 import {
+  RenderOptions,
   act,
   cleanup,
   mockKeycloak,
-  prettyDOM,
   render,
-  RenderOptions,
   screen,
   userEvent,
   waitFor,
 } from '@/utils/test-utils';
 
-import MapContainer from './MapContainer';
 import { useApiProperties } from '@/hooks/pims-api/useApiProperties';
 import { ApiGen_Base_Page } from '@/models/api/generated/ApiGen_Base_Page';
 import { ApiGen_Concepts_Property } from '@/models/api/generated/ApiGen_Concepts_Property';
+import MapContainer from './MapContainer';
 
 const mockAxios = new MockAdapter(axios);
 jest.mock('@react-keycloak/web');
@@ -82,6 +81,7 @@ jest.mock('react-visibility-sensor', () => {
   getPropertyConceptWithIdApi: jest.fn(),
   getPropertyConceptWithPidApi: jest.fn(),
   putPropertyConceptApi: jest.fn(),
+  getPropertyConceptWithPinApi: jest.fn(),
 });
 
 const mockStore = configureMockStore([thunk]);

--- a/source/frontend/src/hooks/pims-api/useApiProperties.ts
+++ b/source/frontend/src/hooks/pims-api/useApiProperties.ts
@@ -44,6 +44,8 @@ export const useApiProperties = () => {
         api.get<ApiGen_Concepts_Property>(`/properties/${id}`),
       getPropertyConceptWithPidApi: (pid: string) =>
         api.get<ApiGen_Concepts_Property>(`/properties/pid/${pid}`),
+      getPropertyConceptWithPinApi: (pin: number) =>
+        api.get<ApiGen_Concepts_Property>(`/properties/pin/${pin}`),
       putPropertyConceptApi: (property: ApiGen_Concepts_Property) =>
         api.put<ApiGen_Concepts_Property>(`/properties/${property.id}`, property),
     }),

--- a/source/frontend/src/hooks/repositories/usePimsPropertyRepository.ts
+++ b/source/frontend/src/hooks/repositories/usePimsPropertyRepository.ts
@@ -1,5 +1,4 @@
-import { AxiosError } from 'axios';
-import { AxiosResponse } from 'axios';
+import { AxiosError, AxiosResponse } from 'axios';
 import { useCallback, useMemo } from 'react';
 import { toast } from 'react-toastify';
 
@@ -19,6 +18,7 @@ export const usePimsPropertyRepository = () => {
     putPropertyConceptApi,
     getMatchingPropertiesApi,
     getPropertyConceptWithPidApi,
+    getPropertyConceptWithPinApi,
   } = useApiProperties();
 
   const getPropertyWrapper = useApiRequestWrapper({
@@ -38,6 +38,17 @@ export const usePimsPropertyRepository = () => {
       [getPropertyConceptWithPidApi],
     ),
     requestName: 'getPropertyConceptWithPidApi',
+    throwError: true,
+  });
+
+  const getPropertyByPinWrapper = useApiRequestWrapper<
+    (...args: any[]) => Promise<AxiosResponse<ApiGen_Concepts_Property, any>>
+  >({
+    requestFunction: useCallback(
+      async (pin: number) => await getPropertyConceptWithPinApi(pin),
+      [getPropertyConceptWithPinApi],
+    ),
+    requestName: 'getPropertyConceptWithPinApi',
     throwError: true,
   });
 
@@ -77,7 +88,14 @@ export const usePimsPropertyRepository = () => {
       updatePropertyWrapper,
       getMatchingProperties,
       getPropertyByPidWrapper,
+      getPropertyByPinWrapper,
     }),
-    [getPropertyWrapper, updatePropertyWrapper, getMatchingProperties, getPropertyByPidWrapper],
+    [
+      getPropertyWrapper,
+      updatePropertyWrapper,
+      getMatchingProperties,
+      getPropertyByPidWrapper,
+      getPropertyByPinWrapper,
+    ],
   );
 };


### PR DESCRIPTION
I've addressed comments from my previous PR to include the check for properties added via text search (PID and PIN searches). The map selection was already covered.

![add-property-warning](https://github.com/bcgov/PSP/assets/24322224/0fcc33a5-15f6-4b65-bc7d-3320e25dd5a1)
