### PR TITLE
PSP-11455: Remove duplicate View Project icon on Manage Projects screen

### DIFF
--- a/source/frontend/src/features/projects/list/ProjectSearchResults/columns.tsx
+++ b/source/frontend/src/features/projects/list/ProjectSearchResults/columns.tsx
@@ -15,11 +15,6 @@ export const columns: ColumnWithProps<ProjectSearchResultModel>[] = [
     sortable: true,
     width: 5,
     maxWidth: 20,
-    Cell: (props: CellProps<ProjectSearchResultModel>) => (
-      <ExternalLink to={`/mapview/sidebar/project/${props.row.original.id}`}>
-        {props.row.original.code}
-      </ExternalLink>
-    ),
   },
   {
     Header: 'Project name',


### PR DESCRIPTION
<img width="1902" height="726" alt="image" src="https://github.com/user-attachments/assets/055ef067-843e-42c3-b0f2-b3484750e47d" />
