### PR TITLE
PSP-11923: FT: Acquisition Files - When an acquisition file is created with pre-populated owners, an error is displayed.

### DIFF
--- a/source/frontend/src/features/mapSideBar/acquisition/add/AddAcquisitionContainer.tsx
+++ b/source/frontend/src/features/mapSideBar/acquisition/add/AddAcquisitionContainer.tsx
@@ -162,7 +162,7 @@ export const AddAcquisitionContainer: React.FC<IAddAcquisitionContainerProps> = 
         owner.incorporationNumber = ownerData.incorporationNumber ?? '';
         owner.isFromLtsa = true;
         owner.ltsaPid = pid;
-        owner.ltsaSourcedDate = new Date().toUTCString();
+        owner.ltsaSourcedDate = new Date().toISOString().slice(0, 10);
         return owner;
       });
 

--- a/source/frontend/src/features/mapSideBar/acquisition/common/update/acquisitionOwners/UpdateAcquisitionOwnersSubForm.tsx
+++ b/source/frontend/src/features/mapSideBar/acquisition/common/update/acquisitionOwners/UpdateAcquisitionOwnersSubForm.tsx
@@ -11,7 +11,7 @@ import { InlineMessage } from '@/components/common/Section/SectionStyles';
 import { H3 } from '@/components/common/styles';
 import Address from '@/features/contacts/contact/create/components/address/Address';
 import { exists } from '@/utils';
-import { prettyFormatDateTime } from '@/utils/dateUtils';
+import { prettyFormatDate } from '@/utils/dateUtils';
 
 import { TeamMemberFormModal } from '../../modals/AcquisitionFormModal';
 import {
@@ -113,8 +113,7 @@ const UpdateAcquisitionOwnersSubForm: React.FC<{ isSubFile?: boolean }> = ({
               <Container>
                 {showOwnerLtsaMessage(owner) && (
                   <StyledLtsaMessage>
-                    This data was retrieved from LTSA on{' '}
-                    {prettyFormatDateTime(owner.ltsaSourcedDate)}
+                    This data was retrieved from LTSA on {prettyFormatDate(owner.ltsaSourcedDate)}
                   </StyledLtsaMessage>
                 )}
 


### PR DESCRIPTION
Updated LtsaSourcedDate to show the user only Date in the UI.  `toISOString()` converts the date/time to UTC in ISO 8601 format, and .slice(0, 10) extracts the date portion in the standard YYYY-MM-DD format. This provides the expected UTC date-only value, unlike toUTCString(), which returns a full date-time string such as `Fri, 21 Aug 2026 19:59:12 GMT`.

[Jira](https://moti-imb.atlassian.net/browse/PSP-11923)


