### PR TITLE
Fix in PIMS_S119_00 Build

### DIFF
--- a/source/database/mssql/scripts/dbscripts/PSP_PIMS_S119_00/Build/075_DML_PIMS_ROLE_CLAIM.sql
+++ b/source/database/mssql/scripts/dbscripts/PSP_PIMS_S119_00/Build/075_DML_PIMS_ROLE_CLAIM.sql
@@ -3519,7 +3519,7 @@ VALUES
     ),
     (
         @disprdon,
-        @notificationdd,
+        @notificationAdd,
         N'SEED',
         @appUserGuid,
         N'SEED',


### PR DESCRIPTION
Fix the following error:
```
Must declare the scalar variable "@notificationdd".

======= SCRIPT PSP_PIMS_S119_00/Build/075_DML_PIMS_ROLE_CLAIM.sql RETURNS AN ERROR. =========
```