### PR TITLE
[CI] Fix build failures after ubuntu-latest upgrade to 24.04

### DIFF
--- a/.github/workflows/api-dotnetcore.yml
+++ b/.github/workflows/api-dotnetcore.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   # JOB to run change detection
   check-changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Set job outputs to values from filter step
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
@@ -24,11 +24,19 @@ jobs:
 
   build-backend:
     needs: check-changes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ needs.check-changes.outputs.backend == 'true' }}
     strategy:
       matrix:
-        services: [{directory: ./source/backend/api, solution: 'Pims.sln'}, {directory: ./source/backend/proxy, solution: 'Proxy.sln'}, {directory: ./source/backend/scheduler, solution: 'Scheduler.sln'}]
+        services:
+          [
+            { directory: ./source/backend/api, solution: "Pims.sln" },
+            { directory: ./source/backend/proxy, solution: "Proxy.sln" },
+            {
+              directory: ./source/backend/scheduler,
+              solution: "Scheduler.sln",
+            },
+          ]
     env:
       working-directory: ${{ matrix.services.directory }}
       solution-name: ${{ matrix.services.solution }}
@@ -147,7 +155,7 @@ jobs:
           sonarHostname: ${{secrets.SONAR_URL}}
   post-build:
     needs: build-backend
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       working-directory: ./source/backend
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/app-logging.yml
+++ b/.github/workflows/app-logging.yml
@@ -6,14 +6,11 @@ on:
   pull_request:
     branches: [master, test, dev]
 
-
 jobs:
-
   build:
-
     name: build-logging
     if: github.event.ref == 'refs/heads/master' || github.event.ref == 'refs/heads/test' || github.event.ref == 'refs/heads/dev'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       SLEEP_TIME: 60
       STORAGE_TYPE: Amazon_S3
@@ -32,44 +29,44 @@ jobs:
       working-directory: ./openshift/4.0/templates/Logging
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set ENV variable
-      run: |
-        if [[ ${{github.event.ref}} == 'refs/heads/test' ]]; then
-            echo "FRONTEND_APP_NAME=pims-app-test" >> $GITHUB_ENV
-            echo "API_NAME=pims-api-test" >> $GITHUB_ENV
-        elif [[ ${{github.event.ref}} == 'refs/heads/master' ]]; then
-           echo "FRONTEND_APP_NAME=pims-app-uat" >> $GITHUB_ENV
-           echo "API_NAME=pims-api-uat" >> $GITHUB_ENV
-           echo "PROJECT_NAMESPACE=3cd915-test" >> $GITHUB_ENV
-        else
-            echo "FRONTEND_APP_NAME=pims-app" >> $GITHUB_ENV
-            echo "API_NAME=pims-api" >> $GITHUB_ENV
-        fi
-    - name: Build the pims-logging docker-compose stack
-      run: docker-compose -f docker-compose.yml up -d
-      working-directory: ${{env.working-directory}}
-    - name: Sleep for 180 seconds
-      uses: jakejarvis/wait-action@master
-      with:
-        time: '180s'
-    - name: Check Extracted Logs
-      run: |
-        docker cp pims-logging:/logging/. .
-        exitcode=$(docker inspect pims-logging --format='{{.State.ExitCode}}')
-        if [[ "$(ls -A pims* 2>/dev/null | wc -l)" != "0" ]]; then
-            ls -A pims* && rm -f pims*
-        elif [[ $exitcode == 0 ]]; then
-            echo "Info: No log captured between sleep time"
-        else
-            echo "There's an error capturing pims logs" && exit 1
-        fi
-    - name: Check running containers
-      run: docker ps -a
-    - name: Check pims-logging logs
-      if: always()
-      run: docker logs pims-logging
-    - name: Stop containers
-      if: always()
-      run: docker-compose -f "docker-compose.yml" down
-      working-directory: ${{env.working-directory}}
+      - uses: actions/checkout@v4
+      - name: Set ENV variable
+        run: |
+          if [[ ${{github.event.ref}} == 'refs/heads/test' ]]; then
+              echo "FRONTEND_APP_NAME=pims-app-test" >> $GITHUB_ENV
+              echo "API_NAME=pims-api-test" >> $GITHUB_ENV
+          elif [[ ${{github.event.ref}} == 'refs/heads/master' ]]; then
+             echo "FRONTEND_APP_NAME=pims-app-uat" >> $GITHUB_ENV
+             echo "API_NAME=pims-api-uat" >> $GITHUB_ENV
+             echo "PROJECT_NAMESPACE=3cd915-test" >> $GITHUB_ENV
+          else
+              echo "FRONTEND_APP_NAME=pims-app" >> $GITHUB_ENV
+              echo "API_NAME=pims-api" >> $GITHUB_ENV
+          fi
+      - name: Build the pims-logging docker-compose stack
+        run: docker-compose -f docker-compose.yml up -d
+        working-directory: ${{env.working-directory}}
+      - name: Sleep for 180 seconds
+        uses: jakejarvis/wait-action@master
+        with:
+          time: "180s"
+      - name: Check Extracted Logs
+        run: |
+          docker cp pims-logging:/logging/. .
+          exitcode=$(docker inspect pims-logging --format='{{.State.ExitCode}}')
+          if [[ "$(ls -A pims* 2>/dev/null | wc -l)" != "0" ]]; then
+              ls -A pims* && rm -f pims*
+          elif [[ $exitcode == 0 ]]; then
+              echo "Info: No log captured between sleep time"
+          else
+              echo "There's an error capturing pims logs" && exit 1
+          fi
+      - name: Check running containers
+        run: docker ps -a
+      - name: Check pims-logging logs
+        if: always()
+        run: docker logs pims-logging
+      - name: Stop containers
+        if: always()
+        run: docker-compose -f "docker-compose.yml" down
+        working-directory: ${{env.working-directory}}

--- a/.github/workflows/app-react.yml
+++ b/.github/workflows/app-react.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   # JOB to run change detection
   check-changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Set job outputs to values from filter step
     outputs:
       frontend: ${{ steps.filter.outputs.frontend }}
@@ -25,7 +25,7 @@ jobs:
   build-frontend:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.frontend == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CI: true
       working-directory: ./source/frontend

--- a/.github/workflows/ci-cd-pims-dev.yml
+++ b/.github/workflows/ci-cd-pims-dev.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   ci-cd-start-notification:
     name: CI-CD Start Notification to Teams Channel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Start notification to Teams Channel
         uses: dragos-cojocari/ms-teams-notification@v1.0.2
@@ -46,7 +46,7 @@ jobs:
   build-frontend:
     name: Build frontend
     needs: ci-cd-start-notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
   build-api:
     name: Build api
     needs: ci-cd-start-notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -85,7 +85,7 @@ jobs:
   deploy:
     name: Deploy to OpenShift
     needs: [build-frontend, build-api]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -132,7 +132,7 @@ jobs:
   database-upgrade:
     name: Upgrade database
     needs: [deploy]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -155,7 +155,7 @@ jobs:
   mayan-sync:
     name: sync mayan
     needs: database-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -177,7 +177,7 @@ jobs:
   keycloak-sync:
     name: sync keycloak
     needs: database-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -195,7 +195,7 @@ jobs:
 
   ci-cd-end-notification:
     name: CI-CD End Notification to Teams Channel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: keycloak-sync
     steps:
       - name: check workflow status

--- a/.github/workflows/codecov-comment-pr.yml
+++ b/.github/workflows/codecov-comment-pr.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   upload:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/credentials-comment-pr.yml
+++ b/.github/workflows/credentials-comment-pr.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   # this action will leave a comment in response to credential scans performed on pull requests
   on-completed:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.workflow_run.event == 'pull_request'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/credentials-scan.yml
+++ b/.github/workflows/credentials-scan.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   credentials-scan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/db-schma.yml
+++ b/.github/workflows/db-schma.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: db-schema
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/deploy-prod-end.yml
+++ b/.github/workflows/deploy-prod-end.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   maintenance-page:
     name: Hide the maintenance page
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
 
   ci-cd-end-notification:
     name: CI-CD End Notification to Teams Channel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: maintenance-page
     steps:
       - name: check workflow status

--- a/.github/workflows/deploy-prod-start-argo.yml
+++ b/.github/workflows/deploy-prod-start-argo.yml
@@ -35,7 +35,7 @@ on:
 jobs:
   ci-cd-start-notification:
     name: CI-CD Start Notification to Teams Channel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Start notification to Teams Channel
         uses: dragos-cojocari/ms-teams-notification@v1.0.2
@@ -48,7 +48,7 @@ jobs:
 
   deploy:
     name: Deploy frontend and api to OpenShift
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: ci-cd-start-notification
     steps:
       - name: Checkout Source Code
@@ -94,7 +94,7 @@ jobs:
   database-upgrade:
     name: Upgrade database
     needs: [deploy]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -117,7 +117,7 @@ jobs:
   mayan-sync:
     name: sync mayan
     needs: database-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -139,7 +139,7 @@ jobs:
   keycloak-sync:
     name: sync keycloak
     needs: database-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-prod-start.yml
+++ b/.github/workflows/deploy-prod-start.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   ci-cd-start-notification:
     name: CI-CD Start Notification to Teams Channel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Start notification to Teams Channel
         uses: dragos-cojocari/ms-teams-notification@v1.0.2
@@ -47,7 +47,7 @@ jobs:
 
   deploy:
     name: Deploy frontend and api to OpenShift
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: ci-cd-start-notification
     steps:
       - name: Checkout Source Code
@@ -84,7 +84,7 @@ jobs:
   database-upgrade:
     name: Upgrade database
     needs: [deploy]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -107,7 +107,7 @@ jobs:
   mayan-sync:
     name: sync mayan
     needs: database-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -125,11 +125,11 @@ jobs:
           oc process -f ./openshift/4.0/templates/jobs/mayan-sync.yaml -p NAMESPACE=3cd915-prod -p TOKEN_URL=https://loginproxy.gov.bc.ca:443/auth/realms/standard/protocol/openid-connect/token -p CLIENT_ID=property-services-project-api-4380 -p MAYAN_SYNC_URL=https://pims-app-3cd915-prod.apps.silver.devops.gov.bc.ca/documents/sync/documenttype -p KEYCLOAK_SECRET_NAME=pims-api-sso | oc create -f - | grep -oP "(?<=\/)[^\s]*" | (read TASK_NAME; oc wait --for=condition=succeeded taskruns/$TASK_NAME --timeout=80s)
           oc process -f ./openshift/4.0/templates/jobs/mayan-sync.yaml -p NAMESPACE=3cd915-prod -p TOKEN_URL=https://loginproxy.gov.bc.ca:443/auth/realms/standard/protocol/openid-connect/token -p CLIENT_ID=property-services-project-api-4380 -p MAYAN_SYNC_URL=https://pims-app-3cd915-prod.apps.silver.devops.gov.bc.ca/api/documents/sync/mayan -p KEYCLOAK_SECRET_NAME=pims-api-sso | oc create -f - | grep -oP "(?<=\/)[^\s]*" | (read TASK_NAME; oc wait --for=condition=succeeded taskruns/$TASK_NAME --timeout=80s)
 
-## Call the tekton pipeline that executes the keycloak sync. Dependent on the pims-api being accessible. Can run in parallel with the mayan sync.
+  ## Call the tekton pipeline that executes the keycloak sync. Dependent on the pims-api being accessible. Can run in parallel with the mayan sync.
   keycloak-sync:
     name: sync keycloak
     needs: database-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -144,4 +144,3 @@ jobs:
         shell: bash
         run: |
           oc process -f ./openshift/4.0/templates/jobs/keycloak-sync-pipeline-run.yaml -p ASPNETCORE_ENVIRONMENT=$ASPNETCORE_ENVIRONMENT -p NAMESPACE=3cd915-prod -p BRANCH=$DESTINATION -p API_URL=http://pims-api:8080/api  | oc create -f - | grep -oP "(?<=\/)[^\s]*" | (read PIPELINE_NAME; oc wait --for=condition=succeeded pipelineruns/$PIPELINE_NAME --timeout=500s)
-

--- a/.github/workflows/image-scan-analysis.yml
+++ b/.github/workflows/image-scan-analysis.yml
@@ -12,7 +12,7 @@ jobs:
   nodejs-base-image:
     name: nodejs-base-image
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read
@@ -75,7 +75,7 @@ jobs:
     # this action will leave a comment in response to vulnerability scans performed on cotnainer image
     if: always() && needs.nodejs-base-image.result == 'failure' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     needs: nodejs-base-image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       working-directory: ./source/frontend
       image-name: nodejs-14-ubi8
@@ -145,7 +145,7 @@ jobs:
   nginx-base-image:
     name: nginx-base-image
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read
@@ -205,7 +205,7 @@ jobs:
     # this action will leave a comment in response to vulnerability scans performed on cotnainer image
     if: always() && needs.nginx-base-image.result == 'failure' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     needs: nginx-base-image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       working-directory: ./source/frontend
       image-name: nginx-base
@@ -276,7 +276,7 @@ jobs:
     if: always() && github.event.pull_request.head.repo.full_name == github.repository
     needs: [nodejs-base-image, nginx-base-image]
     name: pims-frontend
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read
@@ -338,7 +338,7 @@ jobs:
     # this action will leave a comment in response to credential scans performed on pull requests
     if: always() && needs.build_frontend.result == 'failure' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     needs: build_frontend
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       working-directory: ./source/frontend
       image-name: pims-app
@@ -408,7 +408,7 @@ jobs:
   aspnet-runtime:
     name: aspnet-runtime
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read
@@ -468,7 +468,7 @@ jobs:
     # this action will leave a comment in response to credential scans performed on pull requests
     if: always() && needs.aspnet-runtime.result == 'failure' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     needs: aspnet-runtime
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       working-directory: ./openshift/4.0/templates/base-images/dotnet50
       image-name: dotnet-aspnet
@@ -538,7 +538,7 @@ jobs:
   dotnet-sdk:
     name: dotnet5-sdk
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read
@@ -598,7 +598,7 @@ jobs:
     # this action will leave a comment in response to credential scans performed on pull requests
     if: always() && needs.dotnet-sdk.result == 'failure' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     needs: dotnet-sdk
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       working-directory: ./openshift/4.0/templates/base-images/dotnet50
       image-name: dotnet-sdk
@@ -669,7 +669,7 @@ jobs:
     if: always() && github.event.pull_request.head.repo.full_name == github.repository
     needs: [aspnet-runtime, dotnet-sdk]
     name: pims-backend
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read
@@ -729,7 +729,7 @@ jobs:
     # this action will leave a comment in response to credential scans performed on pull requests
     if: always() && needs.build_backend.result == 'failure' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     needs: build_backend
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       working-directory: ./source/backend
       image-name: pims-api
@@ -800,7 +800,7 @@ jobs:
     if: always() && github.event.pull_request.head.repo.full_name == github.repository
     needs: [build_frontend, build_backend]
     name: logging
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read
@@ -861,7 +861,7 @@ jobs:
     # this action will leave a comment in response to Image scans performed on pull requests
     if: always() && needs.pims_logging.result == 'failure' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     needs: pims_logging
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       working-directory: ./openshift/4.0/templates/jenkins-slaves/jenkins-slave-zap
       image-name: pims-logging
@@ -930,7 +930,7 @@ jobs:
   jenkins-agent-dotnet:
     if: github.event.pull_request.head.repo.full_name == github.repository
     name: jenkins-agent-dotnet
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read
@@ -992,7 +992,7 @@ jobs:
     # this action will leave a comment in response to credential scans performed on pull requests
     if: always() && needs.jenkins-agent-dotnet.result == 'failure' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     needs: jenkins-agent-dotnet
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       working-directory: ./openshift/4.0/templates/jenkins-slaves/jenkins-slave-zap
       image-name: jenkins-agent-dotnet

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   smoke-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/keycloak-sync.yml
+++ b/.github/workflows/keycloak-sync.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   sync-keycloak:
     name: Sync Keycloak
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4

--- a/.github/workflows/mayan-sync.yml
+++ b/.github/workflows/mayan-sync.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   mayan-sync:
     name: mayan-sync
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/retag-dev-to-test.yml
+++ b/.github/workflows/retag-dev-to-test.yml
@@ -34,7 +34,7 @@ on: workflow_dispatch
 jobs:
   ci-cd-start-notification:
     name: CI-CD Start Notification to Teams Channel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Start notification to Teams Channel
         uses: dragos-cojocari/ms-teams-notification@v1.0.2
@@ -48,7 +48,7 @@ jobs:
   deploy:
     name: Retag/Deploy to OpenShift
     needs: ci-cd-start-notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -95,7 +95,7 @@ jobs:
   database-upgrade:
     name: Upgrade database
     needs: [deploy]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -113,12 +113,12 @@ jobs:
           oc wait --for=condition=complete job/$JOB_NAME --timeout=120s
           oc get pods -o custom-columns=POD:.metadata.name --no-headers | grep -Eo $JOB_NAME-[^\s].* | (read POD_NAME; oc logs $POD_NAME)
 
-## Call the mayan sync task three times, once for each mayan sync endpoint. The task will wait for the job to complete before exiting.
-## Note: this depends on the mayan-sync configmap for the target namespace being up to date.
+  ## Call the mayan sync task three times, once for each mayan sync endpoint. The task will wait for the job to complete before exiting.
+  ## Note: this depends on the mayan-sync configmap for the target namespace being up to date.
   mayan-sync:
     name: sync mayan
     needs: database-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -136,11 +136,11 @@ jobs:
           oc process -f ./openshift/4.0/templates/jobs/mayan-sync.yaml -p NAMESPACE=3cd915-dev -p TOKEN_URL=https://dev.loginproxy.gov.bc.ca:443/auth/realms/standard/protocol/openid-connect/token -p CLIENT_ID=property-services-project-api-4380 -p MAYAN_SYNC_URL=https://pims-app-test-3cd915-dev.apps.silver.devops.gov.bc.ca:443/api/documents/sync/documenttype -p KEYCLOAK_SECRET_NAME=pims-api-sso-test | oc create -f - | grep -oP "(?<=\/)[^\s]*" | (read TASK_NAME; oc wait --for=condition=succeeded taskruns/$TASK_NAME --timeout=80s)
           oc process -f ./openshift/4.0/templates/jobs/mayan-sync.yaml -p NAMESPACE=3cd915-dev -p TOKEN_URL=https://dev.loginproxy.gov.bc.ca:443/auth/realms/standard/protocol/openid-connect/token -p CLIENT_ID=property-services-project-api-4380 -p MAYAN_SYNC_URL=https://pims-app-test-3cd915-dev.apps.silver.devops.gov.bc.ca:443/api/documents/sync/mayan -p KEYCLOAK_SECRET_NAME=pims-api-sso-test | oc create -f - | grep -oP "(?<=\/)[^\s]*" | (read TASK_NAME; oc wait --for=condition=succeeded taskruns/$TASK_NAME --timeout=80s)
 
-## Call the tekton pipeline that executes the keycloak sync. Dependent on the pims-api being accessible. Can run in parallel with the mayan sync.
+  ## Call the tekton pipeline that executes the keycloak sync. Dependent on the pims-api being accessible. Can run in parallel with the mayan sync.
   keycloak-sync:
     name: sync keycloak
     needs: database-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -156,10 +156,9 @@ jobs:
         run: |
           oc process -f ./openshift/4.0/templates/jobs/keycloak-sync-pipeline-run.yaml -p ASPNETCORE_ENVIRONMENT=$ASPNETCORE_ENVIRONMENT -p NAMESPACE=$NAMESPACE_OVERRIDE -p BRANCH=dev -p KEYCLOAK_SECRET_NAME=pims-api-sso-test -p KEYCLOAK_SERVICE_ACCOUNT_SECRET_NAME=pims-api-sso-test -p API_URL=http://pims-api-test:8080/api  | oc create -f - | grep -oP "(?<=\/)[^\s]*" | (read PIPELINE_NAME; oc wait --for=condition=succeeded pipelineruns/$PIPELINE_NAME --timeout=600s)
 
-
   ci-cd-end-notification:
     name: CI-CD End Notification to Teams Channel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: keycloak-sync
     steps:
       - name: check workflow status

--- a/.github/workflows/retag-test-to-uat-argo.yml
+++ b/.github/workflows/retag-test-to-uat-argo.yml
@@ -35,7 +35,7 @@ on: workflow_dispatch
 jobs:
   ci-cd-start-notification:
     name: CI-CD Start Notification to Teams Channel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Start notification to Teams Channel
         uses: dragos-cojocari/ms-teams-notification@v1.0.2
@@ -49,7 +49,7 @@ jobs:
   deploy:
     name: Retag/Deploy to OpenShift
     needs: ci-cd-start-notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -96,7 +96,7 @@ jobs:
   database-upgrade:
     name: Upgrade database
     needs: [deploy]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -119,7 +119,7 @@ jobs:
   mayan-sync:
     name: sync mayan
     needs: database-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -141,7 +141,7 @@ jobs:
   keycloak-sync:
     name: sync keycloak
     needs: database-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -160,7 +160,7 @@ jobs:
   tag-release-image:
     name: Release Tag
     needs: [deploy]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -183,7 +183,7 @@ jobs:
 
   ci-cd-end-notification:
     name: CI-CD End Notification to Teams Channel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [keycloak-sync, mayan-sync]
     if: always()
     steps:

--- a/.github/workflows/retag-test-to-uat.yml
+++ b/.github/workflows/retag-test-to-uat.yml
@@ -35,7 +35,7 @@ on: workflow_dispatch
 jobs:
   ci-cd-start-notification:
     name: CI-CD Start Notification to Teams Channel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Start notification to Teams Channel
         uses: dragos-cojocari/ms-teams-notification@v1.0.2
@@ -49,7 +49,7 @@ jobs:
   deploy:
     name: Retag/Deploy frontend and api to OpenShift
     needs: ci-cd-start-notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -82,7 +82,7 @@ jobs:
   database-upgrade:
     name: Upgrade database
     needs: [deploy]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -105,7 +105,7 @@ jobs:
   mayan-sync:
     name: sync mayan
     needs: database-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -127,7 +127,7 @@ jobs:
   keycloak-sync:
     name: sync keycloak
     needs: database-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -146,7 +146,7 @@ jobs:
   tag-release-image:
     name: Release Tag
     needs: [deploy]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -169,7 +169,7 @@ jobs:
 
   ci-cd-end-notification:
     name: CI-CD End Notification to Teams Channel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [keycloak-sync, mayan-sync]
     if: always()
     steps:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -9,7 +9,7 @@ jobs:
   prepare-release:
     # this job will only run if the PR has been merged
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/uat_hotfix.yml
+++ b/.github/workflows/uat_hotfix.yml
@@ -33,7 +33,7 @@ on:
 jobs:
   ci-cd-start-notification:
     name: CI-CD Start Notification to Teams Channel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Start notification to Teams Channel
         uses: dragos-cojocari/ms-teams-notification@v1.0.2
@@ -47,7 +47,7 @@ jobs:
   build-frontend:
     name: Build frontend
     needs: ci-cd-start-notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
   build-api:
     name: Build api
     needs: ci-cd-start-notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -86,7 +86,7 @@ jobs:
   deploy:
     name: Deploy frontend and api to OpenShift
     needs: [build-frontend, build-api]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -111,7 +111,7 @@ jobs:
   database-upgrade:
     name: Upgrade database
     needs: [deploy]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -132,7 +132,7 @@ jobs:
   mayan-sync:
     name: sync mayan
     needs: database-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -154,7 +154,7 @@ jobs:
   keycloak-sync:
     name: sync keycloak
     needs: database-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -173,7 +173,7 @@ jobs:
   tag-release-image:
     name: Release Tag
     needs: [deploy]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -196,7 +196,7 @@ jobs:
   ci-cd-end-notification:
     if: always()
     name: CI-CD End Notification to Teams Channel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [mayan-sync, keycloak-sync]
     steps:
       - name: check workflow status

--- a/.github/workflows/uat_hotfix_argo.yml
+++ b/.github/workflows/uat_hotfix_argo.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   ci-cd-start-notification:
     name: CI-CD Start Notification to Teams Channel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Start notification to Teams Channel
         uses: dragos-cojocari/ms-teams-notification@v1.0.2
@@ -48,7 +48,7 @@ jobs:
   build-frontend:
     name: Build frontend
     needs: ci-cd-start-notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -67,7 +67,7 @@ jobs:
   build-api:
     name: Build api
     needs: ci-cd-start-notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -87,7 +87,7 @@ jobs:
   deploy:
     name: Deploy to OpenShift
     needs: [build-frontend, build-api]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -130,7 +130,7 @@ jobs:
   database-upgrade:
     name: Upgrade database
     needs: [deploy]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -151,7 +151,7 @@ jobs:
   mayan-sync:
     name: sync mayan
     needs: database-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -173,7 +173,7 @@ jobs:
   keycloak-sync:
     name: sync keycloak
     needs: database-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -192,7 +192,7 @@ jobs:
   tag-release-image:
     name: Release Tag
     needs: [deploy]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -216,7 +216,7 @@ jobs:
   ci-cd-end-notification:
     if: always()
     name: CI-CD End Notification to Teams Channel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [mayan-sync, keycloak-sync]
     steps:
       - name: check workflow status

--- a/.github/workflows/uat_pre_release_hotfix.yml
+++ b/.github/workflows/uat_pre_release_hotfix.yml
@@ -37,7 +37,7 @@ on:
 jobs:
   ci-cd-start-notification:
     name: CI-CD Start Notification to Teams Channel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Start notification to Teams Channel
         uses: dragos-cojocari/ms-teams-notification@v1.0.2
@@ -51,7 +51,7 @@ jobs:
   create-builds:
     name: create builds
     needs: ci-cd-start-notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -72,7 +72,7 @@ jobs:
   build-frontend:
     name: Build frontend
     needs: create-builds
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -92,7 +92,7 @@ jobs:
   build-api:
     name: Build api
     needs: create-builds
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -112,7 +112,7 @@ jobs:
   deploy:
     name: Deploy frontend and api to OpenShift
     needs: [build-frontend, build-api]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -137,7 +137,7 @@ jobs:
   database-upgrade:
     name: Upgrade database
     needs: [deploy]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -158,7 +158,7 @@ jobs:
   mayan-sync:
     name: sync mayan
     needs: database-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -180,7 +180,7 @@ jobs:
   keycloak-sync:
     name: sync keycloak
     needs: database-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -199,7 +199,7 @@ jobs:
   tag-release-image:
     name: Release Tag
     needs: [deploy]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -222,7 +222,7 @@ jobs:
   ci-cd-end-notification:
     if: always()
     name: CI-CD End Notification to Teams Channel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [mayan-sync, keycloak-sync]
     steps:
       - name: check workflow status
@@ -241,7 +241,7 @@ jobs:
     if: always()
     name: cleanup builds
     needs: ci-cd-end-notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4

--- a/.github/workflows/uat_pre_release_hotfix_argo.yml
+++ b/.github/workflows/uat_pre_release_hotfix_argo.yml
@@ -38,7 +38,7 @@ on:
 jobs:
   ci-cd-start-notification:
     name: CI-CD Start Notification to Teams Channel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Start notification to Teams Channel
         uses: dragos-cojocari/ms-teams-notification@v1.0.2
@@ -52,7 +52,7 @@ jobs:
   create-builds:
     name: create builds
     needs: ci-cd-start-notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -73,7 +73,7 @@ jobs:
   build-frontend:
     name: Build frontend
     needs: create-builds
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -93,7 +93,7 @@ jobs:
   build-api:
     name: Build api
     needs: create-builds
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
   deploy:
     name: Deploy to OpenShift
     needs: [build-frontend, build-api]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -160,7 +160,7 @@ jobs:
   database-upgrade:
     name: Upgrade database
     needs: [deploy]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -181,7 +181,7 @@ jobs:
   mayan-sync:
     name: sync mayan
     needs: database-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -203,7 +203,7 @@ jobs:
   keycloak-sync:
     name: sync keycloak
     needs: database-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -222,7 +222,7 @@ jobs:
   tag-release-image:
     name: Release Tag
     needs: [deploy]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
@@ -245,7 +245,7 @@ jobs:
   ci-cd-end-notification:
     if: always()
     name: CI-CD End Notification to Teams Channel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [mayan-sync, keycloak-sync]
     steps:
       - name: check workflow status
@@ -264,7 +264,7 @@ jobs:
     if: always()
     name: cleanup builds
     needs: ci-cd-end-notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -9,7 +9,7 @@ jobs:
   bump-version:
     # this job will only run if the PR has been merged
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/zap-scan.yml
+++ b/.github/workflows/zap-scan.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   zap_scan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Scan the web application
     env:
       ZAP_REPORT: zap-report.xml


### PR DESCRIPTION
Revert to using older `ubuntu-22.04` runner image because the newest "latest" has removed a lot of required dependencies