### PR TITLE
SetOriginalConcurrencyControlNumber function removal

### DIFF
--- a/source/backend/dal/Helpers/Extensions/DbContextExtensions.cs
+++ b/source/backend/dal/Helpers/Extensions/DbContextExtensions.cs
@@ -9,18 +9,6 @@ namespace Pims.Dal.Helpers.Extensions
     public static class DbContextExtensions
     {
         /// <summary>
-        /// When manipulating entities it is necessary to reset the original value for 'ConcurrencyControlNumber' so that concurrency checking can occur.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="context"></param>
-        /// <param name="source">The original source entity from the database.</param>
-        public static void SetOriginalConcurrencyControlNumber<T>(this DbContext context, T source)
-            where T : IBaseEntity
-        {
-            context.Entry(source).OriginalValues[nameof(IBaseEntity.ConcurrencyControlNumber)] = source.ConcurrencyControlNumber;
-        }
-
-        /// <summary>
         /// Detach the entity from the context.
         /// </summary>
         /// <typeparam name="T"></typeparam>

--- a/source/backend/dal/Repositories/UserRepository.cs
+++ b/source/backend/dal/Repositories/UserRepository.cs
@@ -458,9 +458,6 @@ namespace Pims.Dal.Repositories
                 user.IssueDate = DateTime.UtcNow;
             }
 
-            user.ConcurrencyControlNumber = update.ConcurrencyControlNumber;
-            this.Context.SetOriginalConcurrencyControlNumber(user);
-
             var addRoles = update.PimsUserRoles.Except(user.PimsUserRoles, new UserRoleRoleIdComparer());
             addRoles.ForEach(r => user.PimsUserRoles.Add(new PimsUserRole() { UserId = user.UserId, RoleId = r.RoleId }));
             var removeRoles = user.PimsUserRoles.Except(update.PimsUserRoles, new UserRoleRoleIdComparer());
@@ -511,7 +508,6 @@ namespace Pims.Dal.Repositories
                 .FirstOrDefault(u => u.UserId == delete.UserId) ?? throw new KeyNotFoundException();
 
             user.ConcurrencyControlNumber = delete.ConcurrencyControlNumber;
-            this.Context.SetOriginalConcurrencyControlNumber(user);
 
             user.PimsUserRoles.ForEach(ur => this.Context.Remove(ur));
             user.PimsUserRoles.Clear();


### PR DESCRIPTION
discussed in person some time ago.

Only uses are in user update and user delete.

User delete unused, tested user update continues to work.