### PR TITLE
PSP-11778:  Discrepancy between LTSA and PIMS Land Title Information for Ownership and Tenancy fields

### DIFF
--- a/source/frontend/src/features/mapSideBar/property/tabs/ltsa/LtsaOwnershipInformationTitleOwnerForm.tsx
+++ b/source/frontend/src/features/mapSideBar/property/tabs/ltsa/LtsaOwnershipInformationTitleOwnerForm.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/common/form';
 import { SectionField, StyledFieldLabel } from '@/components/common/Section/SectionField';
 import { LtsaOrders, TitleOwner } from '@/interfaces/ltsaModels';
 import { withNameSpace } from '@/utils/formUtils';
+import { formatNames } from '@/utils/personUtils';
 
 export interface ILtsaOwnershipInformationTitleOwnerFormProps {
   nameSpace?: string;
@@ -17,6 +18,16 @@ export const LtsaOwnershipInformationTitleOwnerForm: React.FunctionComponent<
 > = ({ nameSpace }) => {
   const { values } = useFormikContext<LtsaOrders>();
   const titleOwners = getIn(values, withNameSpace(nameSpace, 'titleOwners')) ?? [];
+  const allOwnerNames = titleOwners
+    .map((titleOwner: TitleOwner) =>
+      formatNames([
+        titleOwner.givenName,
+        titleOwner.lastNameOrCorpName1,
+        titleOwner.lastNameOrCorpName2,
+      ]),
+    )
+    .filter(name => name.length > 0)
+    .join(', ');
 
   const getJoinedFieldValues = (input1?: string, input2?: string): string => {
     const retVal: string[] = [];
@@ -35,17 +46,14 @@ export const LtsaOwnershipInformationTitleOwnerForm: React.FunctionComponent<
           <Fragment key={`title-owner-info-row-${nameSpace}`}>
             {titleOwners.map((titleOwner: TitleOwner, index: number) => {
               const innerNameSpace = withNameSpace(nameSpace, `titleOwners.${index}`);
-              const ownerName = [
-                titleOwner.givenName ?? '',
-                titleOwner.lastNameOrCorpName1 ?? '',
-                titleOwner.lastNameOrCorpName2 ?? '',
-              ];
               return (
                 <Fragment key={`title-owner-info-sub-row-${innerNameSpace}`}>
                   <OwnershipTitleInfo>
-                    <SectionField label="Owner name">
-                      <p>{ownerName.join(' ')}</p>
-                    </SectionField>
+                    {index === 0 && (
+                      <SectionField label="Owner name">
+                        <p>{allOwnerNames}</p>
+                      </SectionField>
+                    )}
                     <SectionField label="Incorporation number">
                       <Input field={`${withNameSpace(innerNameSpace, 'incorporationNumber')}`} />
                     </SectionField>

--- a/source/frontend/src/features/mapSideBar/property/tabs/ltsa/LtsaOwnershipInformationTitleOwnerForm.tsx
+++ b/source/frontend/src/features/mapSideBar/property/tabs/ltsa/LtsaOwnershipInformationTitleOwnerForm.tsx
@@ -50,7 +50,7 @@ export const LtsaOwnershipInformationTitleOwnerForm: React.FunctionComponent<
                 <Fragment key={`title-owner-info-sub-row-${innerNameSpace}`}>
                   <OwnershipTitleInfo>
                     {index === 0 && (
-                      <SectionField label="Owner name">
+                      <SectionField label="Owner name(s)">
                         <p>{allOwnerNames}</p>
                       </SectionField>
                     )}

--- a/source/frontend/src/features/mapSideBar/property/tabs/ltsa/__snapshots__/LtsaOwnershipInformationForm.test.tsx.snap
+++ b/source/frontend/src/features/mapSideBar/property/tabs/ltsa/__snapshots__/LtsaOwnershipInformationForm.test.tsx.snap
@@ -134,7 +134,7 @@ exports[`LtsaOwnershipInformationForm component > renders ownership information 
           class="c4 text-left col"
         >
           <p>
-            MORRIS GRAVES BAYKEY 
+            MORRIS GRAVES BAYKEY, KATHLEEN LOIS BAYKEY, ROCK TYLER BAYKEY, PATRICIA GAIL BAYKEY, CLIFFORD LIETZ, LEILAH MARIA LIETZ
           </p>
         </div>
       </div>
@@ -236,26 +236,6 @@ exports[`LtsaOwnershipInformationForm component > renders ownership information 
     <div
       class="c5"
     >
-      <div
-        class="pb-2 row"
-      >
-        <div
-          class="pr-0 text-left col-4"
-        >
-          <label
-            class="c3"
-          >
-            Owner name:
-          </label>
-        </div>
-        <div
-          class="c4 text-left col"
-        >
-          <p>
-            KATHLEEN LOIS BAYKEY 
-          </p>
-        </div>
-      </div>
       <div
         class="pb-2 row"
       >
@@ -383,26 +363,6 @@ exports[`LtsaOwnershipInformationForm component > renders ownership information 
           <label
             class="c3"
           >
-            Owner name:
-          </label>
-        </div>
-        <div
-          class="c4 text-left col"
-        >
-          <p>
-            ROCK TYLER BAYKEY 
-          </p>
-        </div>
-      </div>
-      <div
-        class="pb-2 row"
-      >
-        <div
-          class="pr-0 text-left col-4"
-        >
-          <label
-            class="c3"
-          >
             Incorporation number:
           </label>
         </div>
@@ -492,26 +452,6 @@ exports[`LtsaOwnershipInformationForm component > renders ownership information 
     <div
       class="c5"
     >
-      <div
-        class="pb-2 row"
-      >
-        <div
-          class="pr-0 text-left col-4"
-        >
-          <label
-            class="c3"
-          >
-            Owner name:
-          </label>
-        </div>
-        <div
-          class="c4 text-left col"
-        >
-          <p>
-            PATRICIA GAIL BAYKEY 
-          </p>
-        </div>
-      </div>
       <div
         class="pb-2 row"
       >
@@ -639,26 +579,6 @@ exports[`LtsaOwnershipInformationForm component > renders ownership information 
           <label
             class="c3"
           >
-            Owner name:
-          </label>
-        </div>
-        <div
-          class="c4 text-left col"
-        >
-          <p>
-            CLIFFORD LIETZ 
-          </p>
-        </div>
-      </div>
-      <div
-        class="pb-2 row"
-      >
-        <div
-          class="pr-0 text-left col-4"
-        >
-          <label
-            class="c3"
-          >
             Incorporation number:
           </label>
         </div>
@@ -748,26 +668,6 @@ exports[`LtsaOwnershipInformationForm component > renders ownership information 
     <div
       class="c5"
     >
-      <div
-        class="pb-2 row"
-      >
-        <div
-          class="pr-0 text-left col-4"
-        >
-          <label
-            class="c3"
-          >
-            Owner name:
-          </label>
-        </div>
-        <div
-          class="c4 text-left col"
-        >
-          <p>
-            LEILAH MARIA LIETZ 
-          </p>
-        </div>
-      </div>
       <div
         class="pb-2 row"
       >

--- a/source/frontend/src/features/mapSideBar/property/tabs/ltsa/__snapshots__/LtsaOwnershipInformationForm.test.tsx.snap
+++ b/source/frontend/src/features/mapSideBar/property/tabs/ltsa/__snapshots__/LtsaOwnershipInformationForm.test.tsx.snap
@@ -127,7 +127,7 @@ exports[`LtsaOwnershipInformationForm component > renders ownership information 
           <label
             class="c3"
           >
-            Owner name:
+            Owner name(s):
           </label>
         </div>
         <div


### PR DESCRIPTION
This fix is including the print of all title owners. No fix needed for `jointTenancyIndication` because this information is read directly from LTSA.

<img width="1852" height="795" alt="image" src="https://github.com/user-attachments/assets/872246a2-237e-4621-aad5-88d6af5b7a17" />

[Jira](https://moti-imb.atlassian.net/browse/PSP-11778)