### PR TITLE
psp-10562

### DIFF
--- a/source/frontend/src/components/common/mapFSM/machineDefinition/mapMachine.ts
+++ b/source/frontend/src/components/common/mapFSM/machineDefinition/mapMachine.ts
@@ -258,7 +258,6 @@ const selectedFeatureLoaderStates = {
           actions: [
             assign({
               isLoading: () => true,
-              mapLocationSelected: () => null,
               mapFeatureSelected: (_, event: any) => event.featureSelected,
               mapLocationFeatureDataset: () => null,
             }),
@@ -282,7 +281,6 @@ const selectedFeatureLoaderStates = {
         CLOSE_POPUP: {
           actions: [
             assign({
-              mapLocationSelected: () => null,
               mapFeatureSelected: () => null,
               mapLocationFeatureDataset: () => null,
             }),

--- a/source/frontend/src/components/maps/MapLeafletView.tsx
+++ b/source/frontend/src/components/maps/MapLeafletView.tsx
@@ -79,7 +79,6 @@ const MapLeafletView: React.FC<React.PropsWithChildren<MapLeafletViewProps>> = (
       return;
     }
     timer.current = setTimeout(() => {
-      mapMachine.mapClearLocationMark();
       mapMachine.mapClick(latlng);
       timer.current = null;
     }, doubleClickInterval ?? 250);

--- a/source/frontend/src/components/maps/leaflet/LayerPopup/LayerPopupView.tsx
+++ b/source/frontend/src/components/maps/leaflet/LayerPopup/LayerPopupView.tsx
@@ -184,6 +184,7 @@ export const LayerPopupView: React.FC<React.PropsWithChildren<ILayerPopupViewPro
       </SimplePagination>
       <LayerPopupLinks
         onViewPropertyInfo={handleViewPropertyInfo}
+        latLng={layerPopup.latlng}
         bounds={getFirstBounds(layerPopup.layers)}
         onEllipsisClick={showFlyout ? closeFlyout : openFlyout}
         showViewPropertyInfo={showViewPropertyInfo}

--- a/source/frontend/src/components/maps/leaflet/LayerPopup/components/LayerPopupLinks.test.tsx
+++ b/source/frontend/src/components/maps/leaflet/LayerPopup/components/LayerPopupLinks.test.tsx
@@ -14,6 +14,7 @@ vi.mock('react-leaflet');
 // Mock react-leaflet dependencies
 const mapMachineMock: Partial<IMapStateMachineContext> = {
   requestFlyToBounds: vi.fn(),
+  requestFlyToLocation: vi.fn(),
 };
 
 const northEast = new L.LatLng(50.5, -120.7);
@@ -35,6 +36,7 @@ describe('Layer Popup links', () => {
       bounds: new L.LatLngBounds(southWest, northEast),
       onViewPropertyInfo: onViewPropertyInfoFn,
       showViewPropertyInfo: true,
+      latLng: undefined,
     });
     expect(asFragment()).toMatchSnapshot();
   });
@@ -44,6 +46,7 @@ describe('Layer Popup links', () => {
       bounds: new L.LatLngBounds(southWest, northEast),
       onViewPropertyInfo: onViewPropertyInfoFn,
       showViewPropertyInfo: true,
+      latLng: undefined,
     });
     const link = getByText(/Zoom/i);
     expect(link).toBeInTheDocument();
@@ -55,6 +58,7 @@ describe('Layer Popup links', () => {
       bounds: new L.LatLngBounds(southWest, northEast),
       onViewPropertyInfo: onViewPropertyInfoFn,
       showViewPropertyInfo: true,
+      latLng: undefined,
     });
     const link = getByText(/Zoom/i);
     expect(link).toBeInTheDocument();
@@ -63,11 +67,27 @@ describe('Layer Popup links', () => {
     expect(mapMachineMock.requestFlyToBounds).toBeCalled();
   });
 
+  it(`Zooms the map to property location when Zoom link is clicked`, async () => {
+    // render popup
+    const { getByText } = renderLinks({
+      bounds: undefined,
+      onViewPropertyInfo: onViewPropertyInfoFn,
+      showViewPropertyInfo: true,
+      latLng: southWest,
+    });
+    const link = getByText(/Zoom/i);
+    expect(link).toBeInTheDocument();
+    // click link
+    await act(async () => userEvent.click(link));
+    expect(mapMachineMock.requestFlyToLocation).toBeCalled();
+  });
+
   it('calls onViewPropertyInfo when link clicked', async () => {
     const { getByText } = renderLinks({
       bounds: new L.LatLngBounds(southWest, northEast),
       onViewPropertyInfo: onViewPropertyInfoFn,
       showViewPropertyInfo: true,
+      latLng: undefined,
     });
 
     const link = getByText('View Property Info');

--- a/source/frontend/src/components/maps/leaflet/LayerPopup/components/LayerPopupLinks.tsx
+++ b/source/frontend/src/components/maps/leaflet/LayerPopup/components/LayerPopupLinks.tsx
@@ -1,4 +1,4 @@
-import { LatLngBounds } from 'leaflet';
+import { LatLngBounds, LatLngLiteral } from 'leaflet';
 import noop from 'lodash/noop';
 import React, { useCallback } from 'react';
 import { FaEllipsisH, FaEye, FaSearchPlus } from 'react-icons/fa';
@@ -7,9 +7,11 @@ import styled from 'styled-components';
 import { LinkButton } from '@/components/common/buttons';
 import { useMapStateMachine } from '@/components/common/mapFSM/MapStateMachineContext';
 import TooltipWrapper from '@/components/common/TooltipWrapper';
+import { exists } from '@/utils/utils';
 
 export interface ILayerPopupLinksProps {
   bounds: LatLngBounds | undefined;
+  latLng: LatLngLiteral | undefined;
   onEllipsisClick?: () => void;
   onViewPropertyInfo: (event: React.MouseEvent<HTMLElement>) => void;
   showViewPropertyInfo: boolean;
@@ -17,17 +19,20 @@ export interface ILayerPopupLinksProps {
 
 export const LayerPopupLinks: React.FC<React.PropsWithChildren<ILayerPopupLinksProps>> = ({
   bounds,
+  latLng,
   onViewPropertyInfo,
   onEllipsisClick,
   showViewPropertyInfo,
 }) => {
-  const { requestFlyToBounds } = useMapStateMachine();
+  const { requestFlyToBounds, requestFlyToLocation } = useMapStateMachine();
 
   const onZoomToBounds = useCallback(() => {
-    if (bounds !== undefined) {
+    if (exists(bounds)) {
       requestFlyToBounds(bounds);
+    } else if (exists(latLng)) {
+      requestFlyToLocation(latLng);
     }
-  }, [requestFlyToBounds, bounds]);
+  }, [bounds, latLng, requestFlyToBounds, requestFlyToLocation]);
 
   return (
     <StyledContainer>

--- a/source/frontend/src/components/maps/leaflet/Layers/MarkerLayer.tsx
+++ b/source/frontend/src/components/maps/leaflet/Layers/MarkerLayer.tsx
@@ -1,5 +1,5 @@
 import { BBox } from 'geojson';
-import { LatLngBounds } from 'leaflet';
+import { LatLngBounds, LeafletMouseEvent } from 'leaflet';
 import React, { useMemo } from 'react';
 import { FeatureGroup, Marker, useMap } from 'react-leaflet';
 
@@ -71,7 +71,16 @@ export const MarkerLayer: React.FC<React.PropsWithChildren<InventoryLayerProps>>
 
       {exists(markedLocation) && (
         <FeatureGroup>
-          <Marker position={markedLocation} icon={getNotOwnerMarkerIcon(true)} />
+          <Marker
+            position={markedLocation}
+            icon={getNotOwnerMarkerIcon(true)}
+            eventHandlers={{
+              click: (e: LeafletMouseEvent) => {
+                e.originalEvent.stopPropagation();
+                mapMachine.mapClick(markedLocation);
+              },
+            }}
+          />
         </FeatureGroup>
       )}
     </>


### PR DESCRIPTION
marked location popups should allow clicks.
clicking elsewhere on the map should not remove makred location popups. allow zooming to lat/lng in addition to boundaries.