### PR TITLE
PSP-9478: Changing zoom map tooltip and title on the Property Information leaflet

### DIFF
--- a/source/frontend/src/features/mapSideBar/property/MotiInventoryHeader.test.tsx
+++ b/source/frontend/src/features/mapSideBar/property/MotiInventoryHeader.test.tsx
@@ -160,7 +160,7 @@ describe('MotiInventoryHeader component', () => {
       },
       isLoading: false,
     });
-    const zoomButton = getByTitle('Zoom Map');
+    const zoomButton = getByTitle('Zoom into parcel');
     await act(async () => userEvent.click(zoomButton));
     expect(onZoom).toHaveBeenCalled();
   });
@@ -173,7 +173,7 @@ describe('MotiInventoryHeader component', () => {
       },
       isLoading: false,
     });
-    const zoomButton = getByTitle('Zoom Map');
+    const zoomButton = getByTitle('Zoom into parcel');
     await act(async () => userEvent.click(zoomButton));
     expect(onZoom).toHaveBeenCalled();
   });
@@ -187,7 +187,7 @@ describe('MotiInventoryHeader component', () => {
       isLoading: false,
     });
 
-    expect(queryByText('Zoom Map')).not.toBeInTheDocument();
+    expect(queryByText('Zoom into parcel')).not.toBeInTheDocument();
     expect(onZoom).not.toHaveBeenCalled();
   });
 

--- a/source/frontend/src/features/mapSideBar/property/MotiInventoryHeader.tsx
+++ b/source/frontend/src/features/mapSideBar/property/MotiInventoryHeader.tsx
@@ -120,11 +120,11 @@ export const MotiInventoryHeader: React.FunctionComponent<IMotiInventoryHeaderPr
         </Col>
         <Col xs="auto" className="d-flex p-0 align-items-center justify-content-end">
           {hasLocation && (
-            <TooltipWrapper tooltipId="property-zoom-map" tooltip="Zoom Map">
+            <TooltipWrapper tooltipId="property-zoom-map" tooltip="Zoom into parcel">
               <StyledIconButton
                 variant="info"
                 disabled={!props.onZoom}
-                title="Zoom Map"
+                title="Zoom into parcel"
                 onClick={() => props?.onZoom && props?.onZoom(latitude, longitude)}
               >
                 <FaSearchPlus size={22} />


### PR DESCRIPTION
The spacing fix for the overlapping issue was fixed by PSP-9486