### PR TITLE
HOTFIX psp-9865 - fix map click loading logic.

### DIFF
--- a/source/backend/api/Pims.Api.csproj
+++ b/source/backend/api/Pims.Api.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <UserSecretsId>0ef6255f-9ea0-49ec-8c65-c172304b4926</UserSecretsId>
-    <Version>5.7.1-96.22</Version>
-    <AssemblyVersion>5.7.1.96</AssemblyVersion>
+    <Version>5.7.2-96.22</Version>
+    <AssemblyVersion>5.7.2.96</AssemblyVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ProjectGuid>{16BC0468-78F6-4C91-87DA-7403C919E646}</ProjectGuid>
     <TargetFramework>net8.0</TargetFramework>

--- a/source/frontend/package.json
+++ b/source/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "5.7.1-96.22",
+  "version": "5.7.2-96.22",
   "private": true,
   "dependencies": {
     "@bcgov/bc-sans": "1.0.1",

--- a/source/frontend/src/components/common/mapFSM/useLocationFeatureLoader.tsx
+++ b/source/frontend/src/components/common/mapFSM/useLocationFeatureLoader.tsx
@@ -148,7 +148,10 @@ const useLocationFeatureLoader = () => {
         const boundaryFeature = await findOneByBoundary(latLng, 'GEOMETRY', 4326);
         if (exists(boundaryFeature)) {
           pimsLocationProperties = { features: [boundaryFeature], type: 'FeatureCollection' };
-        } else if (exists(parcelFeature)) {
+        } else if (
+          exists(parcelFeature) &&
+          (exists(parcelFeature.properties?.PID) || exists(parcelFeature.properties?.PIN))
+        ) {
           pimsLocationProperties = await loadProperties({
             PID: parcelFeature.properties?.PID || '',
             PIN: parcelFeature.properties?.PIN?.toString() || '',


### PR DESCRIPTION
This issue would issue a request to the pims location layer with no pid/pin filter, which would then request all properties in PIMS, and then return the first property. 