### PR TITLE
psp-10020 AOSLCTR backwards-compatibility

### DIFF
--- a/source/frontend/src/features/mapSideBar/acquisition/__snapshots__/AcquisitionView.test.tsx.snap
+++ b/source/frontend/src/features/mapSideBar/acquisition/__snapshots__/AcquisitionView.test.tsx.snap
@@ -1799,7 +1799,9 @@ exports[`AcquisitionView component > renders as expected 1`] = `
                                 rel="noopener noreferrer"
                                 target="_blank"
                               >
-                                <span />
+                                <span>
+                                  Luke Skywalker
+                                </span>
                                 <svg
                                   class="m1-2"
                                   fill="currentColor"

--- a/source/frontend/src/features/mapSideBar/acquisition/tabs/fileDetails/detail/AcquisitionSummaryView.test.tsx
+++ b/source/frontend/src/features/mapSideBar/acquisition/tabs/fileDetails/detail/AcquisitionSummaryView.test.tsx
@@ -14,6 +14,7 @@ import { act, cleanup, render, RenderOptions, userEvent, waitForEffects } from '
 
 import AcquisitionSummaryView, { IAcquisitionSummaryViewProps } from './AcquisitionSummaryView';
 import { mockProjects } from '@/mocks/projects.mock';
+import { InterestHolderType } from '@/constants/interestHolderTypes';
 
 // mock auth library
 
@@ -270,11 +271,85 @@ describe('AcquisitionSummaryView component', () => {
     expect(getByTestId('assigned-date')).toHaveTextContent('Dec 18, 2024');
   });
 
+  it('renders multiple owner solicitor information with primary contact', async () => {
+    const { findByText, findAllByText } = setup(
+      {
+        acquisitionFile: {
+          ...mockAcquisitionFileResponse(),
+          acquisitionFileInterestHolders: [
+            {
+              interestHolderId: 1,
+              interestHolderType: toTypeCodeNullable(InterestHolderType.OWNER_SOLICITOR),
+
+              acquisitionFileId: 1,
+              personId: null,
+              person: null,
+              organizationId: 1,
+              organization: {
+                ...getEmptyOrganization(),
+                id: 1,
+                name: 'Millennium Inc',
+                alias: 'M Inc',
+                incorporationNumber: '1234',
+                comment: '',
+                contactMethods: null,
+                isDisabled: false,
+                organizationAddresses: null,
+                organizationPersons: null,
+                rowVersion: null,
+              },
+              interestHolderProperties: [],
+              primaryContactId: 1,
+              primaryContact: null,
+              comment: null,
+              isDisabled: false,
+              ...getEmptyBaseAudit(),
+            },
+            {
+              interestHolderId: 2,
+              interestHolderType: toTypeCodeNullable(InterestHolderType.OWNER_SOLICITOR),
+
+              acquisitionFileId: 1,
+              personId: null,
+              person: null,
+              organizationId: 2,
+              organization: {
+                ...getEmptyOrganization(),
+                id: 2,
+                name: 'Test Org',
+                alias: 'M Inc',
+                incorporationNumber: '12345',
+                comment: '',
+                contactMethods: null,
+                isDisabled: false,
+                organizationAddresses: null,
+                organizationPersons: null,
+                rowVersion: null,
+              },
+              interestHolderProperties: [],
+              primaryContactId: 2,
+              primaryContact: null,
+              comment: null,
+              isDisabled: false,
+              ...getEmptyBaseAudit(),
+            },
+          ],
+        },
+      },
+      { claims: [] },
+    );
+    await waitForEffects();
+    expect(await findByText('Millennium Inc')).toBeVisible();
+    expect(await findByText('Test Org')).toBeVisible();
+    expect(await findAllByText(/Primary contact/)).toHaveLength(2);
+  });
+
   it('renders owner solicitor information with primary contact', async () => {
     const { findByText } = setup(
       { acquisitionFile: mockAcquisitionFileResponse() },
       { claims: [] },
     );
+    await waitForEffects();
     expect(await findByText('Millennium Inc')).toBeVisible();
     expect(await findByText(/Primary contact/)).toBeVisible();
     expect(await findByText('Foo Bar Baz')).toBeVisible();

--- a/source/frontend/src/features/mapSideBar/acquisition/tabs/fileDetails/update/UpdateAcquisitionForm.test.tsx
+++ b/source/frontend/src/features/mapSideBar/acquisition/tabs/fileDetails/update/UpdateAcquisitionForm.test.tsx
@@ -12,6 +12,7 @@ import {
   act,
   fakeText,
   fireEvent,
+  getByTitle,
   render,
   RenderOptions,
   screen,
@@ -23,6 +24,12 @@ import {
 import { UpdateAcquisitionSummaryFormModel } from './models';
 import { UpdateAcquisitionFileYupSchema } from './UpdateAcquisitionFileYupSchema';
 import UpdateAcquisitionForm, { IUpdateAcquisitionFormProps } from './UpdateAcquisitionForm';
+import { toTypeCodeNullable } from '@/utils/formUtils';
+import { InterestHolderType } from '@/constants/interestHolderTypes';
+import { getEmptyOrganization } from '@/mocks/organization.mock';
+import { getEmptyPerson } from '@/mocks/contacts.mock';
+import { getEmptyBaseAudit } from '@/models/defaultInitializers';
+import { InterestHolderForm } from '../../stakeholders/update/models';
 
 const mockAxios = new MockAdapter(axios);
 
@@ -351,6 +358,84 @@ describe('UpdateAcquisitionForm component', () => {
       expect(getByText('+ Add Sub-interest')).toBeVisible();
       expect(getByText(/Sub-interest solicitor/i)).toBeVisible();
       expect(getByText(/Sub-interest representative/i)).toBeVisible();
+    });
+
+    it('renders multiple solicitors if present', async () => {
+      const { getByTitle, getAllByText } = setup({
+        initialValues: {
+          ...initialValues,
+          toApi: vi.fn(),
+          ownerSolicitors: [
+            InterestHolderForm.fromApi(
+              {
+                interestHolderId: 1,
+                interestHolderType: toTypeCodeNullable(InterestHolderType.OWNER_SOLICITOR),
+
+                acquisitionFileId: 1,
+                personId: null,
+                person: null,
+                organizationId: 1,
+                organization: {
+                  ...getEmptyOrganization(),
+                  id: 1,
+                  name: 'Millennium Inc',
+                  alias: 'M Inc',
+                  incorporationNumber: '1234',
+                  comment: '',
+                  contactMethods: null,
+                  isDisabled: false,
+                  organizationAddresses: null,
+                  organizationPersons: null,
+                  rowVersion: null,
+                },
+                interestHolderProperties: [],
+                primaryContactId: 1,
+                primaryContact: null,
+                comment: null,
+                isDisabled: false,
+                ...getEmptyBaseAudit(),
+              },
+              InterestHolderType.OWNER_SOLICITOR,
+            ),
+            InterestHolderForm.fromApi(
+              {
+                interestHolderId: 2,
+                interestHolderType: toTypeCodeNullable(InterestHolderType.OWNER_SOLICITOR),
+
+                acquisitionFileId: 1,
+                personId: null,
+                person: null,
+                organizationId: 2,
+                organization: {
+                  ...getEmptyOrganization(),
+                  id: 2,
+                  name: 'Test Org',
+                  alias: 'M Inc',
+                  incorporationNumber: '12345',
+                  comment: '',
+                  contactMethods: null,
+                  isDisabled: false,
+                  organizationAddresses: null,
+                  organizationPersons: null,
+                  rowVersion: null,
+                },
+                interestHolderProperties: [],
+                primaryContactId: 1,
+                primaryContact: null,
+                comment: null,
+                isDisabled: false,
+                ...getEmptyBaseAudit(),
+              },
+              InterestHolderType.OWNER_SOLICITOR,
+            ),
+          ],
+        },
+      });
+      await waitForEffects();
+
+      expect(getByTitle(/O1/i)).toBeVisible();
+      expect(getByTitle(/O2/i)).toBeVisible();
+      expect(getAllByText('Owner solicitor:')).toHaveLength(2);
     });
   });
 });

--- a/source/frontend/src/features/mapSideBar/acquisition/tabs/fileDetails/update/UpdateSolicitorsSubForm.tsx
+++ b/source/frontend/src/features/mapSideBar/acquisition/tabs/fileDetails/update/UpdateSolicitorsSubForm.tsx
@@ -1,0 +1,50 @@
+import { FieldArray, useFormikContext } from 'formik';
+import React from 'react';
+
+import { ContactInputContainer } from '@/components/common/form/ContactInput/ContactInputContainer';
+import ContactInputView from '@/components/common/form/ContactInput/ContactInputView';
+import { PrimaryContactSelector } from '@/components/common/form/PrimaryContactSelector/PrimaryContactSelector';
+import { SectionField } from '@/components/common/Section/SectionField';
+
+import { InterestHolderForm } from '../../stakeholders/update/models';
+import { UpdateAcquisitionSummaryFormModel } from './models';
+
+/** This sub form is only used for etl data, where multiple AOSLCTR may exist. In that case, allow the user to interact with those items. */
+export const UpdateSolicitorsSubForm: React.FunctionComponent<React.PropsWithChildren> = () => {
+  const { values } = useFormikContext<UpdateAcquisitionSummaryFormModel>();
+
+  return (
+    <FieldArray
+      name="ownerSolicitors"
+      render={() => (
+        <>
+          {values.ownerSolicitors.map((ownerSolicitor: InterestHolderForm, index: number) => (
+            <React.Fragment key={`owner-solicitor-${ownerSolicitor?.contact?.id ?? index}`}>
+              <SectionField
+                label="Owner solicitor"
+                className="mt-4"
+                labelWidth="4"
+                contentWidth="8"
+              >
+                <ContactInputContainer
+                  field={`ownerSolicitors.${index}.contact`}
+                  View={ContactInputView}
+                  displayErrorAsTooltip={false}
+                ></ContactInputContainer>
+              </SectionField>
+
+              {ownerSolicitor.contact?.organizationId && !ownerSolicitor.contact?.personId && (
+                <SectionField label="Primary contact" labelWidth="5" contentWidth="7">
+                  <PrimaryContactSelector
+                    field={`ownerSolicitors.${index}.primaryContactId`}
+                    contactInfo={ownerSolicitor?.contact}
+                  ></PrimaryContactSelector>
+                </SectionField>
+              )}
+            </React.Fragment>
+          ))}
+        </>
+      )}
+    />
+  );
+};

--- a/source/frontend/src/features/mapSideBar/acquisition/tabs/fileDetails/update/__snapshots__/UpdateAcquisitionForm.test.tsx.snap
+++ b/source/frontend/src/features/mapSideBar/acquisition/tabs/fileDetails/update/__snapshots__/UpdateAcquisitionForm.test.tsx.snap
@@ -3961,8 +3961,8 @@ exports[`UpdateAcquisitionForm component > Sub-interest files > renders as expec
                   >
                     <input
                       class="form-control"
-                      id="input-ownerSolicitor.contact.id"
-                      name="ownerSolicitor.contact.id"
+                      id="input-ownerSolicitors.0.contact.id"
+                      name="ownerSolicitors.0.contact.id"
                       placeholder="Select from Contacts"
                       style="word-break: break-all;"
                       title="O1"
@@ -4081,8 +4081,8 @@ exports[`UpdateAcquisitionForm component > Sub-interest files > renders as expec
                   >
                     <input
                       class="form-control"
-                      id="input-ownerRepresentative.contact.id"
-                      name="ownerRepresentative.contact.id"
+                      id="input-ownerRepresentatives.0.contact.id"
+                      name="ownerRepresentatives.0.contact.id"
                       placeholder="Select from Contacts"
                       style="word-break: break-all;"
                       title="P2"
@@ -4142,8 +4142,8 @@ exports[`UpdateAcquisitionForm component > Sub-interest files > renders as expec
             >
               <textarea
                 class="form-control"
-                id="input-ownerRepresentative.comment"
-                name="ownerRepresentative.comment"
+                id="input-ownerRepresentatives.0.comment"
+                name="ownerRepresentatives.0.comment"
                 placeholder="Remarks or additional representative(s)"
                 style="word-break: break-all;"
                 title="test representative comment"
@@ -8035,8 +8035,8 @@ exports[`UpdateAcquisitionForm component > renders as expected 1`] = `
                   >
                     <input
                       class="form-control"
-                      id="input-ownerSolicitor.contact.id"
-                      name="ownerSolicitor.contact.id"
+                      id="input-ownerSolicitors.0.contact.id"
+                      name="ownerSolicitors.0.contact.id"
                       placeholder="Select from Contacts"
                       style="word-break: break-all;"
                       title="O1"
@@ -8155,8 +8155,8 @@ exports[`UpdateAcquisitionForm component > renders as expected 1`] = `
                   >
                     <input
                       class="form-control"
-                      id="input-ownerRepresentative.contact.id"
-                      name="ownerRepresentative.contact.id"
+                      id="input-ownerRepresentatives.0.contact.id"
+                      name="ownerRepresentatives.0.contact.id"
                       placeholder="Select from Contacts"
                       style="word-break: break-all;"
                       title="P2"
@@ -8216,8 +8216,8 @@ exports[`UpdateAcquisitionForm component > renders as expected 1`] = `
             >
               <textarea
                 class="form-control"
-                id="input-ownerRepresentative.comment"
-                name="ownerRepresentative.comment"
+                id="input-ownerRepresentatives.0.comment"
+                name="ownerRepresentatives.0.comment"
                 placeholder="Remarks or additional representative(s)"
                 style="word-break: break-all;"
                 title="test representative comment"

--- a/source/frontend/src/features/mapSideBar/acquisition/tabs/fileDetails/update/models.ts
+++ b/source/frontend/src/features/mapSideBar/acquisition/tabs/fileDetails/update/models.ts
@@ -63,10 +63,12 @@ export class UpdateAcquisitionSummaryFormModel
   fundingTypeCode?: string;
   fundingTypeOtherDescription = '';
 
-  ownerSolicitor: InterestHolderForm = new InterestHolderForm(InterestHolderType.OWNER_SOLICITOR);
-  ownerRepresentative: InterestHolderForm = new InterestHolderForm(
-    InterestHolderType.OWNER_REPRESENTATIVE,
-  );
+  ownerSolicitors: InterestHolderForm[] = [
+    new InterestHolderForm(InterestHolderType.OWNER_SOLICITOR),
+  ];
+  ownerRepresentatives: InterestHolderForm[] = [
+    new InterestHolderForm(InterestHolderType.OWNER_REPRESENTATIVE),
+  ];
   otherInterestHolders: ApiGen_Concepts_InterestHolder[] = [];
   legacyStakeholders: string[] = [];
 
@@ -113,8 +115,18 @@ export class UpdateAcquisitionSummaryFormModel
         .filter(exists),
       acquisitionFileInterestHolders: [
         ...this.otherInterestHolders,
-        InterestHolderForm.toApi(this.ownerSolicitor, []),
-        InterestHolderForm.toApi(this.ownerRepresentative, []),
+        ...this.ownerSolicitors.map(os =>
+          InterestHolderForm.toApi(
+            { ...os, interestTypeCode: InterestHolderType.OWNER_SOLICITOR },
+            [],
+          ),
+        ),
+        ...this.ownerRepresentatives.map(or =>
+          InterestHolderForm.toApi(
+            { ...or, interestTypeCode: InterestHolderType.OWNER_REPRESENTATIVE },
+            [],
+          ),
+        ),
       ].filter(exists),
       fileChecklistItems: this.fileChecklist.map(x => x.toApi()),
       compensationRequisitions: null,
@@ -180,12 +192,12 @@ export class UpdateAcquisitionSummaryFormModel
     const interestHolders = model.acquisitionFileInterestHolders?.map(x =>
       InterestHolderForm.fromApi(x, x.interestHolderType?.id as InterestHolderType),
     );
-    newForm.ownerSolicitor =
-      interestHolders?.find(x => x.interestTypeCode === InterestHolderType.OWNER_SOLICITOR) ??
-      new InterestHolderForm(InterestHolderType.OWNER_SOLICITOR, model.id);
-    newForm.ownerRepresentative =
-      interestHolders?.find(x => x.interestTypeCode === InterestHolderType.OWNER_REPRESENTATIVE) ??
-      new InterestHolderForm(InterestHolderType.OWNER_REPRESENTATIVE, model.id);
+    newForm.ownerSolicitors = interestHolders?.filter(
+      x => x.interestTypeCode === InterestHolderType.OWNER_SOLICITOR,
+    ) ?? [new InterestHolderForm(InterestHolderType.OWNER_SOLICITOR, model.id)];
+    newForm.ownerRepresentatives = interestHolders?.filter(
+      x => x.interestTypeCode === InterestHolderType.OWNER_REPRESENTATIVE,
+    ) ?? [new InterestHolderForm(InterestHolderType.OWNER_REPRESENTATIVE, model.id)];
 
     newForm.otherInterestHolders =
       model.acquisitionFileInterestHolders?.filter(


### PR DESCRIPTION
ETL data created some (approx 100) files with multiple AOSLCTR rows. This is not accepted by the frontend - which only supports one AOSLCTR per file. Unfortunately, since those rows are related to compensation requisitions, it is not possible to edit those files using the frontend.

This PR adds a backwards-compatible UI, that will allow existing files with multiple AOSLCTR rows to display and be edited, whilst still presenting the single AOSLCTR for ordinary files.