### PR TITLE
pims document preview - pre-cache.

### DIFF
--- a/source/backend/api/Models/Configuration/MayanConfig.cs
+++ b/source/backend/api/Models/Configuration/MayanConfig.cs
@@ -13,5 +13,9 @@ namespace Pims.Api.Models.Config
         public int UploadRetries { get; set; }
 
         public bool ExposeErrors { get; set; }
+
+        public int ImageRetries { get; set; }
+
+        public int PreviewPages { get; set; }
     }
 }

--- a/source/backend/api/Repositories/Mayan/IEdmsDocumentRepository.cs
+++ b/source/backend/api/Repositories/Mayan/IEdmsDocumentRepository.cs
@@ -47,7 +47,7 @@ namespace Pims.Api.Repositories.Mayan
 
         Task<ExternalResponse<string>> TryDeleteDocumentTypeMetadataTypeAsync(long documentTypeId, long documentTypeMetadataTypeId);
 
-        Task<ExternalResponse<QueryResponse<FilePageModel>>> TryGetFilePageListAsync(long documentId, long documentFileId);
+        Task<ExternalResponse<QueryResponse<FilePageModel>>> TryGetFilePageListAsync(long documentId, long documentFileId, int pageSize, int pageNumber);
 
         Task<HttpResponseMessage> TryGetFilePageImage(long documentId, long documentFileId, long documentFilePageId);
     }

--- a/source/backend/api/Repositories/Mayan/MayanDocumentRepository.cs
+++ b/source/backend/api/Repositories/Mayan/MayanDocumentRepository.cs
@@ -447,12 +447,12 @@ namespace Pims.Api.Repositories.Mayan
             return response;
         }
 
-        public async Task<ExternalResponse<QueryResponse<FilePageModel>>> TryGetFilePageListAsync(long documentId, long documentFileId)
+        public async Task<ExternalResponse<QueryResponse<FilePageModel>>> TryGetFilePageListAsync(long documentId, long documentFileId, int pageSize, int pageNumber)
         {
             _logger.LogDebug("Retrieving page list for mayan file...");
             string authenticationToken = await _authRepository.GetTokenAsync();
 
-            Uri endpoint = new($"{_config.BaseUri}/documents/{documentId}/files/{documentFileId}/pages/");
+            Uri endpoint = new($"{_config.BaseUri}/documents/{documentId}/files/{documentFileId}/pages/?page_size={pageSize}&page={pageNumber}");
 
             var response = await GetAsync<QueryResponse<FilePageModel>>(endpoint, authenticationToken);
 

--- a/source/backend/api/appsettings.json
+++ b/source/backend/api/appsettings.json
@@ -114,7 +114,9 @@
     "ConnectionUser": "[MAYAN_USER]",
     "ConnectionPassword": "[MAYAN_USER_PASSWORD]",
     "ExposeErrors": false,
-    "UploadRetries": 4
+    "UploadRetries": 4,
+    "ImageRetries": 2,
+    "PreviewPages": 10
   },
   "Cdogs": {
     "AuthEndpoint": "[AUTH_ENDPOINT]",

--- a/source/frontend/src/assets/scss/App.scss
+++ b/source/frontend/src/assets/scss/App.scss
@@ -27,6 +27,7 @@
 .tooltip {
   pointer-events: none;
   font-size: 1.4rem;
+  z-index: 99999;
 }
 
 .dropdown-menu {

--- a/source/frontend/src/features/documents/DocumentPreviewView.tsx
+++ b/source/frontend/src/features/documents/DocumentPreviewView.tsx
@@ -4,6 +4,8 @@ import { GrDocumentMissing } from 'react-icons/gr';
 import Lightbox from 'yet-another-react-lightbox';
 import { Captions, Counter, Download, Fullscreen, Zoom } from 'yet-another-react-lightbox/plugins';
 
+import TooltipIcon from '@/components/common/TooltipIcon';
+
 import { LoadedPage } from './DocumentPreviewContainer';
 
 export interface IDocumentPreviewViewProps {
@@ -29,6 +31,21 @@ export const DocumentPreviewView: React.FunctionComponent<IDocumentPreviewViewPr
       open={pages.length > 0 && showDocumentPreview}
       slides={pages.map(page => ({
         src: page.loadedDocumentImageDataUrl,
+        description: (
+          <TooltipIcon
+            toolTipId="document-preview-tip"
+            innerClassName="text-white"
+            toolTip={
+              <>
+                <p>
+                  You are viewing a preview of the selected document, with a limited number of
+                  pages.
+                </p>
+                <p>To view the full document, please download it.</p>
+              </>
+            }
+          />
+        ),
       }))}
       animation={{ fade: 500, swipe: 750 }}
       render={{


### PR DESCRIPTION
By default, Mayan will only cache document pages on a schedule, or when they are requested. This adds an async pre-cache task to the upload action to facilitate that - greatly increasing the odds that a page preview will be ready when requested.