### PR TITLE
PSP-11411: [HOTFIX] Acquisition Files - When update information on any tab from an Acquisition File, PIMS navigates back to FIle Details instead of staying at the chosen tab - view form

### DIFF
--- a/source/frontend/package.json
+++ b/source/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "6.1.1-119.16",
+  "version": "6.1.0-119.16",
   "private": true,
   "dependencies": {
     "@bcgov/bc-sans": "1.0.1",

--- a/source/frontend/package.json
+++ b/source/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "6.1.0-119.16",
+  "version": "6.1.1-119.16",
   "private": true,
   "dependencies": {
     "@bcgov/bc-sans": "1.0.1",

--- a/source/frontend/src/features/mapSideBar/acquisition/AcquisitionContainer.tsx
+++ b/source/frontend/src/features/mapSideBar/acquisition/AcquisitionContainer.tsx
@@ -263,9 +263,6 @@ export const AcquisitionContainer: React.FunctionComponent<IAcquisitionContainer
     await fetchLastUpdatedBy();
     mapMachine.refreshMapProperties();
     setIsEditing(false);
-    if (isValidId(acquisitionFileId)) {
-      pathGenerator.showFile('acquisition', acquisitionFileId);
-    }
   };
 
   const canRemove = async () => {
@@ -308,6 +305,9 @@ export const AcquisitionContainer: React.FunctionComponent<IAcquisitionContainer
           )
           .then(response => {
             onSuccess();
+            if (isValidId(response?.id)) {
+              pathGenerator.showFile('acquisition', response.id);
+            }
             return response;
           });
       },

--- a/source/frontend/src/features/mapSideBar/research/ResearchContainer.tsx
+++ b/source/frontend/src/features/mapSideBar/research/ResearchContainer.tsx
@@ -240,6 +240,9 @@ export const ResearchContainer: React.FunctionComponent<IResearchContainerProps>
           userOverrideCodes,
         ).then(response => {
           onSuccess();
+          if (isValidId(response?.id)) {
+            pathGenerator.showFile('acquisition', response.id);
+          }
           return response;
         });
       },

--- a/source/frontend/src/features/mapSideBar/research/ResearchContainer.tsx
+++ b/source/frontend/src/features/mapSideBar/research/ResearchContainer.tsx
@@ -241,7 +241,7 @@ export const ResearchContainer: React.FunctionComponent<IResearchContainerProps>
         ).then(response => {
           onSuccess();
           if (isValidId(response?.id)) {
-            pathGenerator.showFile('acquisition', response.id);
+            pathGenerator.showFile('research', response.id);
           }
           return response;
         });


### PR DESCRIPTION
The previous [PR](https://github.com/bcgov/PSP/pull/5277) added the logic to navigate to fileDetails in `onSuccess` function. However, this is shared among the child components in the Container. This caused that when saving changes in Stakeholder the navigation sent the user to fileDetails.

The change needs to be apply only for updating properties in the container and after `onSuccess` execution to add the customized logic to redirect the user to fileDetails. During my review I also found ResearchContainer presented the same issue when properties with no location are added. The other containers include the logic added to Acquisition and Research.


[Jira](https://moti-imb.atlassian.net/browse/PSP-11411)