### PR TITLE
PSP-11228: FT:Chevron icon direction incorrect for expanded/collapsed state in Common Property section

### DIFF
--- a/source/frontend/src/features/properties/worklist/worklistItem/WorklistItemView.tsx
+++ b/source/frontend/src/features/properties/worklist/worklistItem/WorklistItemView.tsx
@@ -1,7 +1,8 @@
 import { Collapse } from 'react-bootstrap';
+import { MdArrowRight } from 'react-icons/md';
 import styled from 'styled-components';
 
-import { ArrowDropDownIcon, ArrowDropUpIcon } from '@/components/common/Section/SectionStyles';
+import { ArrowDropDownIcon } from '@/components/common/Section/SectionStyles';
 
 import ParcelItem from '../../parcelList/ParcelItem';
 import { WorklistItemModel } from './models/WorklistItem.model';
@@ -33,8 +34,8 @@ export const WorklistItemView: React.FC<CommonPropertyItemViewProps> = ({
             }}
             data-testid={`worklist-item[${parcelIndex}].collapse-btn`}
           >
-            {isCollapsed && <ArrowDropDownIcon />}
-            {!isCollapsed && <ArrowDropUpIcon />}
+            {isCollapsed && <MdArrowRight size={30} fill="#1a5a96" />}
+            {!isCollapsed && <ArrowDropDownIcon fill="#1a5a96" />}
           </StyledArrowCollapseDiv>
           <StyledHeaderParcelDiv data-testid={`worklist-item[${parcelIndex}].parcel`}>
             <ParcelItem

--- a/source/frontend/src/features/properties/worklist/worklistItem/WorklistItemView.tsx
+++ b/source/frontend/src/features/properties/worklist/worklistItem/WorklistItemView.tsx
@@ -34,8 +34,8 @@ export const WorklistItemView: React.FC<CommonPropertyItemViewProps> = ({
             }}
             data-testid={`worklist-item[${parcelIndex}].collapse-btn`}
           >
-            {isCollapsed && <MdArrowRight size={30} fill="#1a5a96" />}
-            {!isCollapsed && <ArrowDropDownIcon fill="#1a5a96" />}
+            {isCollapsed && <StyledClosedIcon />}
+            {!isCollapsed && <StyledOpenIcon />}
           </StyledArrowCollapseDiv>
           <StyledHeaderParcelDiv data-testid={`worklist-item[${parcelIndex}].parcel`}>
             <ParcelItem
@@ -142,6 +142,16 @@ const StyledHeaderParcelDiv = styled.div`
 
 const StyledSectionGroupDiv = styled.div`
   padding-left: 3rem;
+`;
+
+const StyledOpenIcon = styled(ArrowDropDownIcon)`
+  font-size: 2.4rem;
+  color: ${props => props.theme.css.pimsBlue200};
+`;
+
+const StyledClosedIcon = styled(MdArrowRight)`
+  font-size: 2.4rem;
+  color: ${props => props.theme.css.pimsBlue200};
 `;
 
 export default WorklistItemView;


### PR DESCRIPTION
<img width="360" height="230" alt="image" src="https://github.com/user-attachments/assets/f281e02a-8a3c-49e7-9759-581c587151c5" />
<img width="323" height="203" alt="image" src="https://github.com/user-attachments/assets/d196b03e-a54b-44b1-9a5e-6ec6779370cf" />
