### PR TITLE
fix dockerfiles. replace explicit imports with importing the entire b…

### DIFF
--- a/source/backend/Dockerfile
+++ b/source/backend/Dockerfile
@@ -6,28 +6,13 @@ EXPOSE 5001 5000
 # Copy csproj and restore as distinct layers
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
-COPY Directory.Build.props .
-COPY api/*.csproj api/
-COPY apimodels/*.csproj apimodels/
-COPY entities/*.csproj entities/
-COPY tests/core/*.csproj tests/core/
-COPY tests/unit/api/*.csproj tests/unit/api/
-COPY tests/unit/dal/*.csproj tests/unit/dal/
-COPY tests/unit/mockdal/*.csproj tests/unit/mockdal/
-COPY dal/*.csproj dal/
-COPY dal.keycloak/*.csproj dal.keycloak/
-COPY keycloak/*.csproj keycloak/
-COPY geocoder/*.csproj geocoder/
-COPY core/*.csproj core/
-COPY core.api/*.csproj core.api/
-COPY ltsa/*.csproj ltsa/
-COPY clamav/*.csproj clamav/
+COPY . .
 
 RUN dotnet restore
 ENV PATH="$PATH:/root/.dotnet/tools"
 RUN dotnet tool install --global dotnet-ef --version 5.0.0
 # Copy everything else and build
-COPY . .
+
 WORKDIR /src/api
 RUN dotnet build "Pims.Api.csproj" -c "$BUILD_CONFIGURATION" -o /app/build
 
@@ -38,6 +23,6 @@ RUN dotnet publish "Pims.Api.csproj" -c "$BUILD_CONFIGURATION" -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-COPY api/entrypoint.sh .
+COPY ./entrypoint.sh .
 RUN chmod +x /app/entrypoint.sh
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/source/backend/Dockerfile.proxy
+++ b/source/backend/Dockerfile.proxy
@@ -6,13 +6,7 @@ EXPOSE 5001 5000
 # Copy csproj and restore as distinct layers
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
-COPY proxy proxy/
-COPY proxy/Directory.Build.props proxy/
-COPY api api/
-COPY core core/
-COPY core.api core.api/
-COPY keycloak keycloak/
-COPY proxy/*.csproj proxy/
+COPY . .
 
 RUN dotnet restore proxy/Pims.Proxy.csproj
 ENV PATH="$PATH:/root/.dotnet/tools"

--- a/source/backend/Dockerfile.scheduler
+++ b/source/backend/Dockerfile.scheduler
@@ -6,14 +6,7 @@ EXPOSE 5001 5000
 # Copy csproj and restore as distinct layers
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
-COPY scheduler scheduler/
-COPY scheduler/Directory.Build.props ./
-COPY core core/
-COPY apimodels apimodels/
-COPY entities entities/
-COPY core.api core.api/
-COPY keycloak keycloak/
-COPY scheduler/*.csproj scheduler/
+COPY . .
 
 RUN dotnet restore scheduler/Pims.Scheduler.csproj
 ENV PATH="$PATH:/root/.dotnet/tools"


### PR DESCRIPTION
…ackend folder.

I know we don't use these much, but they shouldn't be broken.

I tried just fixing the specific imports, but was getting difficult to diagnose issues with the target framework being overwritten by null during restore/build. Given that this is only used during dev and not by most of us, this seemed like a fair compromise.