### PR TITLE
PSP-8351: Expand Visible Text Under the Intended Use Field (L/L)

### DIFF
--- a/source/frontend/src/features/leases/detail/LeasePages/details/DetailAdministration.tsx
+++ b/source/frontend/src/features/leases/detail/LeasePages/details/DetailAdministration.tsx
@@ -26,6 +26,7 @@ export const DetailAdministration: React.FunctionComponent<
 > = ({ nameSpace, disabled }: IDetailAdministrationProps) => {
   const { values } = useFormikContext<ApiGen_Concepts_Lease>();
   const responsibilityDate = getIn(values, withNameSpace(nameSpace, 'responsibilityEffectiveDate'));
+  const intendedUse = getIn(values, withNameSpace(nameSpace, 'description'));
   const note = getIn(values, withNameSpace(nameSpace, 'note'));
 
   const leasePurposes: ApiGen_Concepts_LeasePurpose[] = getIn(
@@ -112,7 +113,7 @@ export const DetailAdministration: React.FunctionComponent<
           labelWidth="3"
           tooltip="The purpose for which the license is issued, as per the agreement"
         >
-          <Input disabled={disabled} field={withNameSpace(nameSpace, 'description')} />
+          {intendedUse}
         </SectionField>
         <SectionField
           label="Primary arbitration city"

--- a/source/frontend/src/features/leases/detail/LeasePages/details/__snapshots__/DetailAdministration.test.tsx.snap
+++ b/source/frontend/src/features/leases/detail/LeasePages/details/__snapshots__/DetailAdministration.test.tsx.snap
@@ -383,17 +383,7 @@ exports[`DetailAdministration component > renders a complete lease as expected 1
         <div
           class="c4 text-left col"
         >
-          <div
-            class="input form-group"
-          >
-            <input
-              class="form-control"
-              id="input-description"
-              name="description"
-              title="a test description"
-              value="a test description"
-            />
-          </div>
+          a test description
         </div>
       </div>
       <div
@@ -828,18 +818,7 @@ exports[`DetailAdministration component > renders minimally as expected 1`] = `
         </div>
         <div
           class="c4 text-left col"
-        >
-          <div
-            class="input form-group"
-          >
-            <input
-              class="form-control"
-              id="input-description"
-              name="description"
-              value=""
-            />
-          </div>
-        </div>
+        />
       </div>
       <div
         class="pb-2 row"


### PR DESCRIPTION
<img width="962" alt="image" src="https://github.com/user-attachments/assets/54cd6512-a58b-465d-b753-a8ffe6ac0b57" />
