### PR TITLE
PIMS devops updates

### DIFF
--- a/.github/workflows/api-dotnetcore.yml
+++ b/.github/workflows/api-dotnetcore.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -32,7 +32,7 @@ jobs:
       GIT_BRANCH: "${{github.ref}}"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Extract Branch Name
         shell: bash

--- a/.github/workflows/app-logging.yml
+++ b/.github/workflows/app-logging.yml
@@ -32,7 +32,7 @@ jobs:
       working-directory: ./openshift/4.0/templates/Logging
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set ENV variable
       run: |
         if [[ ${{github.event.ref}} == 'refs/heads/test' ]]; then
@@ -55,7 +55,7 @@ jobs:
         time: '180s'
     - name: Check Extracted Logs
       run: |
-        docker cp pims-logging:/logging/. . 
+        docker cp pims-logging:/logging/. .
         exitcode=$(docker inspect pims-logging --format='{{.State.ExitCode}}')
         if [[ "$(ls -A pims* 2>/dev/null | wc -l)" != "0" ]]; then
             ls -A pims* && rm -f pims*

--- a/.github/workflows/app-react.yml
+++ b/.github/workflows/app-react.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -32,7 +32,7 @@ jobs:
       GIT_BRANCH: "${{github.ref}}"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Extract Branch Name
         shell: bash
@@ -59,7 +59,7 @@ jobs:
 
       - name: Codecov
         uses: codecov/codecov-action@v3.1.1
-        env: 
+        env:
           CODECOV_TOKEN: ${{ secrets.CODECOV }}
         with:
           # User defined upload name. Visible in Codecov UI

--- a/.github/workflows/ci-cd-pims-dev.yml
+++ b/.github/workflows/ci-cd-pims-dev.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v3
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:

--- a/.github/workflows/ci-cd-pims-master.yml
+++ b/.github/workflows/ci-cd-pims-master.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
       - name: Login to OpenShift
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
       - name: Login to OpenShift
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
       - name: Fetch Tags
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
       - name: Login to OpenShift

--- a/.github/workflows/credentials-comment-pr.yml
+++ b/.github/workflows/credentials-comment-pr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download artifact
         uses: actions/github-script@v3.1.0
         with:

--- a/.github/workflows/credentials-scan.yml
+++ b/.github/workflows/credentials-scan.yml
@@ -45,7 +45,7 @@ jobs:
           echo ${{ github.event.pull_request.number }} > ./pr/NR
           ./tools/cicd/build/secops_report.sh trufflehog_report.json > ./pr/PRBODY
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: pr
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload HTML report
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Security Scan Report
           path: trufflehog_report.html

--- a/.github/workflows/credentials-scan.yml
+++ b/.github/workflows/credentials-scan.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup python
         uses: actions/setup-python@v2

--- a/.github/workflows/db-schma.yml
+++ b/.github/workflows/db-schma.yml
@@ -20,7 +20,7 @@ jobs:
       working-directory: ./source/database/mssql/scripts/dbscripts
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Set up random env variable
         run: |
           passvar=$(date +%s | sha256sum | base64 | head -c 29)A8!

--- a/.github/workflows/deploy-prod-end.yml
+++ b/.github/workflows/deploy-prod-end.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
           fetch-depth: 0

--- a/.github/workflows/deploy-prod-start.yml
+++ b/.github/workflows/deploy-prod-start.yml
@@ -52,7 +52,7 @@ jobs:
     needs: ci-cd-start-notification
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
           fetch-depth: 0
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -129,7 +129,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/image-scan-analysis.yml
+++ b/.github/workflows/image-scan-analysis.yml
@@ -25,7 +25,7 @@ jobs:
       output-filename: nodejs14.txt
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Authenticate and set context
         uses: redhat-actions/oc-login@v1
         env:
@@ -83,7 +83,7 @@ jobs:
       OPENSHIFT_NAMESPACE: 3cd915-tools
       output-filename: nodejs14.txt
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download artifact
         id: artifact
         uses: actions/download-artifact@master
@@ -158,7 +158,7 @@ jobs:
       output-filename: nginx-base.txt
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Authenticate and set context
         uses: redhat-actions/oc-login@v1
         env:
@@ -212,7 +212,7 @@ jobs:
       tag: ${{secrets.NGINX_BASE_TAG}}
       output-filename: nginx-base.txt
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download artifact
         id: artifact
         uses: actions/download-artifact@master
@@ -289,7 +289,7 @@ jobs:
       output-filename: pims-app.txt
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Authenticate and set context
         uses: redhat-actions/oc-login@v1
         env:
@@ -345,7 +345,7 @@ jobs:
       tag: latest
       output-filename: pims-app.txt
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download artifact
         id: artifact
         uses: actions/download-artifact@master
@@ -421,7 +421,7 @@ jobs:
       output-filename: dotnet-aspnet.txt
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Authenticate and set context
         uses: redhat-actions/oc-login@v1
         env:
@@ -475,7 +475,7 @@ jobs:
       tag: "5.0"
       output-filename: dotnet-aspnet.txt
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download artifact
         id: artifact
         uses: actions/download-artifact@master
@@ -551,7 +551,7 @@ jobs:
       output-filename: dotnet-sdk.txt
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Authenticate and set context
         uses: redhat-actions/oc-login@v1
         env:
@@ -605,7 +605,7 @@ jobs:
       tag: "5.0"
       output-filename: dotnet-sdk.txt
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download artifact
         id: artifact
         uses: actions/download-artifact@master
@@ -682,7 +682,7 @@ jobs:
       output-filename: pims-api.txt
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Authenticate and set context
         uses: redhat-actions/oc-login@v1
         env:
@@ -736,7 +736,7 @@ jobs:
       tag: latest
       output-filename: pims-api.txt
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download artifact
         id: artifact
         uses: actions/download-artifact@master
@@ -813,7 +813,7 @@ jobs:
       output-filename: pims-logging.txt
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Authenticate and set context
         uses: redhat-actions/oc-login@v1
         env:
@@ -868,7 +868,7 @@ jobs:
       tag: latest
       output-filename: pims-logging.txt
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download artifact
         id: artifact
         uses: actions/download-artifact@master
@@ -944,7 +944,7 @@ jobs:
       output-filename: jenkins-agent-dotnet.txt
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Authenticate and set context
         uses: redhat-actions/oc-login@v1
         env:
@@ -999,7 +999,7 @@ jobs:
       tag: latest
       output-filename: jenkins-agent-dotnet.txt
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download artifact
         id: artifact
         uses: actions/download-artifact@master

--- a/.github/workflows/image-scan-analysis.yml
+++ b/.github/workflows/image-scan-analysis.yml
@@ -64,7 +64,7 @@ jobs:
           output: ${{env.output-filename}}
       - if: failure() && steps.scan.outcome == 'failure'
         name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{env.image-name}}_scan_report
           path: ./${{env.output-filename}}
@@ -195,7 +195,7 @@ jobs:
           output: ${{env.output-filename}}
       - if: failure() && steps.scan.outcome == 'failure'
         name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{env.image-name}}_scan_report
           path: ./${{env.output-filename}}
@@ -328,7 +328,7 @@ jobs:
           output: ${{env.output-filename}}
       - if: failure() && steps.scan.outcome == 'failure'
         name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{env.image-name}}_scan_report
           path: ./${{env.output-filename}}
@@ -458,7 +458,7 @@ jobs:
           output: ${{env.output-filename}}
       - if: failure() && steps.scan.outcome == 'failure'
         name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{env.image-name}}_scan_report
           path: ./${{env.output-filename}}
@@ -588,7 +588,7 @@ jobs:
           output: ${{env.output-filename}}
       - if: failure() && steps.scan.outcome == 'failure'
         name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{env.image-name}}_scan_report
           path: ./${{env.output-filename}}
@@ -719,7 +719,7 @@ jobs:
           output: ${{env.output-filename}}
       - if: failure() && steps.scan.outcome == 'failure'
         name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{env.image-name}}_scan_report
           path: ./${{env.output-filename}}
@@ -850,7 +850,7 @@ jobs:
           output: ${{env.output-filename}}
       - if: failure() && steps.scan.outcome == 'failure'
         name: Upload OWASP ZAP scan artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{env.image-name}}_scan_report
           path: ./${{env.output-filename}}
@@ -981,7 +981,7 @@ jobs:
           output: ${{env.output-filename}}
       - if: failure() && steps.scan.outcome == 'failure'
         name: Upload jenkins agent scan artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{env.image-name}}_scan_report
           path: ./${{env.output-filename}}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:

--- a/.github/workflows/keycloak-sync.yml
+++ b/.github/workflows/keycloak-sync.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/mayan-sync.yml
+++ b/.github/workflows/mayan-sync.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/retag-dev-to-test.yml
+++ b/.github/workflows/retag-dev-to-test.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v3
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:

--- a/.github/workflows/retag-test-to-uat.yml
+++ b/.github/workflows/retag-test-to-uat.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v3
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }} # with this we can bypass branch protection rules here (no-push)
 

--- a/.github/workflows/uat_hotfix.yml
+++ b/.github/workflows/uat_hotfix.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v3
@@ -177,7 +177,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:

--- a/.github/workflows/uat_pre_release_hotfix.yml
+++ b/.github/workflows/uat_pre_release_hotfix.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -137,7 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v3
@@ -204,7 +204,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:
@@ -244,7 +244,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to OpenShift
         uses: redhat-actions/oc-login@v1
         with:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }} # with this we can bypass branch protection rules here (no-push)
 


### PR DESCRIPTION
This gets rid of a number of warnings we are seeing on our CI/CD pipelines:
* https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
* https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/