### PR TITLE
PSP-10816 HOTFIX - Management: User is not able to update the status of file to "with 3rd Party"

### DIFF
--- a/source/backend/api/Pims.Api.csproj
+++ b/source/backend/api/Pims.Api.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <UserSecretsId>0ef6255f-9ea0-49ec-8c65-c172304b4926</UserSecretsId>
-    <Version>5.12.3-108.30</Version>
-    <AssemblyVersion>5.12.3.108</AssemblyVersion>
+    <Version>5.12.4-108.30</Version>
+    <AssemblyVersion>5.12.4.108</AssemblyVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ProjectGuid>{16BC0468-78F6-4C91-87DA-7403C919E646}</ProjectGuid>
     <TargetFramework>net8.0</TargetFramework>

--- a/source/backend/api/Services/ManagementFileService.cs
+++ b/source/backend/api/Services/ManagementFileService.cs
@@ -107,7 +107,7 @@ namespace Pims.Api.Services
             ValidateName(managementFile);
 
             ManagementFileStatusTypes? currentManagementStatus = GetCurrentManagementStatus(managementFile.Internal_Id);
-            ManagementFileStatusTypes newManagementStatus = (ManagementFileStatusTypes)Enum.Parse(typeof(ManagementFileStatusTypes), managementFile.ManagementFileStatusTypeCode);
+            ManagementFileStatusTypes newManagementStatus = Core.Extensions.EnumExtensions.GetValueFromEnumMember<ManagementFileStatusTypes>(managementFile.ManagementFileStatusTypeCode);
             ValidateStatus(currentManagementStatus, newManagementStatus);
 
             ValidateVersion(id, managementFile.ConcurrencyControlNumber);
@@ -520,7 +520,7 @@ namespace Pims.Api.Services
                 return currentManagementFileStatus;
             }
 
-            return currentManagementFileStatus;
+            return Core.Extensions.EnumExtensions.GetValueFromEnumMember<ManagementFileStatusTypes>(currentManagementFile.ManagementFileStatusTypeCode);
         }
 
     }

--- a/source/backend/core/Extensions/EnumExtensions.cs
+++ b/source/backend/core/Extensions/EnumExtensions.cs
@@ -1,6 +1,8 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
 using Pims.Core.Security;
 
 namespace Pims.Core.Extensions
@@ -62,6 +64,28 @@ namespace Pims.Core.Extensions
             var attribute = (DisplayAttribute)enumValueMemberInfo.GetCustomAttributes(typeof(DisplayAttribute), false).FirstOrDefault();
             return attribute.Name;
         }
+
+        public static T GetValueFromEnumMember<T>(string value)
+            where T : Enum
+        {
+            var enumType = typeof(T);
+            if (!enumType.GetTypeInfo().IsEnum)
+            {
+                throw new InvalidOperationException("Not an Enum");
+            }
+
+            foreach (var name in Enum.GetNames(enumType))
+            {
+                var attr = enumType.GetRuntimeField(name).GetCustomAttribute<EnumMemberAttribute>(true);
+                if (attr != null && attr.Value == value)
+                {
+                    return (T)Enum.Parse(enumType, name);
+                }
+            }
+
+            return default(T);
+        }
+
         #endregion
     }
 }

--- a/source/backend/tests/dal/Core/Extensions/EnumExtensionsTest.cs
+++ b/source/backend/tests/dal/Core/Extensions/EnumExtensionsTest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
 using FluentAssertions;
 using Pims.Core.Extensions;
 using Xunit;
@@ -52,6 +53,33 @@ namespace Pims.Api.Test.Core.Extensions
             result.Should().Be(expectedResult);
         }
         #endregion
+
+        [Fact]
+        public void Enum_GetValueFromEnumMember_Success()
+        {
+            // Arrange
+            var value = "A";
+
+            // Act
+            var result = EnumExtensions.GetValueFromEnumMember<TestEnum2>(value);
+
+            // Assert
+            result.Should().Be(TestEnum2.Alpha);
+        }
+
+        [Fact]
+        public void Enum_GetValueFromEnumMember_Failure()
+        {
+            // Arrange
+            var value = "Z";
+
+            // Act
+            var result = EnumExtensions.GetValueFromEnumMember<TestEnum2>(value);
+
+            // Assert
+            result.Should().Be(default);
+        }
+
         #endregion
 
         public enum TestEnum
@@ -59,6 +87,15 @@ namespace Pims.Api.Test.Core.Extensions
             Utf8,
             Binary,
             Hex,
+        }
+
+        public enum TestEnum2
+        {
+            [EnumMember(Value = "A")]
+            Alpha,
+
+            [EnumMember(Value = "O")]
+            Omega
         }
     }
 }

--- a/source/frontend/package-lock.json
+++ b/source/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "5.12.3-108.8",
+  "version": "5.12.4-108.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "5.12.2-108.8",
+      "version": "5.12.4-108.30",
       "dependencies": {
         "@bcgov/bc-sans": "1.0.1",
         "@bcgov/design-tokens": "3.0.0-rc1",

--- a/source/frontend/package.json
+++ b/source/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "5.12.3-108.30",
+  "version": "5.12.4-108.30",
   "private": true,
   "dependencies": {
     "@bcgov/bc-sans": "1.0.1",


### PR DESCRIPTION
The root cause is an enum where the string value doesn't match the enum field name. This causes **Enum.Parse()** to throw because Enum.Parse doesn't look into the annotations

```cs
    public enum ManagementFileStatusTypes
    {
        [EnumMember(Value = "HOLD")]
        HOLD,

        [EnumMember(Value = "3RDPARTY")] // This is what causes the error THIRDPARTY <> 3RDPARTY
        THIRDRDPARTY,
    }
```