### PR TITLE
PSP-11926: Decouple Teams notifications from the DEV to TEST pipeline chain

### DIFF
--- a/.github/workflows/retag-dev-to-test.yml
+++ b/.github/workflows/retag-dev-to-test.yml
@@ -62,6 +62,8 @@ jobs:
   detect-dependency-changes:
     runs-on: ubuntu-22.04
     needs: ci-cd-start-notification
+    # Notification is informational only, do not let it gate the pipeline
+    if: ${{ !cancelled() }}
     outputs:
       deps_changed: ${{ steps.detect.outputs.deps_changed }}
     steps:
@@ -225,7 +227,8 @@ jobs:
 
   deploy:
     name: Retag/Deploy to OpenShift
-    needs: [ci-cd-start-notification, scan-images]
+    # Ordering after the start notification is already enforced via scan-images
+    needs: [scan-images]
     if: |
       always() &&
       (needs.scan-images.result == 'success' || needs.scan-images.result == 'skipped')
@@ -337,10 +340,39 @@ jobs:
       branch: dev
     secrets: inherit
 
+  run-e2e-smoke-tests:
+    name: PIMS e2e smoke tests
+    # Gated on the sync jobs, not on the Teams notification
+    needs: [mayan-sync, keycloak-sync]
+    if: |
+      always() &&
+      needs.mayan-sync.result == 'success' &&
+      needs.keycloak-sync.result == 'success'
+    uses: ./.github/workflows/ci-cd-pims-smoke-test.yml
+    with:
+      target_env: test
+    secrets: inherit
+
+  run-e2e-integration-tests:
+    name: PIMS e2e integration tests
+    needs: run-e2e-smoke-tests
+    uses: ./.github/workflows/ci-cd-pims-e2e-test.yml
+    with:
+      target_env: test
+    secrets: inherit
+
+  ## Terminal job. Nothing depends on this, so a notification failure cannot
+  ## block deployment or test execution.
   ci-cd-end-notification:
     name: CI-CD End Notification to Teams Channel
     runs-on: ubuntu-22.04
-    needs: keycloak-sync
+    needs:
+      - deploy
+      - database-upgrade
+      - mayan-sync
+      - keycloak-sync
+      - run-e2e-smoke-tests
+      - run-e2e-integration-tests
     if: always()
     steps:
       - name: Checkout Source Code
@@ -358,19 +390,3 @@ jobs:
           title: PIMS Release DEV to TEST
           color: 17a2b8
           timezone: America/Los_Angeles
-
-  run-e2e-smoke-tests:
-    name: PIMS e2e smoke tests
-    needs: ci-cd-end-notification
-    uses: ./.github/workflows/ci-cd-pims-smoke-test.yml
-    with:
-      target_env: test
-    secrets: inherit
-
-  run-e2e-integration-tests:
-    name: PIMS e2e integration tests
-    needs: run-e2e-smoke-tests
-    uses: ./.github/workflows/ci-cd-pims-e2e-test.yml
-    with:
-      target_env: test
-    secrets: inherit


### PR DESCRIPTION
## Problem
 
The e2e smoke and integration tests are not running in the DEV to TEST release pipeline.
 
`run-e2e-smoke-tests` declares `needs: ci-cd-end-notification` with no `if:` condition. The notification job has `if: always()` so it runs, but the Teams webhook step has been failing or being skipped, and any job result other than `success` causes GitHub Actions to skip every downstream job. The result is that both test jobs are skipped on every run, and the pipeline reports green without ever having tested anything.

## Change
 
The notification jobs are informational and should not appear in the critical path. This PR moves the end notification to the tail of the graph and reattaches the tests to the jobs that actually determine whether the deployment succeeded.
 
| Job | Before | After |
| --- | --- | --- |
| `detect-dependency-changes` | no `if:` | `if: ${{ !cancelled() }}` |
| `deploy` | `needs: [ci-cd-start-notification, scan-images]` | `needs: [scan-images]` |
| `run-e2e-smoke-tests` | `needs: ci-cd-end-notification` | `needs: [mayan-sync, keycloak-sync]` plus a result gate |
| `ci-cd-end-notification` | mid chain, `needs: keycloak-sync` | terminal job, `needs` all six pipeline jobs |
 
No step logic, action pins, secrets, `oc` commands, or job names were changed.