### PR TITLE
PSP-11924: FT: Subdivision & Consolidations

### DIFF
--- a/source/backend/api/Services/PropertyOperationService.cs
+++ b/source/backend/api/Services/PropertyOperationService.cs
@@ -108,7 +108,7 @@ namespace Pims.Api.Services
 
             if (incomingSourceKeys.Count != 1)
             {
-                throw new BusinessRuleViolationException("All property operations must have the same PIMS parent property.");
+                throw new BusinessRuleViolationException("All property operations must have the same PIMS source parcel.");
             }
         }
 
@@ -171,7 +171,7 @@ namespace Pims.Api.Services
 
             if (propertyOperations.Any(op => op.SourcePropertyId != firstSourcePropertyId))
             {
-                throw new BusinessRuleViolationException("All property operations must have the same PIMS parent property.");
+                throw new BusinessRuleViolationException("All property operations must have the same PIMS source parcel.");
             }
 
             if (propertyOperations.Select(o => o.DestinationProperty).Count() < 2)
@@ -204,7 +204,7 @@ namespace Pims.Api.Services
 
             if (propertyOperations.Any(op => op.DestinationProperty.Pid != destinationProperty.Pid))
             {
-                throw new BusinessRuleViolationException("All property operations must have the same child property with the same PID.");
+                throw new BusinessRuleViolationException("All property operations must have the same consolidated parcel with the same PID.");
             }
 
             var distinctSourceCount = propertyOperations
@@ -216,7 +216,7 @@ namespace Pims.Api.Services
 
             if (distinctSourceCount < 2)
             {
-                throw new BusinessRuleViolationException("Consolidations must contain at least two different parent properties.");
+                throw new BusinessRuleViolationException("Consolidations must contain at least two source parcels.");
             }
         }
 
@@ -283,7 +283,7 @@ namespace Pims.Api.Services
                 // if the property exists in pims, it must also be present in the source properties list.
                 if (!dbSourceProperties.Any(sp => sp.PropertyId == dbDestinationProperty?.PropertyId))
                 {
-                    throw new BusinessRuleViolationException("Consolidated child property may not be in the PIMS inventory unless also in the parent property list.");
+                    throw new BusinessRuleViolationException("Consolidated parcel may not be in the PIMS inventory unless also in the source parcel list.");
                 }
             }
             catch (KeyNotFoundException)

--- a/source/backend/tests/api/Services/PropertyOperationServiceTest.cs
+++ b/source/backend/tests/api/Services/PropertyOperationServiceTest.cs
@@ -175,7 +175,7 @@ namespace Pims.Api.Test.Services
 
             // Assert
             var exception = act.Should().Throw<BusinessRuleViolationException>();
-            exception.WithMessage("All property operations must have the same PIMS parent property.");
+            exception.WithMessage("All property operations must have the same PIMS source parcel.");
         }
 
         [Fact]
@@ -426,7 +426,7 @@ namespace Pims.Api.Test.Services
 
             // Assert
             var exception = act.Should().Throw<BusinessRuleViolationException>();
-            exception.WithMessage("Consolidations must contain at least two different parent properties.");
+            exception.WithMessage("Consolidations must contain at least two source parcels.");
         }
 
         [Fact]
@@ -535,7 +535,7 @@ namespace Pims.Api.Test.Services
 
             // Assert
             var exception = act.Should().Throw<BusinessRuleViolationException>();
-            exception.WithMessage("All property operations must have the same child property with the same PID.");
+            exception.WithMessage("All property operations must have the same consolidated parcel with the same PID.");
         }
 
         [Fact]
@@ -598,7 +598,7 @@ namespace Pims.Api.Test.Services
 
             // Assert
             var exception = act.Should().Throw<BusinessRuleViolationException>();
-            exception.WithMessage("Consolidated child property may not be in the PIMS inventory unless also in the parent property list.");
+            exception.WithMessage("Consolidated parcel may not be in the PIMS inventory unless also in the source parcel list.");
         }
 
         [Fact]

--- a/source/frontend/src/components/propertySelector/search/PropertySelectorPidSearchContainer.test.tsx
+++ b/source/frontend/src/components/propertySelector/search/PropertySelectorPidSearchContainer.test.tsx
@@ -2,7 +2,7 @@ import { FormikProps } from 'formik';
 import { createMemoryHistory } from 'history';
 import { createRef } from 'react';
 
-import { createAxiosError, renderAsync, RenderOptions, screen } from '@/utils/test-utils';
+import { act, createAxiosError, renderAsync, RenderOptions, screen } from '@/utils/test-utils';
 import PropertySelectorPidSearchContainer, {
   PropertySelectorPidSearchContainerProps,
 } from './PropertySelectorPidSearchContainer';
@@ -80,7 +80,9 @@ describe('PropertySearchPidSelector component', () => {
 
     await setup();
 
-    await viewProps?.onSearch({ pid: '111-111-111' });
+    await act(async () => {
+      await viewProps?.onSearch({ pid: '111-111-111' });
+    });
 
     expect(mockGetByPidWrapper.execute).toHaveBeenCalledWith('111-111-111');
   });

--- a/source/frontend/src/components/propertySelector/search/PropertySelectorPidSearchContainer.tsx
+++ b/source/frontend/src/components/propertySelector/search/PropertySelectorPidSearchContainer.tsx
@@ -37,8 +37,21 @@ export const PropertySelectorPidSearchContainer: React.FunctionComponent<
               handleOk: () => setDisplayModal(false),
             });
             setDisplayModal(true);
-          } else if (result?.property) {
-            setSelectProperty(result.property);
+          } else if (result?.foundInPims === false && result?.property) {
+            setModalContent({
+              variant: 'info',
+              cancelButtonText: 'No',
+              okButtonText: 'Yes',
+              title: 'Property not in PIMS',
+              message:
+                'This property is not currently in PIMS. In order to subdivide/consolidate this property, it will need to be added to PIMS as an owned property. Proceed?',
+              handleOk: () => {
+                setSelectProperty(result.property);
+                setDisplayModal(false);
+              },
+              handleCancel: () => setDisplayModal(false),
+            });
+            setDisplayModal(true);
           } else {
             setModalContent({
               variant: 'error',

--- a/source/frontend/src/features/mapSideBar/consolidation/AddConsolidationContainer.tsx
+++ b/source/frontend/src/features/mapSideBar/consolidation/AddConsolidationContainer.tsx
@@ -106,11 +106,11 @@ const AddConsolidationContainer: React.FC<IAddConsolidationContainerProps> = ({
         message: (
           <>
             <p>
-              You are consolidating two or more properties into one. The old parent properties
-              records will be retired, and a new child property will be created.
+              You are consolidating two or more properties into one. The old source parcel records
+              will be retired, and a new consolidated parcel will be created.
             </p>
             <p>
-              If you proceed, you will be redirected to the new child property record, where you can
+              If you proceed, you will be redirected to the new consolidated parcel record, where
               view changes and make updates. Do you want to proceed?
             </p>
           </>

--- a/source/frontend/src/features/mapSideBar/consolidation/AddConsolidationContainer.tsx
+++ b/source/frontend/src/features/mapSideBar/consolidation/AddConsolidationContainer.tsx
@@ -111,7 +111,7 @@ const AddConsolidationContainer: React.FC<IAddConsolidationContainerProps> = ({
             </p>
             <p>
               If you proceed, you will be redirected to the new consolidated parcel record, where
-              view changes and make updates. Do you want to proceed?
+              you can view changes and make updates. Do you want to proceed?
             </p>
           </>
         ),

--- a/source/frontend/src/features/mapSideBar/consolidation/AddConsolidationView.tsx
+++ b/source/frontend/src/features/mapSideBar/consolidation/AddConsolidationView.tsx
@@ -2,7 +2,6 @@ import { FieldArray, Formik, FormikHelpers, FormikProps } from 'formik';
 import noop from 'lodash/noop';
 import { useCallback } from 'react';
 import { Tab } from 'react-bootstrap';
-import { FaInfoCircle } from 'react-icons/fa';
 import { useHistory } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import styled from 'styled-components';
@@ -14,7 +13,6 @@ import { Form } from '@/components/common/form';
 import LoadingBackdrop from '@/components/common/LoadingBackdrop';
 import { Section } from '@/components/common/Section/Section';
 import { H2 } from '@/components/common/styles';
-import TooltipWrapper from '@/components/common/TooltipWrapper';
 import { IMapSelectorContainerProps } from '@/components/propertySelector/MapSelectorContainer';
 import { StyledTabView } from '@/components/propertySelector/PropertySelectorTabsView';
 import { PropertySelectorPidSearchContainerProps } from '@/components/propertySelector/search/PropertySelectorPidSearchContainer';
@@ -36,10 +34,10 @@ export const AddConsolidationYupSchema = Yup.object().shape({
     .nullable()
     .matches(/^\d{0,3}-\d{3}-\d{3}$|^\d{0,9}$/, 'Invalid PID'),
   sourceProperties: Yup.array().test({
-    message: 'You must select at least two parent properties',
+    message: 'You must select at least two source parcels',
     test: arr => !!arr?.length && arr.length >= 2,
   }),
-  destinationProperty: Yup.object().nullable().required('You must select a child property'),
+  destinationProperty: Yup.object().nullable().required('You must select a consolidated parcel'),
 });
 
 export interface IAddConsolidationViewProps {
@@ -109,22 +107,14 @@ const AddConsolidationView: React.FunctionComponent<
           {({ values, setFieldValue, errors }) => (
             <Form>
               <Section>
-                <H2>
-                  Properties in Consolidation
-                  <TooltipWrapper
-                    tooltipId="pims-only-consolidation-tooltip"
-                    tooltip="Only properties that are in the PIMS inventory can be consolidated"
-                  >
-                    <FaInfoCircle className="tooltip-icon h-20" size="1rem" />
-                  </TooltipWrapper>
-                </H2>
+                <H2>Properties in Consolidation</H2>
                 <AddConsolidationMarkerSynchronizer values={values} />
-                <p>Select two or more parent properties that were consolidated:</p>
+                <p>Select two or more source parcels that were consolidated:</p>
                 <FieldArray name="sourceProperties">
                   {({ remove, push }) => (
                     <>
                       <StyledTabView activeKey="parent-property">
-                        <Tab eventKey="parent-property" title="Parent Property Search">
+                        <Tab eventKey="parent-property" title="Source Parcel Search">
                           <PropertySelectorPidSearchComponent
                             setSelectProperty={selectedProperty => push(selectedProperty)}
                             PropertySelectorPidSearchView={PropertySearchSelectorPidFormView}
@@ -153,7 +143,7 @@ const AddConsolidationView: React.FunctionComponent<
                 </FieldArray>
               </Section>
               <Section>
-                <p>Select the child property to which parent properties were consolidated:</p>
+                <p>Select the subdivided parcel to which source parcels were consolidated:</p>
                 <MapSelectorComponent
                   addSelectedProperties={async properties => {
                     const allProperties: ApiGen_Concepts_Property[] = [];

--- a/source/frontend/src/features/mapSideBar/consolidation/AddConsolidationView.tsx
+++ b/source/frontend/src/features/mapSideBar/consolidation/AddConsolidationView.tsx
@@ -37,7 +37,9 @@ export const AddConsolidationYupSchema = Yup.object().shape({
     message: 'You must select at least two source parcels',
     test: arr => !!arr?.length && arr.length >= 2,
   }),
-  destinationProperty: Yup.object().nullable().required('You must select a consolidated parcel'),
+  destinationProperty: Yup.object()
+    .nullable()
+    .required('You must select a property that will be the new consolidated parcel'),
 });
 
 export interface IAddConsolidationViewProps {

--- a/source/frontend/src/features/mapSideBar/consolidation/__snapshots__/AddConsolidationView.test.tsx.snap
+++ b/source/frontend/src/features/mapSideBar/consolidation/__snapshots__/AddConsolidationView.test.tsx.snap
@@ -597,23 +597,9 @@ exports[`Add Consolidation View > matches snapshot 1`] = `
                   class="c14"
                 >
                   Properties in Consolidation
-                  <svg
-                    class="tooltip-icon h-20"
-                    fill="currentColor"
-                    height="1rem"
-                    stroke="currentColor"
-                    stroke-width="0"
-                    viewBox="0 0 512 512"
-                    width="1rem"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                    />
-                  </svg>
                 </h2>
                 <p>
-                  Select two or more parent properties that were consolidated:
+                  Select two or more source parcels that were consolidated:
                 </p>
                 <div
                   class="c15 c16"
@@ -629,7 +615,7 @@ exports[`Add Consolidation View > matches snapshot 1`] = `
                       href="#"
                       role="tab"
                     >
-                      Parent Property Search
+                      Source Parcel Search
                     </a>
                   </nav>
                   <div
@@ -706,7 +692,7 @@ exports[`Add Consolidation View > matches snapshot 1`] = `
                 class="collapse show"
               >
                 <p>
-                  Select the child property to which parent properties were consolidated:
+                  Select the subdivided parcel to which source parcels were consolidated:
                 </p>
                 <span>
                   Content Rendered

--- a/source/frontend/src/features/mapSideBar/subdivision/AddSubdivisionContainer.tsx
+++ b/source/frontend/src/features/mapSideBar/subdivision/AddSubdivisionContainer.tsx
@@ -104,12 +104,12 @@ const AddSubdivisionContainer: React.FC<IAddSubdivisionContainerProps> = ({
         message: (
           <>
             <p>
-              You are subdividing a property into two or more properties. The old parent property
-              record will be retired, and the new child properties will be created
+              You are subdividing a property into two or more properties. The old source parcel
+              record will be retired, and the subdivided parcels will be created
             </p>
             <p>
-              If you proceed, you will be redirected to the old parent property record, where you
-              can view changes and make updates to the new properties. Do you want to proceed?
+              If you proceed, you will be redirected to the old source parcel record, where you can
+              view changes and make updates to the new properties. Do you want to proceed?
             </p>
           </>
         ),

--- a/source/frontend/src/features/mapSideBar/subdivision/AddSubdivisionView.tsx
+++ b/source/frontend/src/features/mapSideBar/subdivision/AddSubdivisionView.tsx
@@ -2,7 +2,6 @@ import { FieldArray, Formik, FormikHelpers, FormikProps } from 'formik';
 import noop from 'lodash/noop';
 import { useCallback } from 'react';
 import { Col, Row, Tab } from 'react-bootstrap';
-import { FaInfoCircle } from 'react-icons/fa';
 import { useHistory } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import styled from 'styled-components';
@@ -14,7 +13,6 @@ import { Form } from '@/components/common/form';
 import LoadingBackdrop from '@/components/common/LoadingBackdrop';
 import { Section } from '@/components/common/Section/Section';
 import { H2 } from '@/components/common/styles';
-import TooltipWrapper from '@/components/common/TooltipWrapper';
 import { ZoomIconType, ZoomToLocation } from '@/components/maps/ZoomToLocation';
 import { IMapSelectorContainerProps } from '@/components/propertySelector/MapSelectorContainer';
 import { StyledTabView } from '@/components/propertySelector/PropertySelectorTabsView';
@@ -40,7 +38,7 @@ export const AddSubdivisionYupSchema = Yup.object().shape({
     message: 'You must select at least two child properties',
     test: arr => !!arr?.length && arr.length >= 2,
   }),
-  sourceProperty: Yup.object().nullable().required('You must select a parent property'),
+  sourceProperty: Yup.object().nullable().required('You must select a source parcel'),
 });
 
 export interface IAddSubdivisionViewProps {
@@ -116,19 +114,11 @@ const AddSubdivisionView: React.FunctionComponent<
           {({ values, setFieldValue, errors }) => (
             <Form>
               <Section>
-                <H2>
-                  Properties in Subdivision &nbsp;
-                  <TooltipWrapper
-                    tooltipId="pims-only-subdivision-tooltip"
-                    tooltip="Only a property that is in the PIMS inventory can be subdivided"
-                  >
-                    <FaInfoCircle className="tooltip-icon h-20" size="1rem" />
-                  </TooltipWrapper>
-                </H2>
+                <H2>Properties in Subdivision &nbsp;</H2>
                 <AddSubdivisionMarkerSynchronizer values={values} />
-                <p>Select the parent property that was subdivided:</p>
+                <p>Select the source parcel that was subdivided:</p>
                 <StyledTabView activeKey="parent-property">
-                  <Tab eventKey="parent-property" title="Parent Property Search">
+                  <Tab eventKey="parent-property" title="Source Parcel Search">
                     <PropertySelectorPidSearchComponent
                       setSelectProperty={selectedProperty =>
                         setFieldValue('sourceProperty', selectedProperty)
@@ -153,7 +143,7 @@ const AddSubdivisionView: React.FunctionComponent<
                 </Section>
               </Section>
               <Section>
-                <p>Select the child properties to which parent property was subdivided:</p>
+                <p>Select the subdivided parcels to which source parcel was subdivided:</p>
                 <MapSelectorComponent
                   addSelectedProperties={async properties => {
                     const allProperties = [...values.destinationProperties];

--- a/source/frontend/src/features/mapSideBar/subdivision/__snapshots__/AddSubdivisionView.test.tsx.snap
+++ b/source/frontend/src/features/mapSideBar/subdivision/__snapshots__/AddSubdivisionView.test.tsx.snap
@@ -589,23 +589,9 @@ exports[`Add Subdivision View > matches snapshot 1`] = `
                   class="c13"
                 >
                   Properties in Subdivision  
-                  <svg
-                    class="tooltip-icon h-20"
-                    fill="currentColor"
-                    height="1rem"
-                    stroke="currentColor"
-                    stroke-width="0"
-                    viewBox="0 0 512 512"
-                    width="1rem"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                    />
-                  </svg>
                 </h2>
                 <p>
-                  Select the parent property that was subdivided:
+                  Select the source parcel that was subdivided:
                 </p>
                 <div
                   class="c14 c15"
@@ -621,7 +607,7 @@ exports[`Add Subdivision View > matches snapshot 1`] = `
                       href="#"
                       role="tab"
                     >
-                      Parent Property Search
+                      Source Parcel Search
                     </a>
                   </nav>
                   <div
@@ -698,7 +684,7 @@ exports[`Add Subdivision View > matches snapshot 1`] = `
                 class="collapse show"
               >
                 <p>
-                  Select the child properties to which parent property was subdivided:
+                  Select the subdivided parcels to which source parcel was subdivided:
                 </p>
                 <span>
                   Content Rendered

--- a/testing/PIMS.Tests.Automation/PageObjects/SubdivisionConsolidationProperties.cs
+++ b/testing/PIMS.Tests.Automation/PageObjects/SubdivisionConsolidationProperties.cs
@@ -304,14 +304,14 @@ namespace PIMS.Tests.Automation.PageObjects
         public void VerifyInvalidConsolidationChildMessage()
         {
             WaitUntilVisible(subconErrorHeader);
-            Assert.Equal("Consolidated child property may not be in the PIMS inventory unless also in the parent property list.", sharedModals.ModalContent());
+            Assert.Equal("Consolidated parcel may not be in the PIMS inventory unless also in the source parcel list.", sharedModals.ModalContent());
             sharedModals.ModalClickOKBttn();
         }
 
         public void VerifyInvalidConsolidationRepeatedParentMessage()
         {
             WaitUntilVisible(subconErrorHeader);
-            Assert.Equal("Consolidations must contain at least two different parent properties.", sharedModals.ModalContent());
+            Assert.Equal("Consolidations must contain at least two source parcels.", sharedModals.ModalContent());
             sharedModals.ModalClickOKBttn();
         }
 


### PR DESCRIPTION
Changes:
- Remove toltips mentioning user can only add PIMS properties
- Update labels with new terminology for subdivision and consolidation:
  For Subdivisions:
  Update “Parent property” to “Source parcel”
  Update “Child property” or “Children” to “Subdivided parcels”
  For Consolidations:
  Change “Parent property” “parent properties” to “Source parcel” “Source parcels”
  Change “Child property” and “Selected child” to “Consolidated parcel”
- Show modal when property to be added is not from PIMS:
- “This property is not currently in PIMS. In order to subdivide/ consolidate this property. it will need to be added to PIMS as an owner property. Proceed?“


[Jira](https://moti-imb.atlassian.net/browse/PSP-11924)