### PR TITLE
PSP-11333: When saving a property that is in the MOTT Inventory but lacks of spatial data, the property is saved within the file but it doesn't navigate back to the View form

### DIFF
--- a/source/frontend/src/features/mapSideBar/acquisition/AcquisitionContainer.tsx
+++ b/source/frontend/src/features/mapSideBar/acquisition/AcquisitionContainer.tsx
@@ -263,6 +263,9 @@ export const AcquisitionContainer: React.FunctionComponent<IAcquisitionContainer
     await fetchLastUpdatedBy();
     mapMachine.refreshMapProperties();
     setIsEditing(false);
+    if (acquisitionFileId) {
+      pathGenerator.showFile('acquisition', acquisitionFileId);
+    }
   };
 
   const canRemove = async () => {

--- a/source/frontend/src/features/mapSideBar/acquisition/AcquisitionContainer.tsx
+++ b/source/frontend/src/features/mapSideBar/acquisition/AcquisitionContainer.tsx
@@ -263,7 +263,7 @@ export const AcquisitionContainer: React.FunctionComponent<IAcquisitionContainer
     await fetchLastUpdatedBy();
     mapMachine.refreshMapProperties();
     setIsEditing(false);
-    if (acquisitionFileId) {
+    if (isValidId(acquisitionFileId)) {
       pathGenerator.showFile('acquisition', acquisitionFileId);
     }
   };


### PR DESCRIPTION
When the user adds a property with no boundary or location, they are prompted with the modal “User Override Required.” When the user accepts, the navigation goes to Update Property instead of the file details.
<img width="598" height="354" alt="image" src="https://github.com/user-attachments/assets/96df5e46-ccea-4f98-a099-ebc9a44b4b7d" />

The fix allows the user to navigate to file details instead of having to click on Cancel button to go tack to file details.
<img width="937" height="510" alt="image" src="https://github.com/user-attachments/assets/a70f6d37-c018-48d0-8c69-22dab5fd899b" />


[Jira](https://moti-imb.atlassian.net/browse/PSP-11333)